### PR TITLE
Add timeout and retry to transaction confirmation

### DIFF
--- a/OneGateApp/Pages/SendingPage.xaml
+++ b/OneGateApp/Pages/SendingPage.xaml
@@ -29,6 +29,8 @@
             </Label>
             <Label Text="{x:Static og:Strings.TransactionSucceeded}" IsVisible="{Binding IsSucceeded}" HorizontalOptions="Center" />
             <Label Text="{x:Static og:Strings.TransactionFailed}" TextColor="#e25c5c" IsVisible="{Binding IsFailed}" HorizontalOptions="Center" />
+            <Label StyleClass="Secondary" Text="{x:Static og:Strings.TransactionStillPending}" IsVisible="{Binding IsTimedOut}" HorizontalOptions="Center" HorizontalTextAlignment="Center" />
+            <Button Text="{x:Static og:Strings.Retry}" IsVisible="{Binding IsTimedOut}" Clicked="OnRetry" HorizontalOptions="Center" />
             <Grid RowDefinitions="1,1">
                 <BoxView Grid.Row="0" Color="{AppThemeBinding Light='#e0e5ed', Dark='#1E2128'}" />
                 <BoxView Grid.Row="1" Color="{AppThemeBinding Light='#fafafa', Dark='#3A3F49'}" />
@@ -50,6 +52,7 @@
                         <Label Grid.Column="1" Text="{x:Static og:Strings.Confirming}" IsVisible="{Binding IsConfirming}" HorizontalOptions="End" />
                         <Label Grid.Column="1" Text="{x:Static og:Strings.Success}" TextColor="#5bc782" IsVisible="{Binding IsSucceeded}" HorizontalOptions="End" />
                         <Label Grid.Column="1" Text="{x:Static og:Strings.Failed}" TextColor="#e25c5c" IsVisible="{Binding IsFailed}" HorizontalOptions="End" />
+                        <Label Grid.Column="1" Text="{x:Static og:Strings.Pending}" IsVisible="{Binding IsTimedOut}" HorizontalOptions="End" />
                     </Grid>
                     <BoxView HeightRequest="1" />
                     <Grid ColumnDefinitions="auto,*" ColumnSpacing="15" Padding="0,10">

--- a/OneGateApp/Pages/SendingPage.xaml.cs
+++ b/OneGateApp/Pages/SendingPage.xaml.cs
@@ -14,6 +14,7 @@ public partial class SendingPage : ContentPage, IQueryAttributable
 {
     readonly CancellationTokenSource cancellation = new();
     readonly RpcClient rpcClient;
+    bool isPolling;
 
     public required Transaction Transaction { get; set { field = value; OnPropertyChanged(null); } }
     public required TransactionIntent[] Intents { get; set { field = value; OnPropertyChanged(); } }
@@ -28,11 +29,24 @@ public partial class SendingPage : ContentPage, IQueryAttributable
             OnPropertyChanged(nameof(IsConfirming));
             OnPropertyChanged(nameof(IsSucceeded));
             OnPropertyChanged(nameof(IsFailed));
+            OnPropertyChanged(nameof(IsTimedOut));
         }
     }
-    public bool IsConfirming => Succeeded is null;
+    public bool TimedOut
+    {
+        get;
+        set
+        {
+            field = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(IsConfirming));
+            OnPropertyChanged(nameof(IsTimedOut));
+        }
+    }
+    public bool IsConfirming => Succeeded is null && !TimedOut;
     public bool IsSucceeded => Succeeded == true;
     public bool IsFailed => Succeeded == false;
+    public bool IsTimedOut => Succeeded is null && TimedOut;
 
     public long Fee => (Transaction?.SystemFee + Transaction?.NetworkFee) ?? 0;
     public BigDecimal DecimalFee => new((BigInteger)Fee, NativeContract.GAS.Decimals);
