### PR TITLE
fix(ios): 修复 iOS 与 MacCatalyst 应用链接处理空引用问题

### DIFF
--- a/OneGateApp/Platforms/MacCatalyst/AppDelegate.cs
+++ b/OneGateApp/Platforms/MacCatalyst/AppDelegate.cs
@@ -33,8 +33,9 @@ public class AppDelegate : MauiUIApplicationDelegate
         return HandleAppLink(activity.WebPageUrl);
     }
 
-    static bool HandleAppLink(NSUrl url)
+    static bool HandleAppLink(NSUrl? url)
     {
+        if (url?.AbsoluteString is null) return false;
         if (Microsoft.Maui.Controls.Application.Current is not App app) return false;
         if (!Uri.TryCreate(url.AbsoluteString, UriKind.Absolute, out var uri)) return false;
         return app.ProcessAppLinkUri(uri);

--- a/OneGateApp/Platforms/MacCatalyst/SceneDelegate.cs
+++ b/OneGateApp/Platforms/MacCatalyst/SceneDelegate.cs
@@ -8,7 +8,9 @@ public class SceneDelegate : MauiUISceneDelegate
 {
     public override void WillConnect(UIScene scene, UISceneSession session, UISceneConnectionOptions connectionOptions)
     {
-        var activity = connectionOptions.UserActivities.ToArray().FirstOrDefault(p => p.ActivityType == NSUserActivityType.BrowsingWeb);
+        var activity = connectionOptions.UserActivities?
+            .ToArray()
+            .FirstOrDefault(p => p?.ActivityType == NSUserActivityType.BrowsingWeb);
         if (activity is not null)
             HandleAppLink(activity);
         else
@@ -34,14 +36,15 @@ public class SceneDelegate : MauiUISceneDelegate
         return HandleAppLink(activity.WebPageUrl);
     }
 
-    static bool HandleAppLink(NSSet<UIOpenUrlContext> urlContexts)
+    static bool HandleAppLink(NSSet<UIOpenUrlContext>? urlContexts)
     {
-        if (urlContexts.Count == 0) return false;
-        return HandleAppLink(urlContexts.AnyObject!.Url);
+        if (urlContexts is null || urlContexts.Count == 0) return false;
+        return urlContexts.AnyObject?.Url is NSUrl url && HandleAppLink(url);
     }
 
-    static bool HandleAppLink(NSUrl url)
+    static bool HandleAppLink(NSUrl? url)
     {
+        if (url?.AbsoluteString is null) return false;
         if (Application.Current is not App app) return false;
         if (!Uri.TryCreate(url.AbsoluteString, UriKind.Absolute, out var uri)) return false;
         return app.ProcessAppLinkUri(uri);

--- a/OneGateApp/Platforms/iOS/AppDelegate.cs
+++ b/OneGateApp/Platforms/iOS/AppDelegate.cs
@@ -33,8 +33,9 @@ public class AppDelegate : MauiUIApplicationDelegate
         return HandleAppLink(activity.WebPageUrl);
     }
 
-    static bool HandleAppLink(NSUrl url)
+    static bool HandleAppLink(NSUrl? url)
     {
+        if (url?.AbsoluteString is null) return false;
         if (Microsoft.Maui.Controls.Application.Current is not App app) return false;
         if (!Uri.TryCreate(url.AbsoluteString, UriKind.Absolute, out var uri)) return false;
         return app.ProcessAppLinkUri(uri);

--- a/OneGateApp/Platforms/iOS/SceneDelegate.cs
+++ b/OneGateApp/Platforms/iOS/SceneDelegate.cs
@@ -8,7 +8,9 @@ public class SceneDelegate : MauiUISceneDelegate
 {
     public override void WillConnect(UIScene scene, UISceneSession session, UISceneConnectionOptions connectionOptions)
     {
-        var activity = connectionOptions.UserActivities.ToArray().FirstOrDefault(p => p.ActivityType == NSUserActivityType.BrowsingWeb);
+        var activity = connectionOptions.UserActivities?
+            .ToArray()
+            .FirstOrDefault(p => p?.ActivityType == NSUserActivityType.BrowsingWeb);
         if (activity is not null)
             HandleAppLink(activity);
         else
@@ -34,14 +36,15 @@ public class SceneDelegate : MauiUISceneDelegate
         return HandleAppLink(activity.WebPageUrl);
     }
 
-    static bool HandleAppLink(NSSet<UIOpenUrlContext> urlContexts)
+    static bool HandleAppLink(NSSet<UIOpenUrlContext>? urlContexts)
     {
-        if (urlContexts.Count == 0) return false;
-        return HandleAppLink(urlContexts.AnyObject!.Url);
+        if (urlContexts is null || urlContexts.Count == 0) return false;
+        return urlContexts.AnyObject?.Url is NSUrl url && HandleAppLink(url);
     }
 
-    static bool HandleAppLink(NSUrl url)
+    static bool HandleAppLink(NSUrl? url)
     {
+        if (url?.AbsoluteString is null) return false;
         if (Application.Current is not App app) return false;
         if (!Uri.TryCreate(url.AbsoluteString, UriKind.Absolute, out var uri)) return false;
         return app.ProcessAppLinkUri(uri);


### PR DESCRIPTION
## ios 启动时报错

```shell
dotnet run --project /Users/Lawliet/private/415-onegate/OneGateApp/OneGateApp/OneGateApp.csproj --no-launch-profile -c Debug -f net10.0-ios -r ios-arm64 -p:Device="Lawliet’s iPhone"

Press enter to terminate the application
xcrun devicectl -j /var/folders/x2/60gdssbs70s1cjbn2wm6bmlc0000gn/T/tmpdmIGT4.tmp device process launch --terminate-existing --device "Lawliet’s iPhone" --console org.neoorder.onegate
>       Failed to load provisioning paramter list due to error: Error Domain=com.apple.dt.CoreDeviceError Code=1002 "No provider was found." UserInfo={NSLocalizedDescription=No provider was found.}.
        `devicectl manage create` may support a reduced set of arguments.
        11:51:25  Acquired tunnel connection to device.
        11:51:25  Enabling developer disk image services.
        11:51:25  Acquired usage assertion.
        Launched application with org.neoorder.onegate bundle identifier.
        Waiting for the application to terminate…
        2026-04-14 23:51:25.701 OneGateApp[1488:192188] You've implemented -[<UIApplicationDelegate> application:performFetchWithCompletionHandler:], but you still need to add "fetch" to the list of your supported UIBackgroundModes in your Info.plist.
        *** Terminating app due to uncaught exception 'System.NullReferenceException', reason: 'Object reference not set to an instance of an object. (System.NullReferenceException)
           at NeoOrder.OneGate.Platforms.iOS.SceneDelegate.HandleAppLink(NSSet`1 urlContexts) in /Users/Lawliet/private/415-onegate/OneGateApp/OneGateApp/Platforms/iOS/SceneDelegate.cs:line 39
           at NeoOrder.OneGate.Platforms.iOS.SceneDelegate.WillConnect(UIScene scene, UISceneSession session, UISceneConnectionOptions connectionOptions) in /Users/Lawliet/private/415-onegate/OneGateApp/OneGateApp/Platforms/iOS/SceneDelegate.cs:line 15
           at NeoOrder.OneGate.Platforms.iOS.SceneDelegate.__Registrar_Callbacks__.callback_4_NeoOrder_OneGate_Platforms_iOS_SceneDelegate_WillConnect(IntPtr pobj, IntPtr sel, IntPtr p0, IntPtr p1, IntPtr p2, IntPtr* exception_gchandle)
        '
        *** First throw call stack:

        =================================================================
                Native Crash Reporting
        =================================================================
        Got a SIGABRT while executing native code. This usually indicates
        a fatal error in the mono runtime or one of the native libraries 
        used by your application.
        =================================================================

        =================================================================
                Native stacktrace:
        =================================================================
        (0x18594b21c 0x182de5abc 0x1045c2b40 0x1045c2654 0x1047cd828 0x18825f0fc 0x188269134 0x18825b5b8 0x18825b408 0x1a0234528 0x1a02346fc 0x1a023434c 0x1a0233ecc 0x1a0233d38 0x1a0233ac0 0x18d7d6584 0x18d7c1ab0 0x1a02338ac 0x1a0233748 0x1a02337b0 0x185840a8c 0x1858408a4 0x185840764 0x185841080 0x185842c3c 0x1d2a21454 0x188255274 0x188220a28 0x1045a4618 0x10479f1f8 0x10479d86c 0x1047973bc 0x104794170 0x1047661d0 0x104715374 0x10471a938 0x10476c538 0x1045d5dd4 0x1047cbaec 0x1ac717f08)
        2026-04-14 23:51:26.468 OneGateApp[1488:192188] 
        Unhandled Exception:
        System.NullReferenceException: Object reference not set to an instance of an object.
           at NeoOrder.OneGate.Platforms.iOS.SceneDelegate.HandleAppLink(NSSet`1 urlContexts) in /Users/Lawliet/private/415-onegate/OneGateApp/OneGateApp/Platforms/iOS/SceneDelegate.cs:line 39
           at NeoOrder.OneGate.Platforms.iOS.SceneDelegate.WillConnect(UIScene scene, UISceneSession session, UISceneConnectionOptions connectionOptions) in /Users/Lawliet/private/415-onegate/OneGateApp/OneGateApp/Platforms/iOS/SceneDelegate.cs:line 15
           at NeoOrder.OneGate.Platforms.iOS.SceneDelegate.__Registrar_Callbacks__.callback_4_NeoOrder_OneGate_Platforms_iOS_SceneDelegate_WillConnect(IntPtr pobj, IntPtr sel, IntPtr p0, IntPtr p1, IntPtr p2, IntPtr* exception_gchandle)
        2026-04-14 23:51:26.468 OneGateApp[1488:192188] Received unhandled Objective-C exception that was marshalled from a managed exception: Object reference not set to an instance of an object. (System.NullReferenceException)
           at NeoOrder.OneGate.Platforms.iOS.SceneDelegate.HandleAppLink(NSSet`1 urlContexts) in /Users/Lawliet/private/415-onegate/OneGateApp/OneGateApp/Platforms/iOS/SceneDelegate.cs:line 39
           at NeoOrder.OneGate.Platforms.iOS.SceneDelegate.WillConnect(UIScene scene, UISceneSession session, UISceneConnectionOptions connectionOptions) in /Users/Lawliet/private/415-onegate/OneGateApp/OneGateApp/Platforms/iOS/SceneDelegate.cs:line 15
           at NeoOrder.OneGate.Platforms.iOS.SceneDelegate.__Registrar_Callbacks__.callback_4_NeoOrder_OneGate_Platforms_iOS_SceneDelegate_WillConnect(IntPtr pobj, IntPtr sel, IntPtr p0, IntPtr p1, IntPtr p2, IntPtr* exception_gchandle)
                0x104792c7c - /private/var/containers/Bundle/Application/50AF08F2-4496-478B-9BAB-5EC23FD468A8/OneGateApp.app/OneGateApp : mono_dump_native_crash_info
                0x10477e95c - /private/var/containers/Bundle/Application/50AF08F2-4496-478B-9BAB-5EC23FD468A8/OneGateApp.app/OneGateApp : mono_handle_native_crash
                0x1048ebbd4 - /private/var/containers/Bundle/Application/50AF08F2-4496-478B-9BAB-5EC23FD468A8/OneGateApp.app/OneGateApp : sigabrt_signal_handler.cold.1
                0x1047924b0 - /private/var/containers/Bundle/Application/50AF08F2-4496-478B-9BAB-5EC23FD468A8/OneGateApp.app/OneGateApp : mono_runtime_setup_stat_profiler
                0x20fe97a08 - /usr/lib/system/libsystem_platform.dylib : <redacted>
                0x20ff47c60 - /usr/lib/system/libsystem_pthread.dylib : pthread_kill
                0x18d8782d0 - /usr/lib/system/libsystem_c.dylib : abort
                0x1045c318c - /private/var/containers/Bundle/Application/50AF08F2-4496-478B-9BAB-5EC23FD468A8/OneGateApp.app/OneGateApp : _ZL17exception_handlerP11NSException
                0x1859aa148 - /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation : <redacted>
                0x182de7bec - /usr/lib/libobjc.A.dylib : <redacted>
                0x20fe708b4 - /usr/lib/libc++abi.dylib : <redacted>
                0x20fe73e1c - /usr/lib/libc++abi.dylib : __cxa_get_exception_ptr
                0x20fe73dc4 - /usr/lib/libc++abi.dylib : <redacted>
                0x182de5c24 - /usr/lib/libobjc.A.dylib : objc_exception_throw
                0x1045c2b40 - /private/var/containers/Bundle/Application/50AF08F2-4496-478B-9BAB-5EC23FD468A8/OneGateApp.app/OneGateApp : xamarin_process_managed_exception
                0x1045c2654 - /private/var/containers/Bundle/Application/50AF08F2-4496-478B-9BAB-5EC23FD468A8/OneGateApp.app/OneGateApp : xamarin_process_managed_exception_gchandle
                0x1047cd828 - /private/var/containers/Bundle/Application/50AF08F2-4496-478B-9BAB-5EC23FD468A8/OneGateApp.app/OneGateApp : -[SceneDelegate scene:willConnectToSession:options:]
                0x18825f0fc - /System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore : <redacted>
                0x188269134 - /System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore : <redacted>
                0x18825b5b8 - /System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore : <redacted>
                0x18825b408 - /System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore : <redacted>
                0x1a0234528 - /System/Library/PrivateFrameworks/FrontBoardServices.framework/FrontBoardServices : <redacted>
                0x1a02346fc - /System/Library/PrivateFrameworks/FrontBoardServices.framework/FrontBoardServices : <redacted>
                0x1a023434c - /System/Library/PrivateFrameworks/FrontBoardServices.framework/FrontBoardServices : <redacted>
                0x1a0233ecc - /System/Library/PrivateFrameworks/FrontBoardServices.framework/FrontBoardServices : <redacted>
                0x1a0233d38 - /System/Library/PrivateFrameworks/FrontBoardServices.framework/FrontBoardServices : <redacted>
                0x1a0233ac0 - /System/Library/PrivateFrameworks/FrontBoardServices.framework/FrontBoardServices : <redacted>
                0x18d7d6584 - /usr/lib/system/libdispatch.dylib : <redacted>
                0x18d7c1ab0 - /usr/lib/system/libdispatch.dylib : <redacted>
                0x1a02338ac - /System/Library/PrivateFrameworks/FrontBoardServices.framework/FrontBoardServices : <redacted>
                0x1a0233748 - /System/Library/PrivateFrameworks/FrontBoardServices.framework/FrontBoardServices : <redacted>
                0x1a02337b0 - /System/Library/PrivateFrameworks/FrontBoardServices.framework/FrontBoardServices : <redacted>
                0x185840a8c - /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation : <redacted>
                0x1858408a4 - /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation : <redacted>
                0x185840764 - /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation : <redacted>
                0x185841080 - /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation : <redacted>
                0x185842c3c - /System/Library/Frameworks/CoreFoundation.framework/CoreFoundation : CFRunLoopRunSpecific
                0x1d2a21454 - /System/Library/PrivateFrameworks/GraphicsServices.framework/GraphicsServices : GSEventRunModal
                0x188255274 - /System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore : <redacted>
                0x188220a28 - /System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore : UIApplicationMain
                0x1045a4618 - /private/var/containers/Bundle/Application/50AF08F2-4496-478B-9BAB-5EC23FD468A8/OneGateApp.app/OneGateApp : xamarin_UIApplicationMain
                0x10479f1f8 - /private/var/containers/Bundle/Application/50AF08F2-4496-478B-9BAB-5EC23FD468A8/OneGateApp.app/OneGateApp : do_icall
                0x10479d86c - /private/var/containers/Bundle/Application/50AF08F2-4496-478B-9BAB-5EC23FD468A8/OneGateApp.app/OneGateApp : do_icall_wrapper
                0x1047973bc - /private/var/containers/Bundle/Application/50AF08F2-4496-478B-9BAB-5EC23FD468A8/OneGateApp.app/OneGateApp : mono_interp_exec_method
                0x104794170 - /private/var/containers/Bundle/Application/50AF08F2-4496-478B-9BAB-5EC23FD468A8/OneGateApp.app/OneGateApp : interp_runtime_invoke
                0x1047661d0 - /private/var/containers/Bundle/Application/50AF08F2-4496-478B-9BAB-5EC23FD468A8/OneGateApp.app/OneGateApp : mono_jit_runtime_invoke
                0x104715374 - /private/var/containers/Bundle/Application/50AF08F2-4496-478B-9BAB-5EC23FD468A8/OneGateApp.app/OneGateApp : mono_runtime_invoke_checked
                0x10471a938 - /private/var/containers/Bundle/Application/50AF08F2-4496-478B-9BAB-5EC23FD468A8/OneGateApp.app/OneGateApp : mono_runtime_exec_main_checked
                0x10476c538 - /private/var/containers/Bundle/Application/50AF08F2-4496-478B-9BAB-5EC23FD468A8/OneGateApp.app/OneGateApp : mono_jit_exec
                0x1045d5dd4 - /private/var/containers/Bundle/Application/50AF08F2-4496-478B-9BAB-5EC23FD468A8/OneGateApp.app/OneGateApp : xamarin_main
                0x1047cbaec - /private/var/containers/Bundle/Application/50AF08F2-4496-478B-9BAB-5EC23FD468A8/OneGateApp.app/OneGateApp : main
                0x1ac717f08 - /usr/lib/dyld : <redacted>

        =================================================================
                Basic Fault Address Reporting
        =================================================================
        Memory around native instruction pointer (0x1d6a5a1dc):0x1d6a5a1cc  ff 0f 5f d6 c0 03 5f d6 10 29 80 d2 01 10 00 d4  .._..._..)......
        0x1d6a5a1dc  03 01 00 54 7f 23 03 d5 fd 7b bf a9 fd 03 00 91  ...T.#...{......
        0x1d6a5a1ec  59 ed ff 97 bf 03 00 91 fd 7b c1 a8 ff 0f 5f d6  Y........{...._.
        0x1d6a5a1fc  c0 03 5f d6 10 27 80 d2 01 10 00 d4 03 01 00 54  .._..'.........T

        =================================================================
                Managed Stacktrace:
        =================================================================
                  at <unknown> <0xffffffff>
                  at UIKit.UIApplication:xamarin_UIApplicationMain <0xffffffff>
                  at UIKit.UIApplication:UIApplicationMain <0x00046>
                  at UIKit.UIApplication:Main <0x000fe>
                  at NeoOrder.OneGate.Platforms.iOS.Program:Main <0x00018>
                  at <Module>:runtime_invoke_direct_void_string[] <0x0004a>
                  at <unknown> <0x00000>
        =================================================================
        App terminated due to signal 6.
The app 'org.neoorder.onegate' terminated with signal 6
```

## 解决办法

在 AppDelegate 和 SceneDelegate 的 app link 处理逻辑中增加空值保护，兼容系统在冷启动阶段传入 nil 的情况，修复 iOS/MacCatalyst 启动时因解析链接参数为空而闪退的问题。