### PR TITLE
[codex] Add game runtime lifecycle controls

### DIFF
--- a/OneGateApp/Controls/Handlers/BridgeWebViewHandler.Android.cs
+++ b/OneGateApp/Controls/Handlers/BridgeWebViewHandler.Android.cs
@@ -9,6 +9,8 @@ namespace NeoOrder.OneGate.Controls.Handlers;
 
 partial class BridgeWebViewHandler
 {
+    string? installedDocumentStartScript;
+
     class ScriptHandler(Action<string> onMessage, Func<string, string> onSyncMessage) : Java.Lang.Object
     {
         [JavascriptInterface]
@@ -37,7 +39,6 @@ partial class BridgeWebViewHandler
         platformView.Settings.DomStorageEnabled = true;
         platformView.Settings.JavaScriptEnabled = true;
         platformView.AddJavascriptInterface(new ScriptHandler(BridgeWebView.OnMessage, BridgeWebView.OnSyncMessage), "__OneGateBridge");
-        AddDocumentStartScript(platformView);
     }
 
     static void MapDocumentStartScript(IWebViewHandler handler, IWebView webView)
@@ -53,7 +54,11 @@ partial class BridgeWebViewHandler
             string script = Views.BridgeWebView.CreateRpcScript();
             if (!string.IsNullOrWhiteSpace(BridgeWebView.DocumentStartScript))
                 script += BridgeWebView.DocumentStartScript;
+            if (script == installedDocumentStartScript)
+                return;
+
             WebViewCompat.AddDocumentStartJavaScript(platformView, script, ["*"]);
+            installedDocumentStartScript = script;
         }
     }
 }

--- a/OneGateApp/Controls/Handlers/BridgeWebViewHandler.Android.cs
+++ b/OneGateApp/Controls/Handlers/BridgeWebViewHandler.Android.cs
@@ -3,6 +3,7 @@
 using Android.Webkit;
 using AndroidX.WebKit;
 using Java.Interop;
+using Microsoft.Maui.Handlers;
 
 namespace NeoOrder.OneGate.Controls.Handlers;
 
@@ -25,12 +26,28 @@ partial class BridgeWebViewHandler
         }
     }
 