@@ -68,8 +82,12 @@ public partial class SendingPage : ContentPage, IQueryAttributable
 
     async void QueryTransactionStatus()
     {
+        if (isPolling) return;
+
+        isPolling = true;
         try
         {
+            TimedOut = false;
             for (int i = 0; i < 10; i++)
             {
                 await Task.Delay(TimeSpan.FromSeconds(15), cancellation.Token);
@@ -86,17 +104,27 @@ public partial class SendingPage : ContentPage, IQueryAttributable
                 if (!blockTime.HasValue) continue;
                 BlockTime = blockTime;
                 Succeeded = await QueryExecutionSucceededAsync();
-                break;
+                if (Succeeded.HasValue) break;
             }
+            if (Succeeded is null) TimedOut = true;
         }
         catch (OperationCanceledException)
         {
         }
+        finally
+        {
+            isPolling = false;
+        }
+    }
+
+    void OnRetry(object sender, EventArgs e)
+    {
+        QueryTransactionStatus();
     }
 
     // Block inclusion is not success: a transaction can be included in a block yet revert
     // (VMState.FAULT). Read the application log and require HALT before reporting success.
-    async Task<bool> QueryExecutionSucceededAsync()
+    async Task<bool?> QueryExecutionSucceededAsync()
     {
         try
         {
@@ -106,9 +134,7 @@ public partial class SendingPage : ContentPage, IQueryAttributable
         }
         catch (Exception ex) when (ex is RpcException or HttpRequestException or JsonException)
         {
-            // Application log unavailable; the transaction is in a block but the execution result
-            // is unknown. Avoid a false "failed" by treating it as confirmed.
-            return true;
+            return null;
         }
     }
 }

