### PR TITLE
Remove mnemonic verification bypass

### DIFF
--- a/OneGateApp/Pages/VerifyMnemonicPage.xaml
+++ b/OneGateApp/Pages/VerifyMnemonicPage.xaml
@@ -20,13 +20,9 @@
                     </DataTemplate>
                 </BindableLayout.ItemTemplate>
             </FlexLayout>
-            <VerticalStackLayout.Behaviors>
-                <og:KonamiCodeBehavior KonamiCodeEntered="OnKonamiCodeEntered" />
-            </VerticalStackLayout.Behaviors>
         </VerticalStackLayout>
         <VerticalStackLayout Grid.Row="1" Spacing="20">
             <og:Submit Text="{x:Static og:Strings.Next}" Submitted="OnSubmitted" />
-            <Button StyleClass="Secondary" Text="{x:Static og:Strings.Skip}" BorderWidth="0" IsVisible="{Binding ShowSkip, Source={RelativeSource AncestorType={x:Type og:VerifyMnemonicPage}}}" Clicked="OnSubmitted" />
         </VerticalStackLayout>
     </Grid>
 </ContentPage>

--- a/OneGateApp/Pages/VerifyMnemonicPage.xaml.cs
+++ b/OneGateApp/Pages/VerifyMnemonicPage.xaml.cs
@@ -8,8 +8,6 @@ public partial class VerifyMnemonicPage : ContentPage
     readonly IServiceProvider serviceProvider;
     readonly IScreenSecurity screenSecurity;
 
-    public bool ShowSkip { get; set { field = value; OnPropertyChanged(); } }
-
     public VerifyMnemonicPage(IServiceProvider serviceProvider, IScreenSecurity screenSecurity)
     {
         this.serviceProvider = serviceProvider;
@@ -34,25 +32,24 @@ public partial class VerifyMnemonicPage : ContentPage
     void Word_Clicked(object sender, EventArgs e)
     {
         Button button = (Button)sender;
+        string word = button.Text;
+        if (string.IsNullOrEmpty(word)) return;
         if (button.Opacity < 0.5)
         {
-            int index = editorMnemonic.Text.LastIndexOf(button.Text);
-            editorMnemonic.Text = editorMnemonic.Text.Remove(index, 1).Replace("  ", " ").Trim();
+            string text = editorMnemonic.Text ?? string.Empty;
+            int index = text.LastIndexOf(word, StringComparison.Ordinal);
+            if (index < 0) return;
+            editorMnemonic.Text = text.Remove(index, word.Length).Replace("  ", " ").Trim();
             button.Opacity = 1.0;
         }
         else
         {
             if (string.IsNullOrWhiteSpace(editorMnemonic.Text))
-                editorMnemonic.Text = button.Text;
+                editorMnemonic.Text = word;
             else
-                editorMnemonic.Text += " " + button.Text;
+                editorMnemonic.Text += " " + word;
             button.Opacity = 0.1;
         }
-    }
-
-    void OnKonamiCodeEntered(object sender, EventArgs e)
-    {
-        ShowSkip = true;
     }
 
     async void OnSubmitted(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- remove the hidden Konami mnemonic verification bypass
- remove the visible skip path tied to the bypass state
- fix duplicate mnemonic word removal to remove the whole selected word instead of one character

## Verification
- confirmed `origin/master` still exposes `KonamiCodeBehavior` and the skip button in `VerifyMnemonicPage.xaml`
- confirmed this branch no longer contains the bypass or skip UI references
- `git diff --check`
- `dotnet build OneGateApp/OneGateApp.csproj -f net10.0-android -c Debug -v:minimal /p:UseSharedCompilation=false /p:RuntimeIdentifier=android-x64`
