### PR TITLE
[codex] Add dApp QR scanner API

### DIFF
--- a/OneGateApp/Pages/LaunchDAppPage.xaml.cs
+++ b/OneGateApp/Pages/LaunchDAppPage.xaml.cs
@@ -167,7 +167,7 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
                     networkchanged: new Set()
                 };
 
-                const methods = ["authenticate", "getAccounts", "pickAddress", "getBalance", "send", "call", "invoke", "makeTransaction", "sign", "signMessage", "relay", "getBlock", "getBlockCount", "getTransaction", "getApplicationLog", "getStorage", "getTokenInfo"];
+                const methods = ["authenticate", "getAccounts", "scanQRCode", "pickAddress", "getBalance", "send", "call", "invoke", "makeTransaction", "sign", "signMessage", "relay", "getBlock", "getBlockCount", "getTransaction", "getApplicationLog", "getStorage", "getTokenInfo"];
 
                 const provider = {
                     name: '{{AppInfo.Name}}',

--- a/OneGateApp/Pages/LaunchDAppPage.xaml.dAPI.cs
+++ b/OneGateApp/Pages/LaunchDAppPage.xaml.dAPI.cs
@@ -17,6 +17,7 @@ using NeoOrder.OneGate.Services.RPC;
 using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Text.Json.Nodes;
+using ZXing.Net.Maui;
 
 namespace NeoOrder.OneGate.Pages;
 
@@ -59,6 +60,19 @@ partial class LaunchDAppPage
         if (!string.IsNullOrEmpty(prompt)) popup.Message = prompt;
         var result = await this.ShowPopupAsync<string>(popup);
         return result.Result ?? throw new OperationCanceledException();
+    }
+
+    [RpcMethod]
+    async Task<string> ScanQRCode()
+    {
+        if (!BarcodeScanning.IsSupported)
+            throw new DapiException(10001, "QR scanning is not supported");
+
+        var page = serviceProvider.GetServiceOrCreateInstance<ScanPage>();
+        var completion = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
+        page.ReturnRawResult(completion);
+        await Navigation.PushAsync(page);
+        return await completion.Task;
     }
 
     [RpcMethod]

--- a/OneGateApp/Pages/ScanPage.xaml.cs
+++ b/OneGateApp/Pages/ScanPage.xaml.cs
@@ -17,6 +17,7 @@ namespace NeoOrder.OneGate.Pages;
 public partial class ScanPage : ContentPage, IQueryAttributable
 {
     readonly ProtocolSettings protocolSettings;
+    TaskCompletionSource<string>? rawResultCompletion;
     string? action;
 
     public ScanPage(ProtocolSettings protocolSettings)
@@ -35,10 +36,16 @@ public partial class ScanPage : ContentPage, IQueryAttributable
             this.action = (string)action;
     }
 
+    public void ReturnRawResult(TaskCompletionSource<string> completion)
+    {
+        rawResultCompletion = completion;
+    }
+
     protected override void OnDisappearing()
     {
         base.OnDisappearing();
         cameraView.IsDetecting = false;
+        rawResultCompletion?.TrySetCanceled();
     }
 
     async void OnBarcodesDetected(object sender, BarcodeDetectionEventArgs e)
@@ -95,6 +102,13 @@ public partial class ScanPage : ContentPage, IQueryAttributable
 
     async Task ProcessScanResultAsync(string result)
     {
+        if (rawResultCompletion is not null)
+        {
+            rawResultCompletion.TrySetResult(result);
+            await Navigation.PopAsync();
+            return;
+        }
+
         try
         {
             if (Uri.TryCreate(result, UriKind.Absolute, out var uri))

--- a/OneGateApp/Pages/ScanPage.xaml.cs
+++ b/OneGateApp/Pages/ScanPage.xaml.cs
@@ -104,8 +104,10 @@ public partial class ScanPage : ContentPage, IQueryAttributable
     {
         if (rawResultCompletion is not null)
         {
-            rawResultCompletion.TrySetResult(result);
-            await Navigation.PopAsync();
+            var completion = rawResultCompletion;
+            rawResultCompletion = null;
+            if (completion.TrySetResult(result))
+                await Navigation.PopAsync();
             return;
         }
 


### PR DESCRIPTION
## Summary

Adds a native QR scanner API for dApps:

```js
const value = await window.OneGateDapiProvider.scanQRCode();
```

This opens OneGate's existing native QR scanner and returns the raw scanned QR text to the calling dApp.

## Scope

- Adds `scanQRCode` to the injected OneGate dAPI provider.
- Reuses the existing `ScanPage` scanner UI.
- Adds a raw-result mode for dApp calls so scanning does not auto-navigate, auto-open URLs, or execute OneGate QR actions.
- Keeps the existing global scan behavior unchanged for normal app entry points.
- Rejects with the existing dAPI cancellation path when the user backs out.

## Validation

- `git diff --check`
- Android simulator build:
  - `dotnet build OneGateApp/OneGateApp.csproj -f net10.0-android -r android-arm64 -p:AndroidSdkDirectory=/opt/homebrew/share/android-commandlinetools -p:JavaSdkDirectory=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home -p:EmbedAssembliesIntoApk=true`
- iOS simulator build:
  - `DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer MD_APPLE_SDK_ROOT=/Applications/Xcode-26.5.0.app dotnet build OneGateApp/OneGateApp.csproj -f net10.0-ios -p:RuntimeIdentifier=iossimulator-arm64 -p:BuildIpa=false -p:EnableCodeSigning=true -p:CodesignKey=-`
- Android emulator runtime:
  - installed/launched the Debug APK
  - opened a real dApp WebView
  - verified `OneGateDapiProvider.scanQRCode` exists
  - called `scanQRCode()` from the dApp WebView and verified OneGate opened the native scan flow
- iOS simulator runtime:
  - installed/launched the Debug simulator app
  - verified the app starts successfully
  - verified the existing scan entry point returns the simulator camera-unavailable state

## Notes

- iOS Simulator does not provide a usable camera in this environment, so full QR camera scanning needs device validation or a simulator camera setup.
- Existing warnings only:
  - `SQLitePCLRaw.lib.e_sqlite3*` NU1903 warnings
  - existing iOS duplicate `ImageAsset` MT7158 warnings
