### PR TITLE
[codex] Add game runtime mode

### DIFF
--- a/OneGateApp/Pages/LaunchDAppPage.xaml
+++ b/OneGateApp/Pages/LaunchDAppPage.xaml
@@ -6,6 +6,7 @@
              x:Class="NeoOrder.OneGate.Pages.LaunchDAppPage"
              BindingContext="{Binding Source={RelativeSource Self}}"
              SafeAreaEdges="All"
+             Shell.NavBarIsVisible="{Binding IsNavigationChromeVisible}"
              Shell.TabBarIsVisible="False">
     <ContentPage.Resources>
         <og:LocalizerConverter x:Key="LocalizerConverter" />
@@ -24,5 +25,24 @@
         <ToolbarItem Order="Primary" IconImageSource="{FontImageSource &#xe68b;, FontFamily=Icons, Color={toolkit:AppThemeResource Primary}}" IsEnabled="{Binding DApp.IsActive}" Command="{x:Static og:Commands.Share}" CommandParameter="{Binding DApp}" />
         <ToolbarItem x:Name="developerToolsButton" Order="Primary" IconImageSource="{FontImageSource &#xe716;, FontFamily=Icons, Color={toolkit:AppThemeResource Primary}}" Clicked="OnDeveloperToolsClicked" />
     </ContentPage.ToolbarItems>
-    <og:BridgeWebView x:Name="webView" Source="{Binding Url}" Navigating="OnNavigating" InvokedFromJavaScript="OnInvokedFromJavaScript" />
+    <Grid>
+        <og:BridgeWebView x:Name="webView" Source="{Binding Url}" Navigating="OnNavigating" InvokedFromJavaScript="OnInvokedFromJavaScript" />
+        <Button StyleClass="Icon"
+                Text="&#xe6b5;"
+                FontSize="22"
+                WidthRequest="44"
+                HeightRequest="44"
+                MinimumWidthRequest="44"
+                MinimumHeightRequest="44"
+                Padding="0"
+                Margin="{OnPlatform Android='12,28,0,0', iOS='12,58,0,0', Default='12'}"
+                HorizontalOptions="Start"
+                VerticalOptions="Start"
+                BackgroundColor="#990B0F14"
+                TextColor="{StaticResource White}"
+                ZIndex="1"
+                IsVisible="{Binding IsGameRuntimeMode}"
+                AutomationProperties.Name="{x:Static og:Strings.Cancel}"
+                Clicked="OnGameRuntimeExitClicked" />
+    </Grid>
 </ContentPage>

--- a/OneGateApp/Pages/LaunchDAppPage.xaml.cs
+++ b/OneGateApp/Pages/LaunchDAppPage.xaml.cs
@@ -31,6 +31,8 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
     public required string Url { get; set { field = value; OnPropertyChanged(); } }
     public bool IsFavorite { get; set { field = value; OnPropertyChanged(); } }
     public bool IsDeveloperToolsEnabled { get; set { field = value; OnPropertyChanged(); } }
+    public bool IsGameRuntimeMode { get; set { field = value; OnPropertyChanged(); OnPropertyChanged(nameof(IsNavigationChromeVisible)); } }
+    public bool IsNavigationChromeVisible => !IsGameRuntimeMode;
 
     public LaunchDAppPage(IServiceProvider serviceProvider, ProtocolSettings protocolSettings, IWalletProvider walletProvider, WalletAuthorizationService walletAuthorizationService, ApplicationDbContext dbContext, HttpClient httpClient, RpcClient rpcClient, IHomeShortcutService homeShortcutService)
     {
@@ -49,6 +51,13 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
             ToolbarItems.Remove(addToHomeScreenButton);
         if (!IsDeveloperToolsEnabled)
             ToolbarItems.Remove(developerToolsButton);
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        if (DApp is not null)
+            ApplyRuntimeMode();
     }
 
     public async void ApplyQueryAttributes(IDictionary<string, object> query)
@@ -88,6 +97,7 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
                 Url = uri.AbsoluteUri;
             }
         }
