### PR TITLE
[codex] Add dApp asset picker API

### DIFF
--- a/OneGateApp/Controls/Handlers/BridgeWebViewHandler.Android.cs
+++ b/OneGateApp/Controls/Handlers/BridgeWebViewHandler.Android.cs
@@ -3,6 +3,8 @@
 using Android.Webkit;
 using AndroidX.WebKit;
 using Java.Interop;
+using Microsoft.Maui.Handlers;
+using Microsoft.Maui.Platform;
 
 namespace NeoOrder.OneGate.Controls.Handlers;
 
@@ -25,19 +27,56 @@ partial class BridgeWebViewHandler
         }
     }
 
+    class BridgeWebViewClient(BridgeWebViewHandler handler) : MauiWebViewClient(handler)
+    {
+        public override void OnPageFinished(Android.Webkit.WebView? view, string? url)
+        {
+            base.OnPageFinished(view, url);
+            handler.InjectBridgeScript(view);
+        }
+    }
+
     protected override void ConnectHandler(Android.Webkit.WebView platformView)
     {
         base.ConnectHandler(platformView);
         platformView.Settings.DomStorageEnabled = true;
         platformView.Settings.JavaScriptEnabled = true;
         platformView.AddJavascriptInterface(new ScriptHandler(BridgeWebView.OnMessage, BridgeWebView.OnSyncMessage), "__OneGateBridge");
-        if (WebViewFeature.IsFeatureSupported(WebViewFeature.DocumentStartScript))
-        {
-            string script = Views.BridgeWebView.CreateRpcScript();
-            if (!string.IsNullOrWhiteSpace(BridgeWebView.DocumentStartScript))
-                script += BridgeWebView.DocumentStartScript;
-            WebViewCompat.AddDocumentStartJavaScript(platformView, script, ["*"]);
-        }
+        platformView.SetWebViewClient(new BridgeWebViewClient(this));
+        InstallDocumentStartScript(platformView);
+    }
+
+    static partial void ConfigureMapper(PropertyMapper<IWebView, IWebViewHandler> mapper)
+    {
+        mapper[nameof(Views.BridgeWebView.DocumentStartScript)] = MapDocumentStartScript;
+    }
+
+    static void MapDocumentStartScript(IWebViewHandler handler, IWebView webView)
+    {
+        if (handler is BridgeWebViewHandler bridgeHandler)
+            bridgeHandler.InstallDocumentStartScript(bridgeHandler.PlatformView);
+    }
+
+    void InstallDocumentStartScript(Android.Webkit.WebView? platformView)
+    {
+        if (platformView is null || !WebViewFeature.IsFeatureSupported(WebViewFeature.DocumentStartScript))
+            return;
+
+        string script = Views.BridgeWebView.CreateRpcScript();
+        if (!string.IsNullOrWhiteSpace(BridgeWebView.DocumentStartScript))
+            script += BridgeWebView.DocumentStartScript;
+        WebViewCompat.AddDocumentStartJavaScript(platformView, script, ["*"]);
+    }
+
+    void InjectBridgeScript(Android.Webkit.WebView? platformView)
+    {
+        if (platformView is null)
+            return;
+
+        string script = Views.BridgeWebView.CreateRpcScript();
+        if (!string.IsNullOrWhiteSpace(BridgeWebView.DocumentStartScript))
+            script += BridgeWebView.DocumentStartScript;
+        platformView.EvaluateJavascript(script, null);
     }
 }
 #endif

--- a/OneGateApp/Controls/Handlers/BridgeWebViewHandler.Android.cs
+++ b/OneGateApp/Controls/Handlers/BridgeWebViewHandler.Android.cs
@@ -10,6 +10,8 @@ namespace NeoOrder.OneGate.Controls.Handlers;
 
 partial class BridgeWebViewHandler
 {
+    string? installedDocumentStartScript;
+
     class ScriptHandler(Action<string> onMessage, Func<string, string> onSyncMessage) : Java.Lang.Object
     {
         [JavascriptInterface]
@@ -43,7 +45,6 @@ partial class BridgeWebViewHandler
         platformView.Settings.JavaScriptEnabled = true;
         platformView.AddJavascriptInterface(new ScriptHandler(BridgeWebView.OnMessage, BridgeWebView.OnSyncMessage), "__OneGateBridge");
         platformView.SetWebViewClient(new BridgeWebViewClient(this));
-        InstallDocumentStartScript(platformView);
     }
 
     static partial void ConfigureMapper(PropertyMapper<IWebView, IWebViewHandler> mapper)
@@ -65,7 +66,11 @@ partial class BridgeWebViewHandler
         string script = Views.BridgeWebView.CreateRpcScript();
         if (!string.IsNullOrWhiteSpace(BridgeWebView.DocumentStartScript))
             script += BridgeWebView.DocumentStartScript;
+        if (script == installedDocumentStartScript)
+            return;
+
         WebViewCompat.AddDocumentStartJavaScript(platformView, script, ["*"]);
+        installedDocumentStartScript = script;
     }
 
     void InjectBridgeScript(Android.Webkit.WebView? platformView)