+    static partial void ConfigureMapper(PropertyMapper<IWebView, IWebViewHandler> mapper)
+    {
+        mapper.AppendToMapping(nameof(Views.BridgeWebView.DocumentStartScript), MapDocumentStartScript);
+    }
+
     protected override void ConnectHandler(Android.Webkit.WebView platformView)
     {
         base.ConnectHandler(platformView);
         platformView.Settings.DomStorageEnabled = true;
         platformView.Settings.JavaScriptEnabled = true;
         platformView.AddJavascriptInterface(new ScriptHandler(BridgeWebView.OnMessage, BridgeWebView.OnSyncMessage), "__OneGateBridge");
+        AddDocumentStartScript(platformView);
+    }
+
+    static void MapDocumentStartScript(IWebViewHandler handler, IWebView webView)
+    {
+        if (handler is BridgeWebViewHandler bridgeHandler && bridgeHandler.PlatformView is { } platformView)
+            bridgeHandler.AddDocumentStartScript(platformView);
+    }
+
+    void AddDocumentStartScript(Android.Webkit.WebView platformView)
+    {
         if (WebViewFeature.IsFeatureSupported(WebViewFeature.DocumentStartScript))
         {
             string script = Views.BridgeWebView.CreateRpcScript();

--- a/OneGateApp/Controls/Handlers/BridgeWebViewHandler.Windows.cs
+++ b/OneGateApp/Controls/Handlers/BridgeWebViewHandler.Windows.cs
@@ -1,6 +1,7 @@
 ﻿#if WINDOWS
 
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.Maui.Handlers;
 using Microsoft.Web.WebView2.Core;
 
 namespace NeoOrder.OneGate.Controls.Handlers;
@@ -8,6 +9,11 @@ namespace NeoOrder.OneGate.Controls.Handlers;
 partial class BridgeWebViewHandler
 {
     const string SyncPrompt = "__OneGateBridgeSync";
+
+    static partial void ConfigureMapper(PropertyMapper<IWebView, IWebViewHandler> mapper)
+    {
+        mapper.AppendToMapping(nameof(Views.BridgeWebView.DocumentStartScript), MapDocumentStartScript);
+    }
 
     protected override void ConnectHandler(WebView2 platformView)
     {
@@ -42,6 +48,15 @@ partial class BridgeWebViewHandler
         if (!string.IsNullOrWhiteSpace(BridgeWebView.DocumentStartScript))
             script += BridgeWebView.DocumentStartScript;
         await sender.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(script);
+    }
+
+    static async void MapDocumentStartScript(IWebViewHandler handler, IWebView webView)
+    {
+        if (handler is not BridgeWebViewHandler bridgeHandler)
+            return;
+
+        if (bridgeHandler.PlatformView?.CoreWebView2 is { } coreWebView2 && !string.IsNullOrWhiteSpace(bridgeHandler.BridgeWebView.DocumentStartScript))
+            await coreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(bridgeHandler.BridgeWebView.DocumentStartScript);
     }
 
     void CoreWebView2_WebMessageReceived(CoreWebView2 sender, CoreWebView2WebMessageReceivedEventArgs args)

--- a/OneGateApp/Controls/Handlers/BridgeWebViewHandler.Windows.cs
+++ b/OneGateApp/Controls/Handlers/BridgeWebViewHandler.Windows.cs
@@ -9,6 +9,7 @@ namespace NeoOrder.OneGate.Controls.Handlers;
 partial class BridgeWebViewHandler
 {
     const string SyncPrompt = "__OneGateBridgeSync";
+    string? installedDocumentStartScript;
 
     static partial void ConfigureMapper(PropertyMapper<IWebView, IWebViewHandler> mapper)
     {
@@ -48,6 +49,7 @@ partial class BridgeWebViewHandler
         if (!string.IsNullOrWhiteSpace(BridgeWebView.DocumentStartScript))
             script += BridgeWebView.DocumentStartScript;
         await sender.CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(script);
+        installedDocumentStartScript = BridgeWebView.DocumentStartScript;
     }
 
     static async void MapDocumentStartScript(IWebViewHandler handler, IWebView webView)
@@ -55,8 +57,19 @@ partial class BridgeWebViewHandler
         if (handler is not BridgeWebViewHandler bridgeHandler)
             return;
 
-        if (bridgeHandler.PlatformView?.CoreWebView2 is { } coreWebView2 && !string.IsNullOrWhiteSpace(bridgeHandler.BridgeWebView.DocumentStartScript))
-            await coreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(bridgeHandler.BridgeWebView.DocumentStartScript);
+        string? script = bridgeHandler.BridgeWebView.DocumentStartScript;
+        if (bridgeHandler.PlatformView?.CoreWebView2 is not { } coreWebView2 || string.IsNullOrWhiteSpace(script) || script == bridgeHandler.installedDocumentStartScript)
+            return;
+
+        try
+        {
+            await coreWebView2.AddScriptToExecuteOnDocumentCreatedAsync(script);
+            bridgeHandler.installedDocumentStartScript = script;
+        }
+        catch
+        {
+            // The WebView2 instance can shut down while MAUI is remapping properties.
+        }
     }
 
     void CoreWebView2_WebMessageReceived(CoreWebView2 sender, CoreWebView2WebMessageReceivedEventArgs args)

--- a/OneGateApp/Controls/Handlers/BridgeWebViewHandler.iOS.cs
+++ b/OneGateApp/Controls/Handlers/BridgeWebViewHandler.iOS.cs
@@ -22,6 +22,7 @@ partial class BridgeWebViewHandler
     }
 
     BridgeWebViewUIDelegate? uiDelegate;
+    string? installedDocumentStartScript;
 
     class BridgeWebViewUIDelegate : MauiWebViewUIDelegate
     {
@@ -81,8 +82,8 @@ partial class BridgeWebViewHandler
         if (handler is not BridgeWebViewHandler bridgeHandler)
             return;
 
-        if (bridgeHandler.PlatformView is WKWebView platformView && !string.IsNullOrWhiteSpace(bridgeHandler.BridgeWebView.DocumentStartScript))
-            platformView.Configuration.UserContentController.AddUserScript(CreateDocumentStartScript(bridgeHandler.BridgeWebView.DocumentStartScript));
+        if (bridgeHandler.PlatformView is WKWebView platformView)
+            bridgeHandler.AddDocumentStartScript(platformView.Configuration.UserContentController, bridgeHandler.BridgeWebView.DocumentStartScript);
     }
 
     protected override WKWebView CreatePlatformView()
@@ -100,8 +101,7 @@ partial class BridgeWebViewHandler
             };
             """;
         controller.AddUserScript(CreateDocumentStartScript(shim + Views.BridgeWebView.CreateRpcScript()));
-        if (!string.IsNullOrWhiteSpace(BridgeWebView.DocumentStartScript))
-            controller.AddUserScript(CreateDocumentStartScript(BridgeWebView.DocumentStartScript));
+        AddDocumentStartScript(controller, BridgeWebView.DocumentStartScript);
         controller.AddScriptMessageHandler(new ScriptHandler(BridgeWebView.OnMessage), "__OneGateBridge");
 #if MACCATALYST
         config.Preferences.ElementFullscreenEnabled = true;
@@ -113,6 +113,15 @@ partial class BridgeWebViewHandler
     static WKUserScript CreateDocumentStartScript(string script)
     {
         return new WKUserScript(new NSString(script), WKUserScriptInjectionTime.AtDocumentStart, true);
+    }
+
+    void AddDocumentStartScript(WKUserContentController controller, string? script)
+    {
+        if (string.IsNullOrWhiteSpace(script) || script == installedDocumentStartScript)
+            return;
+
+        controller.AddUserScript(CreateDocumentStartScript(script));
+        installedDocumentStartScript = script;
     }
 }
 #endif

--- a/OneGateApp/Controls/Handlers/BridgeWebViewHandler.iOS.cs
+++ b/OneGateApp/Controls/Handlers/BridgeWebViewHandler.iOS.cs
@@ -65,6 +65,7 @@ partial class BridgeWebViewHandler
     static partial void ConfigureMapper(PropertyMapper<IWebView, IWebViewHandler> mapper)
     {
         mapper[nameof(WKUIDelegate)] = MapBridgeWKUIDelegate;
+        mapper.AppendToMapping(nameof(Views.BridgeWebView.DocumentStartScript), MapDocumentStartScript);
     }
 
     static void MapBridgeWKUIDelegate(IWebViewHandler handler, IWebView webView)
@@ -73,6 +74,15 @@ partial class BridgeWebViewHandler
             return;
 
         bridgeHandler.PlatformView.UIDelegate = bridgeHandler.uiDelegate ??= new BridgeWebViewUIDelegate(bridgeHandler);
+    }
+
+    static void MapDocumentStartScript(IWebViewHandler handler, IWebView webView)
+    {
+        if (handler is not BridgeWebViewHandler bridgeHandler)
+            return;
+
+        if (bridgeHandler.PlatformView is WKWebView platformView && !string.IsNullOrWhiteSpace(bridgeHandler.BridgeWebView.DocumentStartScript))
+            platformView.Configuration.UserContentController.AddUserScript(CreateDocumentStartScript(bridgeHandler.BridgeWebView.DocumentStartScript));
     }
 
     protected override WKWebView CreatePlatformView()

--- a/OneGateApp/Pages/LaunchDAppPage.xaml.cs
+++ b/OneGateApp/Pages/LaunchDAppPage.xaml.cs
@@ -26,6 +26,7 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
     readonly HttpClient httpClient;
     readonly RpcServer rpcServer;
     readonly RpcClient rpcClient;
+    Window? lifecycleWindow;
 
     public required DApp DApp { get; set { field = value; OnPropertyChanged(); } }
     public required string Url { get; set { field = value; OnPropertyChanged(); } }
@@ -44,11 +45,27 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
         this.rpcClient = rpcClient;
         IsDeveloperToolsEnabled = dbContext.Settings.Get<bool>(DeveloperModeKey);
         InitializeComponent();
-        webView.DocumentStartScript = CreateDocumentStartScript();
+        ConfigureDocumentStartScript();
         if (!homeShortcutService.IsSupported)
             ToolbarItems.Remove(addToHomeScreenButton);
         if (!IsDeveloperToolsEnabled)
             ToolbarItems.Remove(developerToolsButton);
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        AttachGameRuntimeLifecycle();
+        EmitGameRuntimeEvent("runtimevisible", "page.appearing");
+        EmitGameRuntimeEvent("runtimeresume", "page.appearing");
+    }
+
+    protected override void OnDisappearing()
+    {
+        EmitGameRuntimeEvent("runtimepause", "page.disappearing");
+        EmitGameRuntimeEvent("runtimehidden", "page.disappearing");
+        DetachGameRuntimeLifecycle();
+        base.OnDisappearing();
     }
 
     public async void ApplyQueryAttributes(IDictionary<string, object> query)
@@ -56,6 +73,7 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
         if (query.TryGetValue("dapp", out var value))
         {
             DApp = (DApp)value;
+            ConfigureDocumentStartScript();
             Url = DApp.Url;
         }
         else
@@ -70,6 +88,7 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
                     return;
                 }
                 DApp = (await response.Content.ReadFromJsonAsync<DApp>())!;
+                ConfigureDocumentStartScript();
                 if (string.IsNullOrEmpty(uri.Query))
                     Url = DApp.Url;
                 else
@@ -85,6 +104,7 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
                     Url = uri.AbsoluteUri,
                     Languages = ["en"]
                 };
+                ConfigureDocumentStartScript();
                 Url = uri.AbsoluteUri;
             }
         }
@@ -116,6 +136,7 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
         }
         catch
         {
+            // The WebView may already be unloading during native lifecycle transitions.
         }
     }
 
@@ -136,9 +157,16 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
     string CreateDocumentStartScript()
     {
         string script = CreateDapiInjectionScript();
+        if (DApp is { IsGamingApp: true })
+            script += CreateGameRuntimeInjectionScript();
         if (IsDeveloperToolsEnabled)
             script += CreateDeveloperToolsInjectionScript();
         return script;
+    }
+
+    void ConfigureDocumentStartScript()
+    {
+        webView.DocumentStartScript = CreateDocumentStartScript();
     }
 
     string CreateDapiInjectionScript()
@@ -164,7 +192,13 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
             
                 const listeners = {
                     accountchanged: new Set(),
-                    networkchanged: new Set()
+                    networkchanged: new Set(),
+                    runtimehidden: new Set(),
+                    runtimepause: new Set(),
+                    runtimeresume: new Set(),
+                    runtimevisible: new Set(),
+                    webglcontextlost: new Set(),
+                    webglcontextrestored: new Set()
                 };
 
                 const methods = ["authenticate", "getAccounts", "pickAddress", "getBalance", "send", "call", "invoke", "makeTransaction", "sign", "signMessage", "relay", "getBlock", "getBlockCount", "getTransaction", "getApplicationLog", "getStorage", "getTokenInfo"];
@@ -213,6 +247,100 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
                 dispatchReady();
 
                 window.addEventListener('Neo.DapiProvider.request', dispatchReady);
+            })();
+            """.ReplaceLineEndings("");
+    }
+
+    static string CreateGameRuntimeInjectionScript()
+    {
+        return """
+            (function () {
+                if (window.__OneGateGameRuntimeInjected) return;
+                window.__OneGateGameRuntimeInjected = true;
+
+                function createDetail(reason) {
+                    return {
+                        reason: reason,
+                        visibilityState: document.visibilityState || "visible",
+                        timestamp: Date.now()
+                    };
+                }
+
+                function emit(eventName, detail) {
+                    detail = detail || createDetail("runtime");
+                    const provider = window.OneGateDapiProvider;
+                    if (provider && typeof provider.__emit === "function")
+                        provider.__emit(eventName, detail);
+                    window.dispatchEvent(new CustomEvent("OneGate.GameRuntime." + eventName, { detail: detail }));
+                }
+
+                function describeCanvas(canvas) {
+                    if (!canvas)
+                        return {};
+
+                    return {
+                        id: canvas.id || "",
+                        width: canvas.width || 0,
+                        height: canvas.height || 0,
+                        clientWidth: canvas.clientWidth || 0,
+                        clientHeight: canvas.clientHeight || 0
+                    };
+                }
+
+                function handleVisibilityChange() {
+                    if (document.hidden) {
+                        emit("runtimepause", createDetail("document.visibilitychange"));
+                        emit("runtimehidden", createDetail("document.visibilitychange"));
+                    } else {
+                        emit("runtimevisible", createDetail("document.visibilitychange"));
+                        emit("runtimeresume", createDetail("document.visibilitychange"));
+                    }
+                }
+
+                document.addEventListener("visibilitychange", handleVisibilityChange, true);
+                window.addEventListener("pagehide", function() {
+                    emit("runtimepause", createDetail("pagehide"));
+                    emit("runtimehidden", createDetail("pagehide"));
+                }, true);
+                window.addEventListener("pageshow", function() {
+                    emit("runtimevisible", createDetail("pageshow"));
+                    emit("runtimeresume", createDetail("pageshow"));
+                }, true);
+                window.addEventListener("blur", function() {
+                    emit("runtimepause", createDetail("window.blur"));
+                }, true);
+                window.addEventListener("focus", function() {
+                    emit("runtimeresume", createDetail("window.focus"));
+                }, true);
+
+                document.addEventListener("webglcontextlost", function(event) {
+                    emit("webglcontextlost", {
+                        reason: "webglcontextlost",
+                        statusMessage: event.statusMessage || "",
+                        canvas: describeCanvas(event.target),
+                        timestamp: Date.now()
+                    });
+                }, true);
+                document.addEventListener("webglcontextrestored", function(event) {
+                    emit("webglcontextrestored", {
+                        reason: "webglcontextrestored",
+                        canvas: describeCanvas(event.target),
+                        timestamp: Date.now()
+                    });
+                }, true);
+
+                window.OneGateGameRuntime = Object.freeze({
+                    version: 1,
+                    reload: function() {
+                        window.location.reload();
+                    },
+                    on: function(eventName, listener) {
+                        window.OneGateDapiProvider.on(eventName, listener);
+                    },
+                    removeListener: function(eventName, listener) {
+                        window.OneGateDapiProvider.removeListener(eventName, listener);
+                    }
+                });
             })();
             """.ReplaceLineEndings("");
     }
