### PR TITLE
Handle malformed update responses

### DIFF
--- a/OneGateApp/Services/UpdateService.cs
+++ b/OneGateApp/Services/UpdateService.cs
@@ -17,8 +17,8 @@ public partial class UpdateService(HttpClient httpClient)
 
     async Task<bool> CheckForUpdatesFallbackAsync()
     {
-        Version latest = new(await httpClient.GetStringAsync("/api/app/version"));
-        return latest > AppInfo.Version;
+        string latestVersion = await httpClient.GetStringAsync("/api/app/version");
+        return Version.TryParse(latestVersion, out Version? latest) && latest > AppInfo.Version;
     }
 
     public async Task UpdateAsync()

--- a/OneGateApp/Services/UpdateService.iOS.cs
+++ b/OneGateApp/Services/UpdateService.iOS.cs
@@ -13,9 +13,8 @@ partial class UpdateService
     {
         if (IsAppStore())
         {
-            JsonObject result = (await httpClient.GetFromJsonAsync<JsonObject>("https://itunes.apple.com/lookup?id=1584915425"))!;
-            Version latest = new(result["results"]!["version"]!.GetValue<string>());
-            return latest > AppInfo.Version;
+            JsonObject? result = await httpClient.GetFromJsonAsync<JsonObject>("https://itunes.apple.com/lookup?id=1584915425");
+            return TryGetAppStoreVersion(result, out Version? latest) && latest > AppInfo.Version;
         }
         return await CheckForUpdatesFallbackAsync();
     }
@@ -36,6 +35,21 @@ partial class UpdateService
     static bool IsAppStore()
     {
         return NSBundle.MainBundle.AppStoreReceiptUrl.LastPathComponent == "receipt";
+    }
+
+    static bool TryGetAppStoreVersion(JsonObject? result, out Version? version)
+    {
+        version = null;
+        if (result?["results"] is not JsonArray { Count: > 0 } results) return false;
+        if (results[0] is not JsonObject app) return false;
+        try
+        {
+            return Version.TryParse(app["version"]?.GetValue<string>(), out version);
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- parse App Store lookup responses defensively before comparing versions
- fail closed when the lookup payload is empty, malformed, or missing a valid version
- use `Version.TryParse` for the fallback version endpoint instead of throwing on malformed text

## Verification
- confirmed `origin/master` force-unwraps the iTunes lookup response and constructs `Version` from unchecked JSON
- confirmed this branch validates the JSON shape and uses `Version.TryParse`
- `git diff --check`
- `dotnet build OneGateApp/OneGateApp.csproj -f net10.0-android -c Debug -v:minimal /p:UseSharedCompilation=false /p:RuntimeIdentifier=android-x64`
- attempted `dotnet build OneGateApp/OneGateApp.csproj -f net10.0-ios -c Debug -v:minimal /p:UseSharedCompilation=false /p:RuntimeIdentifier=iossimulator-arm64`, but local .NET iOS SDK requires Xcode 26.3 while this machine has Xcode 16.2
