### PR TITLE
Harden selection popup taps

### DIFF
--- a/OneGateApp/Controls/Popups/SelectAssetPopup.xaml.cs
+++ b/OneGateApp/Controls/Popups/SelectAssetPopup.xaml.cs
@@ -33,8 +33,8 @@ public partial class SelectAssetPopup : MyPopup<AssetInfo?>
 
     async void OnSelectAsset(object sender, TappedEventArgs e)
     {
-        AssetInfo asset = (AssetInfo)e.Parameter!;
-        await CloseAsync(asset);
+        if (e.Parameter is AssetInfo asset)
+            await CloseAsync(asset);
     }
 
     async void OnCancel(object sender, EventArgs e)

--- a/OneGateApp/Controls/Popups/SelectContactPopup.xaml.cs
+++ b/OneGateApp/Controls/Popups/SelectContactPopup.xaml.cs
@@ -36,8 +36,8 @@ public partial class SelectContactPopup : MyPopup<Contact?>
 
     async void OnSelectContact(object sender, TappedEventArgs e)
     {
-        Contact contact = (Contact)e.Parameter!;
-        await CloseAsync(contact);
+        if (e.Parameter is Contact contact)
+            await CloseAsync(contact);
     }
 
     async void OnCancel(object sender, EventArgs e)


### PR DESCRIPTION
## Summary
- guard asset popup tap parameters before closing with a selected asset
- guard contact popup tap parameters before closing with a selected contact
- ignore malformed tap parameters instead of throwing invalid cast exceptions

## Verification
- confirmed `origin/master` directly casts `e.Parameter!` in both popup tap handlers
- confirmed this branch only closes with typed `AssetInfo` / `Contact` parameters
- `git diff --check`
- `dotnet build OneGateApp/OneGateApp.csproj -f net10.0-android -c Debug -v:minimal /p:UseSharedCompilation=false /p:RuntimeIdentifier=android-x64`
