### PR TITLE
Capture unhandled exceptions and report crashes

### DIFF
--- a/OneGateApp/App.xaml.cs
+++ b/OneGateApp/App.xaml.cs
@@ -37,6 +37,8 @@ public partial class App : Application
         }
         httpClient.DefaultRequestHeaders.AcceptLanguage.Clear();
         httpClient.DefaultRequestHeaders.AcceptLanguage.ParseAdd(CultureInfo.CurrentUICulture.Name);
+
+        _ = CrashReporter.FlushAsync(httpClient);
     }
 
     internal bool ProcessAppLinkUri(Uri uri)

--- a/OneGateApp/MauiProgram.cs
+++ b/OneGateApp/MauiProgram.cs
@@ -30,6 +30,8 @@ public static class MauiProgram
 {
     public static MauiApp CreateMauiApp()
     {
+        CrashReporter.Initialize();
+
         var builder = MauiApp.CreateBuilder()
             .UseMauiApp<App>()
             .UseMauiCommunityToolkit(ConfigureMauiCommunityToolkit)

--- a/OneGateApp/Services/CrashReporter.cs
+++ b/OneGateApp/Services/CrashReporter.cs
@@ -1,0 +1,135 @@
+using System.Text;
+using System.Text.Json;
+
+namespace NeoOrder.OneGate.Services;
+
+/// <summary>
+/// Global crash/exception capture. Hooks every unhandled-exception source (managed + native),
+/// writes a diagnostic report to a local file synchronously when a crash happens (so it survives
+/// the process dying), and best-effort uploads pending reports to the OneGate API on next launch.
+/// No third-party SDK; reports contain only diagnostic fields, never wallet/account data.
+/// </summary>
+public static class CrashReporter
+{
+    const string ReportEndpoint = "api/app/crash";
+    const int MaxStoredReports = 50;
+
+    static readonly object fileLock = new();
+    static string FilePath => Path.Combine(FileSystem.AppDataDirectory, "crash-reports.jsonl");
+
+    /// <summary>Register the unhandled-exception handlers. Call as early as possible in startup.</summary>
+    public static void Initialize()
+    {
+        AppDomain.CurrentDomain.UnhandledException += (_, e) => Persist(e.ExceptionObject as Exception, "AppDomain");
+        TaskScheduler.UnobservedTaskException += (_, e) =>
+        {
+            Persist(e.Exception, "TaskScheduler");
+            e.SetObserved();
+        };
+#if ANDROID
+        Android.Runtime.AndroidEnvironment.UnhandledExceptionRaiser += (_, e) => Persist(e.Exception, "Android");
+#elif IOS || MACCATALYST
+        ObjCRuntime.Runtime.MarshalManagedException += (_, e) => Persist(e.Exception, "Apple");
+#endif
+    }
+
+    static void Persist(Exception? exception, string source)
+    {
+        if (exception is null) return;
+        try
+        {
+            CrashReport report = new()
+            {
+                Timestamp = DateTimeOffset.UtcNow,
+                Source = source,
+                Type = exception.GetType().FullName ?? nameof(Exception),
+                Message = exception.Message,
+                StackTrace = exception.ToString(),
+                AppVersion = AppInfo.VersionString,
+                Platform = $"{DeviceInfo.Platform} {DeviceInfo.VersionString}",
+                Device = $"{DeviceInfo.Manufacturer} {DeviceInfo.Model}",
+            };
+            string line = JsonSerializer.Serialize(report, SharedOptions.JsonSerializerOptions);
+            lock (fileLock)
+                File.AppendAllText(FilePath, line + Environment.NewLine);
+        }
+        catch
+        {
+            // A crash handler must never throw.
+        }
+    }
+
+    /// <summary>Upload pending crash reports to the OneGate API; clear them on success.</summary>
+    public static async Task FlushAsync(HttpClient httpClient)
+    {
+        string[] lines;
+        try
+        {
+            lock (fileLock)
+            {
+                if (!File.Exists(FilePath)) return;
+                lines = File.ReadAllLines(FilePath);
+            }
+        }
+        catch
+        {
+            return;
+        }
+
+        lines = [.. lines.Where(l => !string.IsNullOrWhiteSpace(l))];
+        if (lines.Length == 0) { TryDelete(); return; }
+        if (lines.Length > MaxStoredReports)
+            lines = lines[^MaxStoredReports..];
+
+        try
+        {
+            string payload = "[" + string.Join(",", lines) + "]";
+            using StringContent content = new(payload, Encoding.UTF8, "application/json");
+            HttpResponseMessage response = await httpClient.PostAsync(ReportEndpoint, content);
+            if (response.IsSuccessStatusCode)
+                TryDelete();
+            else
+                Persist(lines); // keep bounded for the next attempt
+        }
+        catch
+        {
+            Persist(lines); // endpoint unavailable/offline; keep for next launch
+        }
+    }
+
+    static void Persist(string[] lines)
+    {
+        try
+        {
+            lock (fileLock)
+                File.WriteAllText(FilePath, string.Join(Environment.NewLine, lines) + Environment.NewLine);
+        }
+        catch
+        {
+        }
+    }
+
+    static void TryDelete()
+    {
+        try
+        {
+            lock (fileLock)
+                if (File.Exists(FilePath)) File.Delete(FilePath);
+        }
+        catch
+        {
+        }
+    }
+}
+
+public sealed class CrashReport
+{
+    public DateTimeOffset Timestamp { get; set; }
+    public required string Source { get; set; }
+    public required string Type { get; set; }
+    public required string Message { get; set; }
+    public required string StackTrace { get; set; }
+    public required string AppVersion { get; set; }
+    public required string Platform { get; set; }
+    public required string Device { get; set; }
+}


### PR DESCRIPTION
## What
Adds global crash/exception capture (OneGate currently has **none** — no Crashlytics/App Center/Sentry, and no unhandled-exception handlers at all).

`CrashReporter`:
- Hooks **every** unhandled-exception source: `AppDomain.UnhandledException`, `TaskScheduler.UnobservedTaskException`, and the native raisers (Android `AndroidEnvironment.UnhandledExceptionRaiser`, Apple `Runtime.MarshalManagedException`).
- On a crash, writes a diagnostic report to a **local file synchronously** so it survives the process dying.
- On next launch, **best-effort uploads** pending reports to the OneGate API and clears them; if the endpoint is unavailable it keeps them (bounded to the last 50) for the next attempt.

## Design choices
- **Zero third-party SDK** — no Firebase/Sentry/App Center dependency, no DSN, data stays within your own API. (App Center is also retired, so it wasn't an option.)
- **Privacy-conscious** for a wallet: reports contain only `type / message / stack / appVersion / platform / device + timestamp` — **never wallet, account, address or key data**.

## Wiring
- `CrashReporter.Initialize()` at the very top of `MauiProgram.CreateMauiApp()` (earliest point, to catch startup crashes).
- `CrashReporter.FlushAsync(httpClient)` fired on `App` startup.

## Verified / notes
- Builds clean for **net10.0-android** (0 errors). iOS/maccatalyst not buildable here (no Xcode); the Apple raiser is behind `#if IOS || MACCATALYST` and is standard API.
- **Backend**: expects `POST {OneGateApi}/api/app/crash` with a JSON array of reports — adjust the path/handler to match the server. Until the endpoint exists, reports persist locally (graceful).
- Consider gating auto-upload behind user consent / the existing privacy mode — easy follow-up.