### PR TITLE
Handle change password failures

### DIFF
--- a/OneGateApp/Pages/ChangePasswordPage.xaml.cs
+++ b/OneGateApp/Pages/ChangePasswordPage.xaml.cs
@@ -44,7 +44,16 @@ public partial class ChangePasswordPage : ContentPage
         Submit submit = (Submit)sender;
         using (submit.EnterBusyState())
         {
-            bool success = await Task.Run(() => wallet.ChangePassword(CurrentPassword, Password));
+            bool success;
+            try
+            {
+                success = await Task.Run(() => wallet.ChangePassword(CurrentPassword, Password));
+            }
+            catch
+            {
+                errMsg.SetError(Strings.UnknownError);
+                return;
+            }
             if (success)
             {
                 await Shell.Current.GoToAsync("..");


### PR DESCRIPTION
## Summary
- catch wallet change-password exceptions during form submission
- show the existing generic field error instead of letting the page crash
- keep the existing false-return path for incorrect current password unchanged

## Verification
- confirmed `origin/master` awaits `wallet.ChangePassword` without an exception boundary
- confirmed this branch catches failures and reports `Strings.UnknownError`
- `git diff --check`
- `dotnet build OneGateApp/OneGateApp.csproj -f net10.0-android -c Debug -v:minimal /p:UseSharedCompilation=false /p:RuntimeIdentifier=android-x64`
