### PR TITLE
Serialize dAPI JavaScript callbacks safely

### DIFF
--- a/OneGateApp/Pages/LaunchDAppPage.xaml.cs
+++ b/OneGateApp/Pages/LaunchDAppPage.xaml.cs
@@ -9,6 +9,7 @@ using NeoOrder.OneGate.Services;
 using NeoOrder.OneGate.Services.RPC;
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace NeoOrder.OneGate.Pages;
@@ -217,12 +218,15 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
     async void OnInvokedFromJavaScript(BridgeWebView webView, JsonObject request)
     {
         var response = await rpcServer.HandleRequestAsync(request);
-        await webView.EvaluateJavaScriptAsync($"window.__OneGateDapiCallback({response.ToJsonString()})");
+        string responseJson = JsonSerializer.Serialize(response.ToJsonString());
+        await webView.EvaluateJavaScriptAsync($"window.__OneGateDapiCallback({responseJson})");
     }
 
     async Task EmitEventAsync(string eventName, JsonObject? detial)
     {
         detial ??= new();
-        await webView.EvaluateJavaScriptAsync($"window.OneGateDapiProvider.__emit('{eventName}', {detial.ToJsonString()})");
+        string eventNameJson = JsonSerializer.Serialize(eventName);
+        string detailJson = JsonSerializer.Serialize(detial.ToJsonString());
+        await webView.EvaluateJavaScriptAsync($"window.OneGateDapiProvider.__emit({eventNameJson}, JSON.parse({detailJson}))");
     }
 }


### PR DESCRIPTION
## Summary
- serialize dAPI callback response JSON as a JavaScript string literal before evaluating it
- serialize event names and event detail JSON before invoking the in-page event emitter
- keep the existing page-side JSON.parse path for callback responses

## Verification
- confirmed origin/master interpolates raw JSON/event values into EvaluateJavaScriptAsync
- confirmed this branch passes callback/event data as serialized JavaScript string literals
- git diff --check
- dotnet build OneGateApp/OneGateApp.csproj -f net10.0-android -c Debug -v:minimal /p:UseSharedCompilation=false /p:RuntimeIdentifier=android-x64