--- a/OneGateApp/Properties/Strings.Designer.cs
+++ b/OneGateApp/Properties/Strings.Designer.cs
@@ -2976,5 +2976,32 @@ namespace NeoOrder.OneGate.Properties {
                 return ResourceManager.GetString("TransactionFailed", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Pending.
+        /// </summary>
+        internal static string Pending {
+            get {
+                return ResourceManager.GetString("Pending", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Retry.
+        /// </summary>
+        internal static string Retry {
+            get {
+                return ResourceManager.GetString("Retry", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Still waiting for confirmation.
+        /// </summary>
+        internal static string TransactionStillPending {
+            get {
+                return ResourceManager.GetString("TransactionStillPending", resourceCulture);
+            }
+        }
     }
 }

--- a/OneGateApp/Properties/Strings.de.resx
+++ b/OneGateApp/Properties/Strings.de.resx
@@ -1106,4 +1106,13 @@ Es wird empfohlen, den NEP-2-Schlüssel und das Passwort getrennt aufzubewahren 
   <data name="TransactionFailed" xml:space="preserve">
     <value>Transaktion fehlgeschlagen</value>
   </data>
+  <data name="Pending" xml:space="preserve">
+    <value>Ausstehend</value>
+  </data>
+  <data name="Retry" xml:space="preserve">
+    <value>Erneut versuchen</value>
+  </data>
+  <data name="TransactionStillPending" xml:space="preserve">
+    <value>Wartet weiterhin auf Bestätigung</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.es.resx
+++ b/OneGateApp/Properties/Strings.es.resx
@@ -1106,4 +1106,13 @@ Se recomienda almacenar la clave NEP-2 y la contraseña por separado y realizar 
   <data name="TransactionFailed" xml:space="preserve">
     <value>Transacción fallida</value>
   </data>
+  <data name="Pending" xml:space="preserve">
+    <value>Pendiente</value>
+  </data>
+  <data name="Retry" xml:space="preserve">
+    <value>Reintentar</value>
+  </data>
+  <data name="TransactionStillPending" xml:space="preserve">
+    <value>Aún esperando confirmación</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.fr.resx
+++ b/OneGateApp/Properties/Strings.fr.resx
@@ -1106,4 +1106,13 @@ Il est recommandé de conserver séparément la clé NEP-2 et le mot de passe, e
   <data name="TransactionFailed" xml:space="preserve">
     <value>Transaction échouée</value>
   </data>
+  <data name="Pending" xml:space="preserve">
+    <value>En attente</value>
+  </data>
+  <data name="Retry" xml:space="preserve">
+    <value>Réessayer</value>
+  </data>
+  <data name="TransactionStillPending" xml:space="preserve">
+    <value>Toujours en attente de confirmation</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.id.resx
+++ b/OneGateApp/Properties/Strings.id.resx
@@ -1106,4 +1106,13 @@ Disarankan untuk menyimpan kunci NEP-2 dan kata sandinya secara terpisah serta m
   <data name="TransactionFailed" xml:space="preserve">
     <value>Transaksi gagal</value>
   </data>
+  <data name="Pending" xml:space="preserve">
+    <value>Menunggu</value>
+  </data>
+  <data name="Retry" xml:space="preserve">
+    <value>Coba lagi</value>
+  </data>
+  <data name="TransactionStillPending" xml:space="preserve">
+    <value>Masih menunggu konfirmasi</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.it.resx
+++ b/OneGateApp/Properties/Strings.it.resx
@@ -1106,4 +1106,13 @@ Si consiglia di conservare separatamente la chiave NEP-2 e la password e di eseg
   <data name="TransactionFailed" xml:space="preserve">
     <value>Transazione non riuscita</value>
   </data>
+  <data name="Pending" xml:space="preserve">
+    <value>In sospeso</value>
+  </data>
+  <data name="Retry" xml:space="preserve">
+    <value>Riprova</value>
+  </data>
+  <data name="TransactionStillPending" xml:space="preserve">
+    <value>Ancora in attesa di conferma</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.ja.resx
+++ b/OneGateApp/Properties/Strings.ja.resx
@@ -1106,4 +1106,13 @@ NEP-2 とパスワードは別々に保管し、それぞれを安全にバッ�
   <data name="TransactionFailed" xml:space="preserve">
     <value>トランザクション失敗</value>
   </data>
+  <data name="Pending" xml:space="preserve">
+    <value>保留中</value>
+  </data>
+  <data name="Retry" xml:space="preserve">
+    <value>再試行</value>
+  </data>
+  <data name="TransactionStillPending" xml:space="preserve">
+    <value>まだ確認を待っています</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.ko.resx
+++ b/OneGateApp/Properties/Strings.ko.resx
@@ -1106,4 +1106,13 @@ NEP-2와 비밀번호는 별도로 보관하고 각각 안전하게 백업하는
   <data name="TransactionFailed" xml:space="preserve">
     <value>트랜잭션 실패</value>
   </data>
+  <data name="Pending" xml:space="preserve">
+    <value>대기 중</value>
+  </data>
+  <data name="Retry" xml:space="preserve">
+    <value>다시 시도</value>
+  </data>
+  <data name="TransactionStillPending" xml:space="preserve">
+    <value>아직 확인 대기 중</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.nl.resx
+++ b/OneGateApp/Properties/Strings.nl.resx
@@ -1106,4 +1106,13 @@ Het wordt aanbevolen om de NEP-2-sleutel en het wachtwoord apart op te slaan en 
   <data name="TransactionFailed" xml:space="preserve">
     <value>Transactie mislukt</value>
   </data>
+  <data name="Pending" xml:space="preserve">
+    <value>In behandeling</value>
+  </data>
+  <data name="Retry" xml:space="preserve">
+    <value>Opnieuw proberen</value>
+  </data>
+  <data name="TransactionStillPending" xml:space="preserve">
+    <value>Nog steeds wachten op bevestiging</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.pt-BR.resx
+++ b/OneGateApp/Properties/Strings.pt-BR.resx
@@ -1106,4 +1106,13 @@ Recomenda-se armazenar a chave NEP-2 e a senha separadamente e fazer backups seg
   <data name="TransactionFailed" xml:space="preserve">
     <value>Transação falhou</value>
   </data>
+  <data name="Pending" xml:space="preserve">
+    <value>Pendente</value>
+  </data>
+  <data name="Retry" xml:space="preserve">
+    <value>Tentar novamente</value>
+  </data>
+  <data name="TransactionStillPending" xml:space="preserve">
+    <value>Ainda aguardando confirmação</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.resx
+++ b/OneGateApp/Properties/Strings.resx
@@ -1106,4 +1106,13 @@ It is recommended to store the NEP-2 key and password separately and back them u
   <data name="TransactionFailed" xml:space="preserve">
     <value>Transaction failed</value>
   </data>
+  <data name="Pending" xml:space="preserve">
+    <value>Pending</value>
+  </data>
+  <data name="Retry" xml:space="preserve">
+    <value>Retry</value>
+  </data>
+  <data name="TransactionStillPending" xml:space="preserve">
+    <value>Still waiting for confirmation</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.ru.resx
+++ b/OneGateApp/Properties/Strings.ru.resx
@@ -1106,4 +1106,13 @@
   <data name="TransactionFailed" xml:space="preserve">
     <value>Транзакция не удалась</value>
   </data>
+  <data name="Pending" xml:space="preserve">
+    <value>В ожидании</value>
+  </data>
+  <data name="Retry" xml:space="preserve">
+    <value>Повторить</value>
+  </data>
+  <data name="TransactionStillPending" xml:space="preserve">
+    <value>Все еще ожидается подтверждение</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.tr.resx
+++ b/OneGateApp/Properties/Strings.tr.resx
@@ -1106,4 +1106,13 @@ NEP-2 anahtarı ile şifreyi ayrı ayrı saklamanız ve güvenli şekilde yedekl
   <data name="TransactionFailed" xml:space="preserve">
     <value>İşlem başarısız</value>
   </data>
+  <data name="Pending" xml:space="preserve">
+    <value>Beklemede</value>
+  </data>
+  <data name="Retry" xml:space="preserve">
+    <value>Yeniden dene</value>
+  </data>
+  <data name="TransactionStillPending" xml:space="preserve">
+    <value>Hala onay bekleniyor</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.vi.resx
+++ b/OneGateApp/Properties/Strings.vi.resx
@@ -1106,4 +1106,13 @@ Nên lưu trữ riêng khóa NEP-2 và mật khẩu, đồng thời sao lưu ch�
   <data name="TransactionFailed" xml:space="preserve">
     <value>Giao dịch thất bại</value>
   </data>
+  <data name="Pending" xml:space="preserve">
+    <value>Đang chờ</value>
+  </data>
+  <data name="Retry" xml:space="preserve">
+    <value>Thử lại</value>
+  </data>
+  <data name="TransactionStillPending" xml:space="preserve">
+    <value>Vẫn đang chờ xác nhận</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.zh-Hans.resx
+++ b/OneGateApp/Properties/Strings.zh-Hans.resx
@@ -1106,4 +1106,13 @@
   <data name="TransactionFailed" xml:space="preserve">
     <value>交易失败</value>
   </data>
+  <data name="Pending" xml:space="preserve">
+    <value>待确认</value>
+  </data>
+  <data name="Retry" xml:space="preserve">
+    <value>重试</value>
+  </data>
+  <data name="TransactionStillPending" xml:space="preserve">
+    <value>仍在等待确认</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.zh-Hant.resx
+++ b/OneGateApp/Properties/Strings.zh-Hant.resx
@@ -1106,4 +1106,13 @@
   <data name="TransactionFailed" xml:space="preserve">
     <value>交易失敗</value>
   </data>
+  <data name="Pending" xml:space="preserve">
+    <value>待確認</value>
+  </data>
+  <data name="Retry" xml:space="preserve">
+    <value>重試</value>
+  </data>
+  <data name="TransactionStillPending" xml:space="preserve">
+    <value>仍在等待確認</value>
+  </data>
 </root>


### PR DESCRIPTION
## Problem

`SendingPage` stops polling after ten attempts but previously left the page on an indefinite confirmation spinner. It also treated an unavailable application log as a successful transaction, even though the execution result was unknown.

## Changes

- Show a pending state after the polling window expires.
- Add a Retry action without allowing overlapping polling loops.
- Keep an unavailable execution result pending instead of reporting a false success.
- Continue to report `HALT` as success and other known VM states as failure.
- Add the pending and retry text to every supported resource file.

## Scope

This PR only changes transaction confirmation polling and its pending UI. The branch was rebuilt from current `master` to remove merged commits and unrelated resource formatting changes.

## Validation

- Android `net10.0-android` arm64 build passed.
- Installed and launched with the .NET Android `Run` target on the API 36 `onegate_api36` emulator.
- Verified the running process, UI hierarchy, Wallet page, and Send page.
- iOS `net10.0-ios` simulator arm64 build passed.
- Installed and launched on an iPhone 17 Pro simulator running iOS 26.5.
- `git diff --check` passed.

Simulator screenshots are attached in a PR comment as external GitHub release assets.
