### PR TITLE
[codex] Disable Android wallet backups

### DIFF
--- a/OneGateApp/Platforms/Android/AndroidManifest.xml
+++ b/OneGateApp/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:supportsRtl="true"></application>
+	<application android:allowBackup="false" android:dataExtractionRules="@xml/data_extraction_rules" android:fullBackupContent="@xml/backup_rules" android:icon="@mipmap/appicon" android:supportsRtl="true"></application>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.CAMERA" />
 	<uses-permission android:name="android.permission.DETECT_SCREEN_CAPTURE" />

--- a/OneGateApp/Platforms/Android/Resources/xml/backup_rules.xml
+++ b/OneGateApp/Platforms/Android/Resources/xml/backup_rules.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <exclude domain="file" path="." />
+    <exclude domain="database" path="." />
+    <exclude domain="sharedpref" path="." />
+    <exclude domain="external" path="." />
+</full-backup-content>

--- a/OneGateApp/Platforms/Android/Resources/xml/data_extraction_rules.xml
+++ b/OneGateApp/Platforms/Android/Resources/xml/data_extraction_rules.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="file" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="external" path="." />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="file" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="external" path="." />
+    </device-transfer>
+</data-extraction-rules>


### PR DESCRIPTION
## Summary

Disables Android backup/transfer for wallet app data and adds explicit backup exclusion rules.

## Root cause

The Android manifest had `android:allowBackup="true"`. For a wallet app, automatic backup or device-transfer flows can copy app databases, settings, encrypted wallet files, and biometric-related state into cloud or restore paths.

## Change

- Set `android:allowBackup="false"`.
- Add `android:dataExtractionRules` and `android:fullBackupContent` references.
- Add XML backup rules that exclude app files, databases, shared preferences, and external app data from cloud backup and device transfer.

## Validation

- Confirmed `origin/master` has `android:allowBackup="true"`.
- Confirmed this branch has backup disabled and explicit backup/data-extraction rules.
- Ran `git diff --check`.
- Ran `dotnet build OneGateApp/OneGateApp.csproj -f net10.0-android -c Debug -v:minimal /p:UseSharedCompilation=false /p:RuntimeIdentifier=android-x64` successfully with 0 warnings and 0 errors.
- Checked generated Android manifests under `obj/Debug/net10.0-android/android-x64`; merged output contains `android:allowBackup="false"`, `android:dataExtractionRules="@xml/data_extraction_rules"`, and `android:fullBackupContent="@xml/backup_rules"`.
