### PR TITLE
Claim accrued GAS rewards from NEO

### DIFF
--- a/OneGateApp/Pages/AssetDetailsPage.xaml
+++ b/OneGateApp/Pages/AssetDetailsPage.xaml
@@ -39,6 +39,15 @@
                     </VerticalStackLayout>
                 </Grid>
             </Border>
+            <Border StrokeShape="RoundRectangle 8" BackgroundColor="{toolkit:AppThemeResource Panel}" IsVisible="{Binding IsNeo}">
+                <Grid ColumnDefinitions="*,auto" ColumnSpacing="10" Padding="20">
+                    <VerticalStackLayout VerticalOptions="Center">
+                        <Label StyleClass="Secondary" Text="{x:Static og:Strings.UnclaimedGas}" />
+                        <Label Text="{Binding DisplayUnclaimedGas}" FontAttributes="Bold" />
+                    </VerticalStackLayout>
+                    <Button Grid.Column="1" Text="{x:Static og:Strings.ClaimGas}" IsEnabled="{Binding HasUnclaimedGas}" Clicked="OnClaimGas" Padding="16,0" VerticalOptions="Center" />
+                </Grid>
+            </Border>
             <Border StrokeShape="RoundRectangle 8" BackgroundColor="{toolkit:AppThemeResource Panel}">
                 <VerticalStackLayout Padding="20,0">
                     <Grid ColumnDefinitions="auto,*" ColumnSpacing="10" Padding="0,20">

--- a/OneGateApp/Pages/AssetDetailsPage.xaml.cs
+++ b/OneGateApp/Pages/AssetDetailsPage.xaml.cs
@@ -1,23 +1,54 @@
 using CommunityToolkit.Maui.Alerts;
+using CommunityToolkit.Maui.Extensions;
+using Neo;
+using Neo.Network.P2P.Payloads;
+using Neo.SmartContract;
 using Neo.SmartContract.Native;
+using Neo.Wallets;
 using NeoOrder.OneGate.Controls;
+using NeoOrder.OneGate.Controls.Popups;
 using NeoOrder.OneGate.Data;
 using NeoOrder.OneGate.Models;
+using NeoOrder.OneGate.Models.Intents;
 using NeoOrder.OneGate.Properties;
 using NeoOrder.OneGate.Services;
+using NeoOrder.OneGate.Services.RPC;
+using System.Numerics;
 
 namespace NeoOrder.OneGate.Pages;
 
 public partial class AssetDetailsPage : ContentPage, IQueryAttributable
 {
     readonly TokenManager tokenManager;
+    readonly RpcClient rpcClient;
+    readonly IWalletProvider walletProvider;
+    readonly ProtocolSettings protocolSettings;
+    readonly IServiceProvider serviceProvider;
 
-    public required AssetInfo Asset { get; set { field = value; OnPropertyChanged(); } }
+    public required AssetInfo Asset { get; set { field = value; OnPropertyChanged(); OnPropertyChanged(nameof(IsNeo)); } }
     public bool ShowBalance { get; set { field = value; OnPropertyChanged(); } }
+    public bool IsNeo => Asset?.Token.Hash == NativeContract.NEO.Hash;
+    public BigInteger UnclaimedGas
+    {
+        get;
+        set
+        {
+            field = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(DisplayUnclaimedGas));
+            OnPropertyChanged(nameof(HasUnclaimedGas));
+        }
+    }
+    public string DisplayUnclaimedGas => $"{new BigDecimal(UnclaimedGas, NativeContract.GAS.Decimals)} {NativeContract.GAS.Symbol}";
+    public bool HasUnclaimedGas => UnclaimedGas > 0;
 
-    public AssetDetailsPage(ApplicationDbContext dbContext, TokenManager tokenManager)
+    public AssetDetailsPage(ApplicationDbContext dbContext, TokenManager tokenManager, RpcClient rpcClient, IWalletProvider walletProvider, ProtocolSettings protocolSettings, IServiceProvider serviceProvider)
     {
         this.tokenManager = tokenManager;
+        this.rpcClient = rpcClient;
+        this.walletProvider = walletProvider;
+        this.protocolSettings = protocolSettings;
+        this.serviceProvider = serviceProvider;
         ShowBalance = dbContext.Settings.Get<bool>("wallet/showBalance");
         InitializeComponent();
     }
