### PR TITLE
fix(android): 修复 AppThemeColor 静态引用导致的 XAML 崩溃

### DIFF
--- a/OneGateApp/Controls/Popups/SelectAssetPopup.xaml
+++ b/OneGateApp/Controls/Popups/SelectAssetPopup.xaml
@@ -25,7 +25,7 @@
                     <Grid ColumnDefinitions="auto,*,auto" ColumnSpacing="10" Padding="10" BackgroundColor="{toolkit:AppThemeResource Panel}">
                         <Image Source="{Binding Token.Icon, TargetNullValue=tokens_icon_default.png}" WidthRequest="32" HeightRequest="32" Aspect="AspectFit" VerticalOptions="Center" />
                         <VerticalStackLayout Grid.Column="1">
-                            <Label Text="{Binding Token.Symbol}" TextColor="{StaticResource Primary}" FontAttributes="Bold" FontSize="16" />
+                            <Label Text="{Binding Token.Symbol}" TextColor="{toolkit:AppThemeResource Primary}" FontAttributes="Bold" FontSize="16" />
                             <Label StyleClass="Secondary" Text="{Binding Token.Name}" FontSize="12" />
                         </VerticalStackLayout>
                         <Label Grid.Column="2" StyleClass="Icon, Secondary" Text="&#xe9b0;" FontSize="22" Margin="10,0" VerticalOptions="Center">

--- a/OneGateApp/Pages/SendingPage.xaml
+++ b/OneGateApp/Pages/SendingPage.xaml
@@ -14,7 +14,7 @@
     </ContentPage.Resources>
     <ScrollView>
         <VerticalStackLayout Margin="20" Spacing="20">
-            <ActivityIndicator IsRunning="True" Color="{StaticResource Secondary}" WidthRequest="64" HeightRequest="64" IsVisible="{Binding BlockTime, Converter={StaticResource IsNullConverter}}" />
+            <ActivityIndicator IsRunning="True" Color="{toolkit:AppThemeResource Secondary}" WidthRequest="64" HeightRequest="64" IsVisible="{Binding BlockTime, Converter={StaticResource IsNullConverter}}" />
             <Border StrokeShape="Ellipse" BackgroundColor="#5bc782" WidthRequest="64" HeightRequest="64" IsVisible="{Binding BlockTime, Converter={StaticResource IsNotNullConverter}}">
                 <Image Source="{FontImageSource &#xe9b0;, FontFamily=Icons, Color=#f1f3f6}" WidthRequest="32" HeightRequest="32" />
             </Border>


### PR DESCRIPTION
## 背景
Android 端打开相关页面/弹窗时发生崩溃：

`XamlParseException: Cannot assign property "TextColor"`

## 根因
`Primary` 和 `Secondary` 在资源字典中定义为 `toolkit:AppThemeColor`，
但部分 XAML 使用了 `StaticResource` 直接赋值给 `TextColor`/`Color`。
运行时会把 `AppThemeColor` 对象直接传给颜色属性，导致 XAML 解析失败。

## 修改内容
- 将 `SelectAssetPopup.xaml` 中 `Label.TextColor` 的 `Primary` 引用改为 `toolkit:AppThemeResource`
- 将 `SendingPage.xaml` 中 `ActivityIndicator.Color` 的 `Secondary` 引用改为 `toolkit:AppThemeResource`
- 顺手排查了同类主题色静态引用，避免同类问题再次出现

## 影响范围
- 资产选择弹窗
- 发送中页面的加载指示器颜色绑定

## 验证
- 重新进入触发崩溃的页面/弹窗，应用不再因 XAML 解析报错崩溃
