### PR TITLE
[codex] Add dApp share API

### DIFF
--- a/OneGateApp/Models/DAppShareRequest.cs
+++ b/OneGateApp/Models/DAppShareRequest.cs
@@ -1,0 +1,9 @@
+namespace NeoOrder.OneGate.Models;
+
+record DAppShareRequest
+{
+    public string? Title { get; init; }
+    public string? Text { get; init; }
+    public string? Uri { get; init; }
+    public string? Subject { get; init; }
+}

--- a/OneGateApp/Pages/LaunchDAppPage.xaml.cs
+++ b/OneGateApp/Pages/LaunchDAppPage.xaml.cs
@@ -167,7 +167,7 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
                     networkchanged: new Set()
                 };
 
-                const methods = ["authenticate", "getAccounts", "pickAddress", "getBalance", "send", "call", "invoke", "makeTransaction", "sign", "signMessage", "relay", "getBlock", "getBlockCount", "getTransaction", "getApplicationLog", "getStorage", "getTokenInfo"];
+                const methods = ["authenticate", "getAccounts", "pickAddress", "share", "getBalance", "send", "call", "invoke", "makeTransaction", "sign", "signMessage", "relay", "getBlock", "getBlockCount", "getTransaction", "getApplicationLog", "getStorage", "getTokenInfo"];
 
                 const provider = {
                     name: '{{AppInfo.Name}}',

--- a/OneGateApp/Pages/LaunchDAppPage.xaml.dAPI.cs
+++ b/OneGateApp/Pages/LaunchDAppPage.xaml.dAPI.cs
@@ -62,6 +62,22 @@ partial class LaunchDAppPage
     }
 
     [RpcMethod]
+    async Task<bool> Share(DAppShareRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.Text) && string.IsNullOrWhiteSpace(request.Uri))
+            throw new DapiException(10002, "Share text or URI is required");
+
+        await Microsoft.Maui.ApplicationModel.DataTransfer.Share.RequestAsync(new Microsoft.Maui.ApplicationModel.DataTransfer.ShareTextRequest
+        {
+            Title = request.Title,
+            Text = request.Text,
+            Uri = request.Uri,
+            Subject = request.Subject
+        });
+        return true;
+    }
+
+    [RpcMethod]
     async Task<BigInteger> GetBalance(UInt160 asset, UInt160 account)
     {
         return await rpcClient.BalanceOf(asset, account);

--- a/OneGateApp/Pages/LaunchDAppPage.xaml.dAPI.cs
+++ b/OneGateApp/Pages/LaunchDAppPage.xaml.dAPI.cs
@@ -62,8 +62,10 @@ partial class LaunchDAppPage
     }
 
     [RpcMethod]
-    async Task<bool> Share(DAppShareRequest request)
+    async Task<bool> Share(DAppShareRequest? request)
     {
+        if (request is null)
+            throw new DapiException(10002, "Share request is required");
         if (string.IsNullOrWhiteSpace(request.Text) && string.IsNullOrWhiteSpace(request.Uri))
             throw new DapiException(10002, "Share text or URI is required");
 


### PR DESCRIPTION
## Summary

Adds `OneGateDapiProvider.share()` so dApps can open the native system share sheet through OneGate.

The API accepts a small payload with `title`, `text`, `uri`, and `subject`. At least `text` or `uri` is required. It does not expose wallet data or send anything automatically; the user still chooses the target app and confirms sharing in the platform share UI.

## Scope

- Registers `share` in the injected OneGate dAPI method list.
- Adds a dAPI RPC method that calls MAUI `Share.RequestAsync`.
- Adds a small request model for the share payload.

## Validation

- `git diff --check`
- Android simulator build:
  `dotnet build OneGateApp/OneGateApp.csproj -f net10.0-android -r android-arm64 -p:AndroidSdkDirectory=/opt/homebrew/share/android-commandlinetools -p:JavaSdkDirectory=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home -p:EmbedAssembliesIntoApk=true`
- Android simulator install/launch passed.
- Android WebView end-to-end test passed: injected a small test page into a real dApp WebView, verified `typeof OneGateDapiProvider.share === "function"`, called `share()`, and confirmed the Android system share sheet opened with the expected text and URI preview.
- iOS simulator build:
  `DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer MD_APPLE_SDK_ROOT=/Applications/Xcode-26.5.0.app dotnet build OneGateApp/OneGateApp.csproj -f net10.0-ios -r iossimulator-arm64 -p:BuildIpa=false -p:EnableCodeSigning=true -p:CodesignKey=-`
- iOS simulator install/launch passed.

Existing warnings only: SQLitePCLRaw `NU1903`; iOS duplicate image asset `MT7158`.

## Known limitation

Local iOS simulator Universal Link testing for `https://onegate.space/app/25` opens Safari instead of routing directly into the local OneGate build in this environment. Because of that existing local app-link limitation, the dApp JS share flow was verified end-to-end on Android WebView, while iOS was verified with build/install/launch screenshots.