@@ -568,6 +696,68 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
     {
         var response = await rpcServer.HandleRequestAsync(request);
         await webView.SendRpcRepsonseAsync(response);
+    }
+
+    void AttachGameRuntimeLifecycle()
+    {
+        if (DApp is not { IsGamingApp: true }) return;
+        if (lifecycleWindow == Window) return;
+        DetachGameRuntimeLifecycle();
+        if (Window is null) return;
+        lifecycleWindow = Window;
+        lifecycleWindow.Activated += OnRuntimeWindowActivated;
+        lifecycleWindow.Deactivated += OnRuntimeWindowDeactivated;
+        lifecycleWindow.Resumed += OnRuntimeWindowResumed;
+        lifecycleWindow.Stopped += OnRuntimeWindowStopped;
+    }
+
+    void DetachGameRuntimeLifecycle()
+    {
+        if (lifecycleWindow is null) return;
+        lifecycleWindow.Activated -= OnRuntimeWindowActivated;
+        lifecycleWindow.Deactivated -= OnRuntimeWindowDeactivated;
+        lifecycleWindow.Resumed -= OnRuntimeWindowResumed;
+        lifecycleWindow.Stopped -= OnRuntimeWindowStopped;
+        lifecycleWindow = null;
+    }
+
+    void OnRuntimeWindowActivated(object? sender, EventArgs e)
+    {
+        EmitGameRuntimeEvent("runtimevisible", "window.activated");
+        EmitGameRuntimeEvent("runtimeresume", "window.activated");
+    }
+
+    void OnRuntimeWindowDeactivated(object? sender, EventArgs e)
+    {
+        EmitGameRuntimeEvent("runtimepause", "window.deactivated");
+    }
+
+    void OnRuntimeWindowResumed(object? sender, EventArgs e)
+    {
+        EmitGameRuntimeEvent("runtimevisible", "window.resumed");
+        EmitGameRuntimeEvent("runtimeresume", "window.resumed");
+    }
+
+    void OnRuntimeWindowStopped(object? sender, EventArgs e)
+    {
+        EmitGameRuntimeEvent("runtimepause", "window.stopped");
+        EmitGameRuntimeEvent("runtimehidden", "window.stopped");
+    }
+
+    async void EmitGameRuntimeEvent(string eventName, string reason)
+    {
+        if (DApp is not { IsGamingApp: true }) return;
+        try
+        {
+            await EmitEventAsync(eventName, new()
+            {
+                ["reason"] = reason,
+                ["timestamp"] = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()
+            });
+        }
+        catch
+        {
+        }
     }
 
     async Task EmitEventAsync(string eventName, JsonObject? detial)