@@ -27,6 +58,20 @@ public partial class AssetDetailsPage : ContentPage, IQueryAttributable
         Asset = (AssetInfo)query["asset"];
         if (Asset.Token.Hash == NativeContract.NEO.Hash || Asset.Token.Hash == NativeContract.GAS.Hash)
             ToolbarItems.Remove(hideButton);
+        if (IsNeo)
+            _ = LoadUnclaimedGasAsync();
+    }
+
+    async Task LoadUnclaimedGasAsync()
+    {
+        try
+        {
+            WalletAccount account = walletProvider.GetWallet()!.GetDefaultAccount()!;
+            UnclaimedGas = await rpcClient.GetUnclaimedGasAsync(account.ScriptHash);
+        }
+        catch
+        {
+        }
     }
 
     async void OnHideClicked(object sender, EventArgs e)
@@ -42,6 +87,64 @@ public partial class AssetDetailsPage : ContentPage, IQueryAttributable
         await Shell.Current.GoToAsync("//wallet/asset/details/send", new Dictionary<string, object>
         {
             ["asset"] = Asset
+        });
+    }
+
+    async void OnClaimGas(object sender, EventArgs e)
+    {
+        Wallet wallet = walletProvider.GetWallet()!;
+        WalletAccount account = wallet.GetDefaultAccount()!;
+        UInt160 from = account.ScriptHash;
+        if (Asset.Balance <= 0)
+        {
+            await Toast.Show(Strings.NoNeoToClaimGas);
+            return;
+        }
+        // Accrued GAS is distributed by a NEO transfer; a self-transfer claims it without moving funds elsewhere.
+        TransactionIntent[] intents = [new TransferIntent
+        {
+            Asset = Asset.Token,
+            From = from,
+            To = from,
+            Amount = Asset.Balance
+        }];
+        Transaction tx;
+        try
+        {
+            tx = await rpcClient.MakeTransactionAsync(NativeContract.NEO.Hash, from, from, Asset.Balance, null);
+        }
+        catch (Exception ex)
+        {
+            await Toast.Show(ex.Message);
+            return;
+        }
+        SendTransactionPopup popup = serviceProvider.GetServiceOrCreateInstance<SendTransactionPopup>();
+        popup.Message = Strings.ClaimGasConfirmText;
+        popup.Transaction = tx;
+        popup.Intents = intents;
+        var result = await this.ShowPopupAsync<bool>(popup);
+        if (!result.Result) return;
+        var context = new ContractParametersContext(null!, tx, protocolSettings.Network);
+        if (!wallet.Sign(context) || !context.Completed)
+        {
+            await Toast.Show(Strings.SignTransactionFailed);
+            return;
+        }
+        tx.Witnesses = context.GetWitnesses();
+        try
+        {
+            await rpcClient.SendRawTransaction(tx);
+        }
+        catch (Exception ex)
+        {
+            await Toast.Show(ex.Message);
+            return;
+        }
+        GlobalStates.Invalidate<WalletPage>();
+        await Shell.Current.GoToAsync("//wallet/sending", new Dictionary<string, object>
+        {
+            ["tx"] = tx,
+            ["intents"] = intents
         });
     }
 }