--- a/OneGateApp/Controls/Views/BridgeWebView.cs
+++ b/OneGateApp/Controls/Views/BridgeWebView.cs
@@ -30,6 +30,7 @@ public partial class BridgeWebView : WebView
         RegisterSystemCallHandler("fullscreen.enter", EnterFullscreenSystemAsync);
         RegisterSystemCallHandler("fullscreen.exit", ExitFullscreenSystemAsync);
 #endif
+        Navigated += OnNavigated;
         Unloaded += (_, _) => RestoreHostState();
         HandlerChanging += (_, e) =>
         {
@@ -431,6 +432,22 @@ public partial class BridgeWebView : WebView
     {
         ArgumentNullException.ThrowIfNull(response);
         return EvaluateJavaScriptAsync($"window.{BridgeCallbackName}({response.ToJsonString()})");
+    }
+
+    async void OnNavigated(object? sender, WebNavigatedEventArgs e)
+    {
+        try
+        {
+            string script = CreateRpcScript();
+            if (!string.IsNullOrWhiteSpace(DocumentStartScript))
+                script += DocumentStartScript;
+            await EvaluateJavaScriptAsync(script);
+        }
+        catch
+        {
+            // The document-start path is preferred; this fallback is best effort for WebView runtimes
+            // that do not support document-start injection.
+        }
     }
 
     protected void RegisterSystemCallHandler(string method, Func<JsonArray?, JsonNode?> handler)

--- a/OneGateApp/Models/DAppAsset.cs
+++ b/OneGateApp/Models/DAppAsset.cs
@@ -1,0 +1,26 @@
+using Neo;
+using System.Numerics;
+
+namespace NeoOrder.OneGate.Models;
+
+record DAppAsset
+{
+    public required UInt160 Hash { get; init; }
+    public required string Name { get; init; }
+    public required string Symbol { get; init; }
+    public required byte Decimals { get; init; }
+    public required BigInteger Balance { get; init; }
+    public string Source { get; init; } = "walletAssets";
+
+    public static DAppAsset From(AssetInfo asset)
+    {
+        return new DAppAsset
+        {
+            Hash = asset.Token.Hash,
+            Name = asset.Token.Name,
+            Symbol = asset.Token.Symbol,
+            Decimals = asset.Token.Decimals,
+            Balance = asset.Balance
+        };
+    }
+}

--- a/OneGateApp/Pages/LaunchDAppPage.xaml.cs
+++ b/OneGateApp/Pages/LaunchDAppPage.xaml.cs
@@ -26,13 +26,14 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
     readonly HttpClient httpClient;
     readonly RpcServer rpcServer;
     readonly RpcClient rpcClient;
+    readonly TokenManager tokenManager;
 
     public required DApp DApp { get; set { field = value; OnPropertyChanged(); } }
     public required string Url { get; set { field = value; OnPropertyChanged(); } }
     public bool IsFavorite { get; set { field = value; OnPropertyChanged(); } }
     public bool IsDeveloperToolsEnabled { get; set { field = value; OnPropertyChanged(); } }
 
-    public LaunchDAppPage(IServiceProvider serviceProvider, ProtocolSettings protocolSettings, IWalletProvider walletProvider, WalletAuthorizationService walletAuthorizationService, ApplicationDbContext dbContext, HttpClient httpClient, RpcClient rpcClient, IHomeShortcutService homeShortcutService)
+    public LaunchDAppPage(IServiceProvider serviceProvider, ProtocolSettings protocolSettings, IWalletProvider walletProvider, WalletAuthorizationService walletAuthorizationService, ApplicationDbContext dbContext, HttpClient httpClient, RpcClient rpcClient, TokenManager tokenManager, IHomeShortcutService homeShortcutService)
     {
         this.serviceProvider = serviceProvider;
         this.protocolSettings = protocolSettings;
@@ -42,6 +43,7 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
         this.httpClient = httpClient;
         this.rpcServer = new(this);
         this.rpcClient = rpcClient;
+        this.tokenManager = tokenManager;
         IsDeveloperToolsEnabled = dbContext.Settings.Get<bool>(DeveloperModeKey);
         InitializeComponent();
         webView.DocumentStartScript = CreateDocumentStartScript();
@@ -167,7 +169,7 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
                     networkchanged: new Set()
                 };
 
-                const methods = ["authenticate", "getAccounts", "pickAddress", "getBalance", "send", "call", "invoke", "makeTransaction", "sign", "signMessage", "relay", "getBlock", "getBlockCount", "getTransaction", "getApplicationLog", "getStorage", "getTokenInfo"];
+                const methods = ["authenticate", "getAccounts", "pickAddress", "pickAsset", "getBalance", "send", "call", "invoke", "makeTransaction", "sign", "signMessage", "relay", "getBlock", "getBlockCount", "getTransaction", "getApplicationLog", "getStorage", "getTokenInfo"];
 
                 const provider = {
                     name: '{{AppInfo.Name}}',

--- a/OneGateApp/Pages/LaunchDAppPage.xaml.cs
+++ b/OneGateApp/Pages/LaunchDAppPage.xaml.cs
@@ -29,7 +29,17 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
     readonly TokenManager tokenManager;
 
     public required DApp DApp { get; set { field = value; OnPropertyChanged(); } }
-    public required string Url { get; set { field = value; OnPropertyChanged(); } }
+    string url = null!;
+    public required string Url
+    {
+        get => url;
+        set
+        {
+            if (url == value) return;
+            url = value;
+            OnPropertyChanged();
+        }
+    }
     public bool IsFavorite { get; set { field = value; OnPropertyChanged(); } }
     public bool IsDeveloperToolsEnabled { get; set { field = value; OnPropertyChanged(); } }
 

--- a/OneGateApp/Pages/LaunchDAppPage.xaml.dAPI.cs
+++ b/OneGateApp/Pages/LaunchDAppPage.xaml.dAPI.cs
@@ -62,6 +62,21 @@ partial class LaunchDAppPage
     }
 
     [RpcMethod]
+    async Task<DAppAsset> PickAsset()
+    {
+        IReadOnlyList<AssetInfo> assets = await tokenManager.LoadAssetsAsync();
+        if (assets.Count == 0)
+            throw new DapiException(10000, "No assets available");
+
+        var popup = serviceProvider.GetServiceOrCreateInstance<SelectAssetPopup>();
+        popup.Assets = assets;
+        popup.SelectedHash = assets[0].Token.Hash;
+        var result = await this.ShowPopupAsync<AssetInfo?>(popup);
+        AssetInfo asset = result.Result ?? throw new OperationCanceledException();
+        return DAppAsset.From(asset);
+    }
+
+    [RpcMethod]
     async Task<BigInteger> GetBalance(UInt160 asset, UInt160 account)
     {
         return await rpcClient.BalanceOf(asset, account);


### PR DESCRIPTION
## Summary

Adds `OneGateDapiProvider.pickAsset()` so dApps can ask OneGate to show the native asset picker and return the user-selected wallet asset.

The API reuses the existing `SelectAssetPopup` and `TokenManager.LoadAssetsAsync()` path, so dApps only receive assets currently visible/available in the wallet asset list. The returned object includes `hash`, `name`, `symbol`, `decimals`, `balance`, and `source`.

## Scope

- Registers `pickAsset` in the injected OneGate dAPI method list.
- Adds a native dAPI RPC method that opens `SelectAssetPopup`.
- Adds a small `DAppAsset` response model for the selected asset payload.

## Validation

- `git diff --check`
- Android simulator build:
  `dotnet build OneGateApp/OneGateApp.csproj -f net10.0-android -r android-arm64 -p:AndroidSdkDirectory=/opt/homebrew/share/android-commandlinetools -p:JavaSdkDirectory=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home -p:EmbedAssembliesIntoApk=true`
- Android simulator install/launch passed.
- Android WebView end-to-end test passed: injected a small test page into a real dApp WebView, verified `typeof OneGateDapiProvider.pickAsset === "function"`, called `pickAsset()`, saw the native asset picker, selected NEO, and confirmed the JSON result returned to the dApp page.
- iOS simulator build:
  `DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer MD_APPLE_SDK_ROOT=/Applications/Xcode-26.5.0.app dotnet build OneGateApp/OneGateApp.csproj -f net10.0-ios -r iossimulator-arm64 -p:BuildIpa=false -p:EnableCodeSigning=true -p:CodesignKey=-`
- iOS simulator install/launch passed.

Existing warnings only: SQLitePCLRaw `NU1903`; iOS duplicate image asset `MT7158` was observed in prior iOS builds for this repo and is unrelated to this PR.

## Known limitation

Local iOS simulator Universal Link testing for `https://onegate.space/app/25` opens Safari instead of routing directly into the local OneGate build. Because of that existing environment/app-link limitation, the dApp JS return path was verified end-to-end on Android WebView, while iOS was verified with build/install/launch screenshots.