+        ApplyRuntimeMode();
         if (DApp.Id > 0)
         {
             List<int>? favorites = await dbContext.Settings.GetAsync<List<int>>("dapps/favorite");
@@ -117,6 +127,19 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
         catch
         {
         }
+    }
+
+    async void OnGameRuntimeExitClicked(object sender, EventArgs e)
+    {
+        await this.GoBackOrCloseAsync();
+    }
+
+    void ApplyRuntimeMode()
+    {
+        IsGameRuntimeMode = DApp.IsGamingApp;
+        Shell.SetNavBarIsVisible(this, IsNavigationChromeVisible);
+        NavigationPage.SetHasNavigationBar(this, IsNavigationChromeVisible);
+        SafeAreaEdges = IsGameRuntimeMode ? SafeAreaEdges.None : SafeAreaEdges.All;
     }
 
     async void OnNavigating(object sender, WebNavigatingEventArgs e)

--- a/OneGateApp/Pages/LaunchDAppPage.xaml.cs
+++ b/OneGateApp/Pages/LaunchDAppPage.xaml.cs
@@ -136,8 +136,7 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
 
     void ApplyRuntimeMode()
     {
-        IsGameRuntimeMode = DApp.IsGamingApp;
-        Shell.SetNavBarIsVisible(this, IsNavigationChromeVisible);
+        IsGameRuntimeMode = DApp?.IsGamingApp == true;
         NavigationPage.SetHasNavigationBar(this, IsNavigationChromeVisible);
         SafeAreaEdges = IsGameRuntimeMode ? SafeAreaEdges.None : SafeAreaEdges.All;
     }


### PR DESCRIPTION
## Summary

Adds a focused game runtime mode for dApps marked with `DApp.IsGamingApp`.

- Hides the app navigation chrome for game dApp launch pages.
- Handles both Shell navigation and the multi-window `NavigationPage` path used by dApp deep links.
- Lets the game WebView use the full launch page area while keeping a native close button available.

## Scope

This is intentionally limited to `LaunchDAppPage`.

It does not change the Gaming Hub, dApp details, trust bars, connected-app permissions, third-party dApp DOM/CSS, transaction history, or any OneGate-brand visual system work. This follows the roadmap in #76 and avoids areas previously rejected in review.

## Validation

- `git diff --check`
- Android build:
  - `dotnet build OneGateApp/OneGateApp.csproj -f net10.0-android -r android-arm64 -p:AndroidSdkDirectory=/opt/homebrew/share/android-commandlinetools -p:JavaSdkDirectory=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home -p:EmbedAssembliesIntoApk=true`
  - Result: passed; only existing SQLitePCLRaw NU1903 warnings.
- Android emulator E2E:
  - Installed `org.neoorder.onegate-Signed.apk` on `emulator-5554`.
  - Opened `https://onegate.space/app/25` through `DocumentLinkActivity`.
  - Verified game launch page no longer exposes `navigationlayout_appbar` in UI tree.
  - Opened regular dApp `https://onegate.space/app/1` and verified `navigationlayout_appbar` remains present.
- iOS simulator build:
  - `DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer MD_APPLE_SDK_ROOT=/Applications/Xcode-26.5.0.app dotnet build OneGateApp/OneGateApp.csproj -f net10.0-ios -r iossimulator-arm64 -p:BuildIpa=false -p:EnableCodeSigning=true -p:CodesignKey=-`
  - Result: passed; only existing SQLitePCLRaw NU1903 warnings.
- iOS simulator install/launch:
  - Installed and launched on `OneGate-PR51-iPhone17`.
  - Local `simctl openurl https://onegate.space/app/25` still routes through Safari because the local debug build does not complete the associated-domain handoff in this environment.
  - XcodeBuildMCP UI snapshot/tap is blocked because `xcode-select -p` points to `/Library/Developer/CommandLineTools`; I did not change the system-wide Xcode selection.

## Draft status

Keeping this PR as draft until the iOS app-internal game runtime flow is manually verified or the simulator automation environment is corrected.
