### PR TITLE
fix(ios): 修复受保护页面连续切换时的闪退问题

### DIFF
--- a/OneGateApp/Pages/CreatePasswordPage.xaml.cs
+++ b/OneGateApp/Pages/CreatePasswordPage.xaml.cs
@@ -25,12 +25,12 @@ public partial class CreatePasswordPage : ContentPage
     protected override void OnAppearing()
     {
         base.OnAppearing();
-        screenSecurity.ActivateScreenSecurityProtection();
+        ScreenSecurityCoordinator.Enter(screenSecurity);
     }
 
     protected override void OnDisappearing()
     {
-        screenSecurity.DeactivateScreenSecurityProtection();
+        ScreenSecurityCoordinator.Exit(screenSecurity);
         base.OnDisappearing();
     }
 

--- a/OneGateApp/Pages/GenerateMnemonicPage.xaml.cs
+++ b/OneGateApp/Pages/GenerateMnemonicPage.xaml.cs
@@ -26,12 +26,12 @@ public partial class GenerateMnemonicPage : ContentPage
 
     protected override void OnAppearing()
     {
-        screenSecurity.ActivateScreenSecurityProtection();
+        ScreenSecurityCoordinator.Enter(screenSecurity);
     }
 
     protected override void OnDisappearing()
     {
-        screenSecurity.DeactivateScreenSecurityProtection();
+        ScreenSecurityCoordinator.Exit(screenSecurity);
     }
 
     async void OnSubmitted(object sender, EventArgs e)

--- a/OneGateApp/Pages/SelectImportTypePage.xaml.cs
+++ b/OneGateApp/Pages/SelectImportTypePage.xaml.cs
@@ -32,12 +32,12 @@ public partial class SelectImportTypePage : ContentPage
 
     protected override void OnAppearing()
     {
-        screenSecurity.ActivateScreenSecurityProtection();
+        ScreenSecurityCoordinator.Enter(screenSecurity);
     }
 
     protected override void OnDisappearing()
     {
-        screenSecurity.DeactivateScreenSecurityProtection();
+        ScreenSecurityCoordinator.Exit(screenSecurity);
     }
 
     void Mnemonic_Validate(object sender, CustomValidationEventArgs e)

--- a/OneGateApp/Pages/VerifyMnemonicPage.xaml.cs
+++ b/OneGateApp/Pages/VerifyMnemonicPage.xaml.cs
@@ -20,12 +20,12 @@ public partial class VerifyMnemonicPage : ContentPage
     protected override void OnAppearing()
     {
         base.OnAppearing();
-        screenSecurity.ActivateScreenSecurityProtection();
+        ScreenSecurityCoordinator.Enter(screenSecurity);
     }
 
     protected override void OnDisappearing()
     {
-        screenSecurity.DeactivateScreenSecurityProtection();
+        ScreenSecurityCoordinator.Exit(screenSecurity);
         base.OnDisappearing();
     }
 

--- a/OneGateApp/Services/ScreenSecurityCoordinator.cs
+++ b/OneGateApp/Services/ScreenSecurityCoordinator.cs
@@ -4,13 +4,13 @@ namespace NeoOrder.OneGate.Services;
 
 static class ScreenSecurityCoordinator
 {
-    static readonly object syncRoot = new();
+    static readonly Lock syncRoot = new();
     static int activeScopes;
     static int generation;
 
     public static void Enter(IScreenSecurity screenSecurity)
     {
-        bool shouldActivate = false;
+        bool shouldActivate;
         lock (syncRoot)
         {
             activeScopes++;

--- a/OneGateApp/Services/ScreenSecurityCoordinator.cs
+++ b/OneGateApp/Services/ScreenSecurityCoordinator.cs
@@ -1,0 +1,49 @@
+using Plugin.Maui.ScreenSecurity;
+
+namespace NeoOrder.OneGate.Services;
+
+static class ScreenSecurityCoordinator
+{
+    static readonly object syncRoot = new();
+    static int activeScopes;
+    static int generation;
+
+    public static void Enter(IScreenSecurity screenSecurity)
+    {
+        bool shouldActivate = false;
+        lock (syncRoot)
+        {
+            activeScopes++;
+            generation++;
+            shouldActivate = activeScopes == 1;
+        }
+        if (!shouldActivate || screenSecurity.IsProtectionEnabled)
+            return;
+        screenSecurity.ActivateScreenSecurityProtection();
+    }
+
+    public static void Exit(IScreenSecurity screenSecurity)
+    {
+        int exitGeneration;
+        lock (syncRoot)
+        {
+            if (activeScopes > 0)
+                activeScopes--;
+            generation++;
+            exitGeneration = generation;
+            if (activeScopes > 0)
+                return;
+        }
+        MainThread.BeginInvokeOnMainThread(async () =>
+        {
+            await Task.Yield();
+            lock (syncRoot)
+            {
+                if (activeScopes > 0 || exitGeneration != generation)
+                    return;
+            }
+            if (screenSecurity.IsProtectionEnabled)
+                screenSecurity.DeactivateScreenSecurityProtection();
+        });
+    }
+}


### PR DESCRIPTION
## 描述

Plugin.Maui.ScreenSecurity 在 iOS 上会在页面 OnAppearing/OnDisappearing 中被频繁开启和关闭。

在以下连续受保护页面跳转链路中：

- GenerateMnemonic -> VerifyMnemonic -> CreatePassword
- SelectImportType -> CreatePassword

前一个页面退出、后一个页面进入时会在同一次导航转场里重复切换屏幕保护状态，最终触发 iOS 原生导航转场异常并导致闪退。

本次修改新增 ScreenSecurityCoordinator，对屏幕保护的开启/关闭进行协调：

- 进入受保护页面时，只有在当前不存在活跃受保护页面时才真正开启保护
- 离开受保护页面时，延后一拍再判断是否需要关闭，避免在连续页面切换过程中先关后开

这样可以保证连续受保护页面之间切换时，屏幕保护状态保持稳定，不再破坏 iOS 导航转场。

## 修改文件

- CreatePasswordPage.xaml.cs
- GenerateMnemonicPage.xaml.cs
- VerifyMnemonicPage.xaml.cs
- SelectImportTypePage.xaml.cs
- ScreenSecurityCoordinator.cs

## 验证

- 已验证上述两条页面跳转链路在 iOS 真机上不再出现闪退
- Android 中没有变化，不影响 Android 端

#4 