--- a/OneGateApp/Properties/Strings.Designer.cs
+++ b/OneGateApp/Properties/Strings.Designer.cs
@@ -2625,5 +2625,41 @@ namespace NeoOrder.OneGate.Properties {
                 return ResourceManager.GetString("WifPrivateKeyWarning", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Claim.
+        /// </summary>
+        internal static string ClaimGas {
+            get {
+                return ResourceManager.GetString("ClaimGas", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unclaimed GAS.
+        /// </summary>
+        internal static string UnclaimedGas {
+            get {
+                return ResourceManager.GetString("UnclaimedGas", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You need NEO to claim GAS..
+        /// </summary>
+        internal static string NoNeoToClaimGas {
+            get {
+                return ResourceManager.GetString("NoNeoToClaimGas", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Claim your accrued GAS. This sends a NEO.
+        /// </summary>
+        internal static string ClaimGasConfirmText {
+            get {
+                return ResourceManager.GetString("ClaimGasConfirmText", resourceCulture);
+            }
+        }
     }
 }

--- a/OneGateApp/Properties/Strings.resx
+++ b/OneGateApp/Properties/Strings.resx
@@ -989,4 +989,16 @@ It is recommended to store the NEP-2 key and password separately and back them u
   <data name="Unavailable" xml:space="preserve">
     <value>Unavailable</value>
   </data>
+  <data name="ClaimGas" xml:space="preserve">
+    <value>Claim</value>
+  </data>
+  <data name="UnclaimedGas" xml:space="preserve">
+    <value>Unclaimed GAS</value>
+  </data>
+  <data name="NoNeoToClaimGas" xml:space="preserve">
+    <value>You need NEO to claim GAS.</value>
+  </data>
+  <data name="ClaimGasConfirmText" xml:space="preserve">
+    <value>Claim your accrued GAS. This sends a NEO transfer to your own address, which distributes the GAS.</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.zh-Hans.resx
+++ b/OneGateApp/Properties/Strings.zh-Hans.resx
@@ -989,4 +989,16 @@
   <data name="Unavailable" xml:space="preserve">
     <value>不可用</value>
   </data>
+  <data name="ClaimGas" xml:space="preserve">
+    <value>领取</value>
+  </data>
+  <data name="UnclaimedGas" xml:space="preserve">
+    <value>未领取 GAS</value>
+  </data>
+  <data name="NoNeoToClaimGas" xml:space="preserve">
+    <value>需要持有 NEO 才能领取 GAS。</value>
+  </data>
+  <data name="ClaimGasConfirmText" xml:space="preserve">
+    <value>领取累积的 GAS。这会向你自己的地址发起一笔 NEO 转账以分发 GAS。</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.zh-Hant.resx
+++ b/OneGateApp/Properties/Strings.zh-Hant.resx
@@ -989,4 +989,16 @@
   <data name="Unavailable" xml:space="preserve">
     <value>不可用</value>
   </data>
+  <data name="ClaimGas" xml:space="preserve">
+    <value>領取</value>
+  </data>
+  <data name="UnclaimedGas" xml:space="preserve">
+    <value>未領取 GAS</value>
+  </data>
+  <data name="NoNeoToClaimGas" xml:space="preserve">
+    <value>需要持有 NEO 才能領取 GAS。</value>
+  </data>
+  <data name="ClaimGasConfirmText" xml:space="preserve">
+    <value>領取累積的 GAS。這會向你自己的地址發起一筆 NEO 轉帳以分發 GAS。</value>
+  </data>
 </root>

--- a/OneGateApp/Services/RPC/RpcClient.cs
+++ b/OneGateApp/Services/RPC/RpcClient.cs
@@ -129,6 +129,12 @@ public class RpcClient(IWalletProvider walletProvider, ProtocolSettings protocol
         return result.Stack[0].GetInteger();
     }
 
+    public async Task<BigInteger> GetUnclaimedGasAsync(UInt160 account)
+    {
+        JsonObject result = await RpcSendAsync<JsonObject>("getunclaimedgas", account.ToAddress(protocolSettings.AddressVersion));
+        return BigInteger.TryParse(result["unclaimed"]?.GetValue<string>(), out BigInteger value) ? value : BigInteger.Zero;
+    }
+
     public async Task<BigInteger[]> BalanceOf(UInt160 account, UInt160[] assets)
     {
         byte[] script;


### PR DESCRIPTION
## What
Holding NEO accrues claimable GAS, but OneGate had no way to **see or claim** it — the single most-wanted Neo-native feature (NeoLine/O3 ship it). This adds:
- `RpcClient.GetUnclaimedGasAsync` (the `getunclaimedgas` RPC).
- An **Unclaimed GAS** row + **Claim** button on the NEO asset detail.
- Claiming reuses the existing flow: a **NEO self-transfer** (which distributes the accrued GAS) is built via `MakeTransactionAsync`, confirmed in `SendTransactionPopup`, signed, broadcast, and tracked on `SendingPage`.

## Notes
- Conflict-checked: touches `RpcClient.cs` and `AssetDetailsPage.xaml(.cs)` — **neither** is touched by any open PR. It *uses* (does not modify) `SendTransactionPopup`, so no overlap with #50.
- Builds clean for **net10.0-android** (0 errors).