### PR TITLE
[codex] Add StrongBox keystore fallback

### DIFF
--- a/OneGateApp/Services/DataProtectionService.Android.cs
+++ b/OneGateApp/Services/DataProtectionService.Android.cs
@@ -103,20 +103,36 @@ partial class DataProtectionService
         keyStore.Load(null);
         if (!keyStore.ContainsAlias(KeyAlias))
         {
-            var keyGenerator = KeyGenerator.GetInstance(KeyProperties.KeyAlgorithmAes, "AndroidKeyStore")!;
-            var spec = new KeyGenParameterSpec.Builder(KeyAlias, KeyStorePurpose.Encrypt | KeyStorePurpose.Decrypt)
-                .SetBlockModes(KeyProperties.BlockModeGcm)
-                .SetEncryptionPaddings(KeyProperties.EncryptionPaddingNone)
-                .SetKeySize(256)
-                .SetUserAuthenticationRequired(true)
-                .SetUserAuthenticationParameters(0, (int)KeyPropertiesAuthType.BiometricStrong)
-                .SetIsStrongBoxBacked(true)
-                .Build();
-            keyGenerator.Init(spec);
-            return keyGenerator.GenerateKey()!;
+            try
+            {
+                return GenerateSecretKey(strongBoxBacked: true);
+            }
+            catch (ProviderException)
+            {
+                return GenerateSecretKey(strongBoxBacked: false);
+            }
+            catch (InvalidAlgorithmParameterException)
+            {
+                return GenerateSecretKey(strongBoxBacked: false);
+            }
         }
         var key = keyStore.GetKey(KeyAlias, null)!;
         return key.JavaCast<ISecretKey>();
+    }
+
+    static ISecretKey GenerateSecretKey(bool strongBoxBacked)
+    {
+        var keyGenerator = KeyGenerator.GetInstance(KeyProperties.KeyAlgorithmAes, "AndroidKeyStore")!;
+        var builder = new KeyGenParameterSpec.Builder(KeyAlias, KeyStorePurpose.Encrypt | KeyStorePurpose.Decrypt)
+            .SetBlockModes(KeyProperties.BlockModeGcm)
+            .SetEncryptionPaddings(KeyProperties.EncryptionPaddingNone)
+            .SetKeySize(256)
+            .SetUserAuthenticationRequired(true)
+            .SetUserAuthenticationParameters(0, (int)KeyPropertiesAuthType.BiometricStrong);
+        if (strongBoxBacked)
+            builder.SetIsStrongBoxBacked(true);
+        keyGenerator.Init(builder.Build());
+        return keyGenerator.GenerateKey()!;
     }
 
     static Task<bool> AuthenticateWithCipherAsync(Cipher? cipher = null, string? title = null, string? message = null)


### PR DESCRIPTION
## Summary

Allows Android biometric secret-key creation to fall back to normal Android Keystore when StrongBox is unavailable.

## Root cause

`DataProtectionService.Android` always called `SetIsStrongBoxBacked(true)`. Many real devices and most emulators do not support StrongBox, so biometric credential availability could be disabled even when normal Android Keystore biometric auth would work.

## Change

- Keep StrongBox as the preferred first attempt.
- Catch StrongBox/key-parameter failures that occur during key generation.
- Retry with a normal biometric-backed Android Keystore AES key.
- Preserve existing biometric authentication requirements and AES/GCM configuration.

## Validation

- Confirmed `origin/master` always sets `SetIsStrongBoxBacked(true)` with no fallback.
- Confirmed this branch tries StrongBox first and falls back to non-StrongBox key generation.
- Ran `git diff --check`.
- Ran `dotnet build OneGateApp/OneGateApp.csproj -f net10.0-android -c Debug -v:minimal /p:UseSharedCompilation=false /p:RuntimeIdentifier=android-x64` successfully with 0 warnings and 0 errors.
