### PR TITLE
Require bridge token for dAPI calls

### DIFF
--- a/OneGateApp/Controls/Views/BridgeWebView.cs
+++ b/OneGateApp/Controls/Views/BridgeWebView.cs
@@ -7,6 +7,8 @@ public partial class BridgeWebView : WebView
 {
     public event EventHandler<BridgeWebView, JsonObject>? InvokedFromJavaScript;
 
+    public string? BridgeToken { get; set; }
+
     internal void OnMessage(string payload)
     {
         JsonObject? request;
@@ -20,6 +22,9 @@ public partial class BridgeWebView : WebView
             if (request["params"] is not null && request["params"] is not JsonArray) return;
             if (request["id"] is not JsonValue id) return;
             if (id.GetValueKind() != JsonValueKind.String && id.GetValueKind() != JsonValueKind.Number) return;
+            if (BridgeToken is not { Length: > 0 } token) return;
+            if (request["onegateBridgeToken"] is not JsonValue bridgeToken || bridgeToken.GetValueKind() != JsonValueKind.String || bridgeToken.GetValue<string>() != token) return;
+            request.Remove("onegateBridgeToken");
         }
         catch
         {

--- a/OneGateApp/Pages/LaunchDAppPage.xaml.cs
+++ b/OneGateApp/Pages/LaunchDAppPage.xaml.cs
@@ -9,6 +9,7 @@ using NeoOrder.OneGate.Services;
 using NeoOrder.OneGate.Services.RPC;
 using System.Net;
 using System.Net.Http.Json;
+using System.Security.Cryptography;
 using System.Text.Json.Nodes;
 
 namespace NeoOrder.OneGate.Pages;
@@ -23,6 +24,8 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
     readonly HttpClient httpClient;
     readonly RpcServer rpcServer;
     readonly RpcClient rpcClient;
+
+    string? pendingBridgeToken;
 
     public bool IsFavorite { get; set { field = value; OnPropertyChanged(); } }
 
@@ -88,19 +91,36 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
         {
             e.Cancel = true;
             await Toast.Show(Strings.RedirectionBlockedText);
+            return;
         }
+
+        BridgeWebView webView = (BridgeWebView)sender;
+        webView.BridgeToken = null;
+        pendingBridgeToken = CreateBridgeToken();
     }
 
     async void OnNavigated(object sender, WebNavigatedEventArgs e)
     {
-        if (e.Result != WebNavigationResult.Success) return;
+        if (e.Result != WebNavigationResult.Success)
+        {
+            pendingBridgeToken = null;
+            return;
+        }
         BridgeWebView webView = (BridgeWebView)sender;
+        if (pendingBridgeToken is not { Length: > 0 } bridgeToken)
+        {
+            webView.BridgeToken = null;
+            return;
+        }
+        webView.BridgeToken = bridgeToken;
+        pendingBridgeToken = null;
         string script = $$"""
             (function () {
                 if (window.__OneGateDapiInjected) return;
                 window.__OneGateDapiInjected = true;
 
                 const pending = new Map();
+                const bridgeToken = '{{bridgeToken}}';
 
                 function createId() {
                     return 'onegate_' + Date.now() + '_' + Math.random().toString(16).slice(2);
@@ -115,7 +135,8 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
                             jsonrpc: "2.0",
                             id: id,
                             method: method,
-                            params: params
+                            params: params,
+                            onegateBridgeToken: bridgeToken
                         };
 
                         window.__OneGateBridge.invoke(JSON.stringify(request));
@@ -204,6 +225,11 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
             })();
             """.ReplaceLineEndings("");
         await webView.EvaluateJavaScriptAsync(script);
+    }
+
+    static string CreateBridgeToken()
+    {
+        return Convert.ToHexString(RandomNumberGenerator.GetBytes(32));
     }
 
     static bool IsCrossDomain(Uri uriOld, Uri uriNew)


### PR DESCRIPTION
## Summary
- require native bridge messages to carry a per-navigation bridge token
- inject the token into the top-frame dAPI provider request payload
- clear pending tokens on failed navigation so stale bridge calls fail closed

## Verification
- static RED/GREEN check: token guard absent before the patch, present after the patch
- git diff --check
- dotnet build OneGateApp/OneGateApp.csproj -f net10.0-android -c Debug -v:minimal /p:UseSharedCompilation=false /p:RuntimeIdentifier=android-x64
- dotnet build OneGateApp/OneGateApp.csproj -f net10.0-android -c Debug -v:minimal /p:UseSharedCompilation=false /p:RuntimeIdentifier=android-arm64 /p:EmbedAssembliesIntoApk=true
- installed org.neoorder.onegate-Signed.apk on emulator-5554 and cold-started org.neoorder.onegate/crc64e93af8ff8666345c.MainActivity; UI showed Welcome to OneGate / Create wallet / Import wallet; filtered logcat showed no ANR/crash after repeat run

## Notes
- This addresses the dAPI bridge-token part of audit finding 2 and also reduces the iOS/MacCatalyst frame-message risk recorded as finding 65. iOS runtime testing is still needed separately.