--- a/OneGateApp/Pages/LaunchDAppPage.xaml.cs
+++ b/OneGateApp/Pages/LaunchDAppPage.xaml.cs
@@ -45,7 +45,6 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
         this.rpcClient = rpcClient;
         IsDeveloperToolsEnabled = dbContext.Settings.Get<bool>(DeveloperModeKey);
         InitializeComponent();
-        ConfigureDocumentStartScript();
         if (!homeShortcutService.IsSupported)
             ToolbarItems.Remove(addToHomeScreenButton);
         if (!IsDeveloperToolsEnabled)
@@ -314,6 +313,7 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
                 }, true);
 
                 document.addEventListener("webglcontextlost", function(event) {
+                    event.preventDefault();
                     emit("webglcontextlost", {
                         reason: "webglcontextlost",
                         statusMessage: event.statusMessage || "",
@@ -757,6 +757,7 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
         }
         catch
         {
+            // Native lifecycle callbacks can race with WebView navigation or teardown.
         }
     }
 


### PR DESCRIPTION
## Summary

Adds focused Game Runtime Lifecycle Controls from #76.

- Exposes `window.OneGateGameRuntime` only for dApps marked as games.
- Emits lifecycle events through both `OneGateDapiProvider.on(...)` and DOM `OneGate.GameRuntime.*` events.
- Reports `runtimepause`, `runtimehidden`, `runtimevisible`, `runtimeresume`, `webglcontextlost`, and `webglcontextrestored`.
- Adds `OneGateGameRuntime.reload()` as a lightweight recovery helper for games.
- Registers updated `DocumentStartScript` values in the WebView handlers so game runtime scripts are available after dApp metadata is loaded.

## Scope

This intentionally stays limited to the runtime/bridge layer and `LaunchDAppPage`.

It does not change the Gaming Hub, dApp details, trust bars, connected-app permissions, transaction history, third-party dApp DOM/CSS, or any dashboard/design-system surfaces. It also does not add a persistent runtime bar or local transaction storage, following the guardrails in #76.

## Validation

- `git diff --check`
- Android build:
  - `dotnet build OneGateApp/OneGateApp.csproj -f net10.0-android -r android-arm64 -p:AndroidSdkDirectory=/opt/homebrew/share/android-commandlinetools -p:JavaSdkDirectory=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home -p:EmbedAssembliesIntoApk=true`
  - Result: passed; only existing SQLitePCLRaw NU1903 warnings.
- Android emulator E2E on `emulator-5554`:
  - Installed `org.neoorder.onegate-Signed.apk`.
  - Opened `https://onegate.space/app/25` through `DocumentLinkActivity`.
  - Verified via WebView CDP on `https://smb.monad.game/`:
    - `typeof window.OneGateGameRuntime === "object"`
    - `OneGateGameRuntime.version === 1`
    - `reload`, `on`, and `removeListener` are functions.
    - Provider listener receives `runtimepause`.
    - DOM listener receives `OneGate.GameRuntime.webglcontextlost`.
  - Backgrounded and restored the same document task; verified the same WebView receives `runtimepause/runtimehidden` and `runtimevisible/runtimeresume` via provider and DOM listeners.
  - Opened regular dApp `https://onegate.space/app/1`; verified `OneGateDapiProvider` remains available and `OneGateGameRuntime` is `undefined`.
- iOS simulator build:
  - `DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer MD_APPLE_SDK_ROOT=/Applications/Xcode-26.5.0.app dotnet restore OneGateApp/OneGateApp.csproj -p:TargetFramework=net10.0-ios -p:RuntimeIdentifier=iossimulator-arm64`
  - `DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer MD_APPLE_SDK_ROOT=/Applications/Xcode-26.5.0.app dotnet build OneGateApp/OneGateApp.csproj -f net10.0-ios -r iossimulator-arm64 --no-restore -p:BuildIpa=false -p:EnableCodeSigning=true -p:CodesignKey=-`
  - Result: passed; only existing SQLitePCLRaw NU1903 warning.
- iOS simulator install/launch:
  - Installed and launched on `OneGate-PR51-iPhone17`.
  - Local `simctl openurl https://onegate.space/app/25` still routes to Safari/web details instead of the local debug OneGate WebView, matching the existing local associated-domain limitation seen in #77.

## Draft status

Keeping this PR as draft until the iOS app-internal game WebView flow can be verified manually or the simulator automation/associated-domain environment is corrected.