### PR TITLE
[codex] Add game manifest contract

### DIFF
--- a/OneGateApp/Data/CacheDbContext.cs
+++ b/OneGateApp/Data/CacheDbContext.cs
@@ -13,6 +13,7 @@ public partial class CacheDbContext(DbContextOptions<CacheDbContext> options) : 
     internal async Task EnsureMigrationsAsync()
     {
         await Migration_AddProperty_DApps_Warnings_20260622();
+        await Migration_AddProperty_DApps_GameManifestUrl_20260702();
     }
 
     async Task Migration_AddProperty_DApps_Warnings_20260622()
@@ -29,6 +30,22 @@ public partial class CacheDbContext(DbContextOptions<CacheDbContext> options) : 
 
         if (!actualColumns.Contains(nameof(DApp.Warnings)))
             await Database.ExecuteSqlRawAsync("ALTER TABLE [DApps] ADD COLUMN [Warnings] INTEGER NOT NULL DEFAULT 0");
+    }
+
+    async Task Migration_AddProperty_DApps_GameManifestUrl_20260702()
+    {
+        HashSet<string> actualColumns = new(StringComparer.OrdinalIgnoreCase);
+        await Database.OpenConnectionAsync();
+        await using (var command = Database.GetDbConnection().CreateCommand())
+        {
+            command.CommandText = "SELECT [name] FROM pragma_table_info('DApps')";
+            await using var reader = await command.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+                actualColumns.Add(reader.GetString(0));
+        }
+
+        if (!actualColumns.Contains(nameof(DApp.GameManifestUrl)))
+            await Database.ExecuteSqlRawAsync("ALTER TABLE [DApps] ADD COLUMN [GameManifestUrl] TEXT NULL");
     }
 }
 

--- a/OneGateApp/Data/CacheDbContext.cs
+++ b/OneGateApp/Data/CacheDbContext.cs
@@ -20,32 +20,46 @@ public partial class CacheDbContext(DbContextOptions<CacheDbContext> options) : 
     {
         HashSet<string> actualColumns = new(StringComparer.OrdinalIgnoreCase);
         await Database.OpenConnectionAsync();
-        await using (var command = Database.GetDbConnection().CreateCommand())
+        try
         {
-            command.CommandText = "SELECT [name] FROM pragma_table_info('DApps')";
-            await using var reader = await command.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
-                actualColumns.Add(reader.GetString(0));
-        }
+            await using (var command = Database.GetDbConnection().CreateCommand())
+            {
+                command.CommandText = "SELECT [name] FROM pragma_table_info('DApps')";
+                await using var reader = await command.ExecuteReaderAsync();
+                while (await reader.ReadAsync())
+                    actualColumns.Add(reader.GetString(0));
+            }
 
-        if (!actualColumns.Contains(nameof(DApp.Warnings)))
-            await Database.ExecuteSqlRawAsync("ALTER TABLE [DApps] ADD COLUMN [Warnings] INTEGER NOT NULL DEFAULT 0");
+            if (!actualColumns.Contains(nameof(DApp.Warnings)))
+                await Database.ExecuteSqlRawAsync("ALTER TABLE [DApps] ADD COLUMN [Warnings] INTEGER NOT NULL DEFAULT 0");
+        }
+        finally
+        {
+            await Database.CloseConnectionAsync();
+        }
     }
 
     async Task Migration_AddProperty_DApps_GameManifestUrl_20260702()
     {
         HashSet<string> actualColumns = new(StringComparer.OrdinalIgnoreCase);
         await Database.OpenConnectionAsync();
-        await using (var command = Database.GetDbConnection().CreateCommand())
+        try
         {
-            command.CommandText = "SELECT [name] FROM pragma_table_info('DApps')";
-            await using var reader = await command.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
-                actualColumns.Add(reader.GetString(0));
-        }
+            await using (var command = Database.GetDbConnection().CreateCommand())
+            {
+                command.CommandText = "SELECT [name] FROM pragma_table_info('DApps')";
+                await using var reader = await command.ExecuteReaderAsync();
+                while (await reader.ReadAsync())
+                    actualColumns.Add(reader.GetString(0));
+            }
 
-        if (!actualColumns.Contains(nameof(DApp.GameManifestUrl)))
-            await Database.ExecuteSqlRawAsync("ALTER TABLE [DApps] ADD COLUMN [GameManifestUrl] TEXT NULL");
+            if (!actualColumns.Contains(nameof(DApp.GameManifestUrl)))
+                await Database.ExecuteSqlRawAsync("ALTER TABLE [DApps] ADD COLUMN [GameManifestUrl] TEXT NULL");
+        }
+        finally
+        {
+            await Database.CloseConnectionAsync();
+        }
     }
 }
 

--- a/OneGateApp/Data/DApp.cs
+++ b/OneGateApp/Data/DApp.cs
@@ -20,6 +20,8 @@ public class DApp : IComparable<DApp>, IShareable, IVersioned
     public string[]? Tags { get; set; }
     [MaxLength(16)]
     public string? GameType { get; set; }
+    [Url]
+    public string? GameManifestUrl { get; set; }
     public required string[] Languages { get; set; }
     [MaxLength(32)]
     public string? Developer { get; set; }
@@ -32,6 +34,7 @@ public class DApp : IComparable<DApp>, IShareable, IVersioned
 
     public bool IsGamingApp => !string.IsNullOrWhiteSpace(GameType);
     public bool IsRegularApp => !IsGamingApp;
+    public bool HasGameManifest => IsGamingApp && !string.IsNullOrWhiteSpace(GameManifestUrl);
     public string? GameTypeDisplayName => LocalizeGameType(GameType);
     public Dictionary<string, string> NameLocalizer => field ??= JsonSerializer.Deserialize<Dictionary<string, string>>(Name)!;
     public Dictionary<string, string>? DescriptionLocalizer => Description is null ? null : field ??= JsonSerializer.Deserialize<Dictionary<string, string>>(Description);

--- a/OneGateApp/MauiProgram.cs
+++ b/OneGateApp/MauiProgram.cs
@@ -111,6 +111,7 @@ public static class MauiProgram
         builder.Services.AddSingleton<TokenManager>();
         builder.Services.AddSingleton<RpcClient>();
         builder.Services.AddSingleton<UpdateService>();
+        builder.Services.AddSingleton<GameManifestService>();
         builder.Services.AddSingleton<IHomeShortcutService, HomeShortcutService>();
         return builder;
     }

--- a/OneGateApp/Models/GameManifest.cs
+++ b/OneGateApp/Models/GameManifest.cs
@@ -1,0 +1,53 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NeoOrder.OneGate.Models;
+
+public enum GamePreferredOrientation
+{
+    Any,
+    Portrait,
+    Landscape
+}
+
+public enum GameInputMethod
+{
+    Touch,
+    Pointer,
+    Keyboard,
+    Gamepad
+}
+
+public sealed class GameAssetBudget
+{
+    public long? InitialBytes { get; init; }
+    public long? TotalFirstLoadBytes { get; init; }
+    public long? JsWasmBytes { get; init; }
+    public long? TextureBytes { get; init; }
+    public long? AudioBytes { get; init; }
+}
+
+public sealed class GameManifest
+{
+    public const int CurrentSchemaVersion = 1;
+
+    public static readonly JsonSerializerOptions JsonSerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        Converters =
+        {
+            new JsonStringEnumConverter(JsonNamingPolicy.CamelCase)
+        }
+    };
+
+    public int SchemaVersion { get; init; } = CurrentSchemaVersion;
+    public string? GameType { get; init; }
+    public GamePreferredOrientation PreferredOrientation { get; init; }
+    public bool FullscreenPreferred { get; init; }
+    public GameAssetBudget? AssetBudget { get; init; }
+    public IReadOnlyList<string> RequiredOneGateApis { get; init; } = [];
+    public IReadOnlyList<GameInputMethod> SupportedInputMethods { get; init; } = [];
+    public string? Version { get; init; }
+    public string? PackageHash { get; init; }
+
+    public bool IsSupportedSchemaVersion => SchemaVersion == CurrentSchemaVersion;
+}

--- a/OneGateApp/Pages/LaunchDAppPage.xaml.cs
+++ b/OneGateApp/Pages/LaunchDAppPage.xaml.cs
@@ -4,12 +4,14 @@ using Neo.Wallets;
 using NeoOrder.OneGate.Controls;
 using NeoOrder.OneGate.Controls.Views;
 using NeoOrder.OneGate.Data;
+using NeoOrder.OneGate.Models;
 using NeoOrder.OneGate.Models.AppLinks;
 using NeoOrder.OneGate.Properties;
 using NeoOrder.OneGate.Services;
 using NeoOrder.OneGate.Services.RPC;
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace NeoOrder.OneGate.Pages;
@@ -26,13 +28,15 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
     readonly HttpClient httpClient;
     readonly RpcServer rpcServer;
     readonly RpcClient rpcClient;
+    readonly GameManifestService gameManifestService;
 
     public required DApp DApp { get; set { field = value; OnPropertyChanged(); } }
     public required string Url { get; set { field = value; OnPropertyChanged(); } }
+    public GameManifest? GameManifest { get; private set { field = value; OnPropertyChanged(); } }
     public bool IsFavorite { get; set { field = value; OnPropertyChanged(); } }
     public bool IsDeveloperToolsEnabled { get; set { field = value; OnPropertyChanged(); } }
 
-    public LaunchDAppPage(IServiceProvider serviceProvider, ProtocolSettings protocolSettings, IWalletProvider walletProvider, WalletAuthorizationService walletAuthorizationService, ApplicationDbContext dbContext, HttpClient httpClient, RpcClient rpcClient, IHomeShortcutService homeShortcutService)
+    public LaunchDAppPage(IServiceProvider serviceProvider, ProtocolSettings protocolSettings, IWalletProvider walletProvider, WalletAuthorizationService walletAuthorizationService, ApplicationDbContext dbContext, HttpClient httpClient, RpcClient rpcClient, GameManifestService gameManifestService, IHomeShortcutService homeShortcutService)
     {
         this.serviceProvider = serviceProvider;
         this.protocolSettings = protocolSettings;
@@ -42,9 +46,9 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
         this.httpClient = httpClient;
         this.rpcServer = new(this);
         this.rpcClient = rpcClient;
+        this.gameManifestService = gameManifestService;
         IsDeveloperToolsEnabled = dbContext.Settings.Get<bool>(DeveloperModeKey);
         InitializeComponent();
-        webView.DocumentStartScript = CreateDocumentStartScript();
         if (!homeShortcutService.IsSupported)
             ToolbarItems.Remove(addToHomeScreenButton);
         if (!IsDeveloperToolsEnabled)
@@ -55,7 +59,7 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
     {
         if (query.TryGetValue("dapp", out var value))
         {
-            DApp = (DApp)value;
+            await ConfigureDAppAsync((DApp)value);
             Url = DApp.Url;
         }
         else
@@ -69,7 +73,7 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
                     await this.GoBackOrCloseAsync();
                     return;
                 }
-                DApp = (await response.Content.ReadFromJsonAsync<DApp>())!;
+                await ConfigureDAppAsync((await response.Content.ReadFromJsonAsync<DApp>())!);
                 if (string.IsNullOrEmpty(uri.Query))
                     Url = DApp.Url;
                 else
@@ -77,14 +81,14 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
             }
             else
             {
-                DApp = new DApp
+                await ConfigureDAppAsync(new DApp
                 {
                     Id = 0,
                     IsActive = false,
                     Name = $"{{\"en\":\"{uri.Host}\"}}",
                     Url = uri.AbsoluteUri,
                     Languages = ["en"]
-                };
+                });
                 Url = uri.AbsoluteUri;
             }
         }
@@ -100,6 +104,13 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
             await dbContext.Settings.PutAsync("dapps/recent", recents);
             if (DApp.IsRegularApp) GlobalStates.Invalidate<DAppsPage>();
         }
+    }
+
+    async Task ConfigureDAppAsync(DApp dapp)
+    {
+        DApp = dapp;
+        GameManifest = await gameManifestService.LoadAsync(dapp);
+        webView.DocumentStartScript = CreateDocumentStartScript();
     }
 
     void OnFavoriteClicked(object sender, EventArgs e)
@@ -178,6 +189,7 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
                     network: {{protocolSettings.Network}},
                     supportedNetworks: [{{protocolSettings.Network}}],
                     icon: 'https://{{SharedOptions.OneGateDomain}}/images/logo.png',
+                    gameManifest: deepFreeze({{JsonSerializer.Serialize(GameManifest, NeoOrder.OneGate.Models.GameManifest.JsonSerializerOptions)}}),
                     website: 'https://{{SharedOptions.OneGateDomain}}',
                     extra: {},
 

--- a/OneGateApp/Services/GameManifestService.cs
+++ b/OneGateApp/Services/GameManifestService.cs
@@ -1,0 +1,38 @@
+using NeoOrder.OneGate.Data;
+using NeoOrder.OneGate.Models;
+using System.Text.Json;
+
+namespace NeoOrder.OneGate.Services;
+
+public sealed class GameManifestService(HttpClient httpClient)
+{
+    const int MaxManifestBytes = 64 * 1024;
+
+    public async Task<GameManifest?> LoadAsync(DApp dapp, CancellationToken cancellationToken = default)
+    {
+        if (!dapp.IsGamingApp || string.IsNullOrWhiteSpace(dapp.GameManifestUrl))
+            return null;
+        if (!Uri.TryCreate(dapp.GameManifestUrl, UriKind.Absolute, out var uri) || uri.Scheme != Uri.UriSchemeHttps)
+            return null;
+
+        try
+        {
+            using var response = await httpClient.GetAsync(uri, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+                return null;
+            if (response.Content.Headers.ContentLength > MaxManifestBytes)
+                return null;
+
+            byte[] content = await response.Content.ReadAsByteArrayAsync(cancellationToken);
+            if (content.Length > MaxManifestBytes)
+                return null;
+
+            var manifest = JsonSerializer.Deserialize<GameManifest>(content, GameManifest.JsonSerializerOptions);
+            return manifest?.IsSupportedSchemaVersion == true ? manifest : null;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or JsonException or NotSupportedException or TaskCanceledException or ArgumentException or InvalidOperationException)
+        {
+            return null;
+        }
+    }
+}

--- a/OneGateApp/Services/GameManifestService.cs
+++ b/OneGateApp/Services/GameManifestService.cs
@@ -17,17 +17,28 @@ public sealed class GameManifestService(HttpClient httpClient)
 
         try
         {
-            using var response = await httpClient.GetAsync(uri, cancellationToken);
+            using var response = await httpClient.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
             if (!response.IsSuccessStatusCode)
                 return null;
             if (response.Content.Headers.ContentLength > MaxManifestBytes)
                 return null;
 
-            byte[] content = await response.Content.ReadAsByteArrayAsync(cancellationToken);
-            if (content.Length > MaxManifestBytes)
-                return null;
+            await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+            using var content = new MemoryStream();
+            byte[] buffer = new byte[8192];
+            int totalBytesRead = 0;
+            int bytesRead;
+            while ((bytesRead = await contentStream.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken)) > 0)
+            {
+                totalBytesRead += bytesRead;
+                if (totalBytesRead > MaxManifestBytes)
+                    return null;
 
-            var manifest = JsonSerializer.Deserialize<GameManifest>(content, GameManifest.JsonSerializerOptions);
+                content.Write(buffer, 0, bytesRead);
+            }
+
+            content.Position = 0;
+            var manifest = await JsonSerializer.DeserializeAsync<GameManifest>(content, GameManifest.JsonSerializerOptions, cancellationToken);
             return manifest?.IsSupportedSchemaVersion == true ? manifest : null;
         }
         catch (Exception ex) when (ex is HttpRequestException or JsonException or NotSupportedException or TaskCanceledException or ArgumentException or InvalidOperationException)


### PR DESCRIPTION
## Summary
- Add a versioned game manifest model for GameFi dApps to declare orientation, fullscreen preference, supported input methods, OneGate API requirements, and asset budgets.
- Add optional HTTPS-only manifest loading for gaming dApps with a 64 KB payload cap and schema-version guard.
- Expose the loaded manifest to dApps through the existing document-start OneGate provider as a frozen `gameManifest` object.

## Scope
Part of #76, Task 4: Game Manifest and Capability Contract.

This intentionally does not add hub UI, a permission center, third-party dApp DOM adaptation, or runtime policy decisions. It only establishes the host/catalog contract that later focused PRs can consume.

## Validation
- `dotnet run --project /tmp/onegate-game-manifest-harness/onegate-game-manifest-harness.csproj`
- `dotnet build OneGateApp/OneGateApp.csproj -f net10.0-ios -c Debug -p:RuntimeIdentifier=iossimulator-arm64 -p:CodesignKey=- -p:CodesignProvision= -p:ProvisioningType=automatic --nologo`
- `dotnet build OneGateApp/OneGateApp.csproj -f net10.0-android -c Debug -p:EmbedAssembliesIntoApk=true --nologo`
- iOS simulator install/launch/screenshot on OneGate-PR51-iPhone17.
- Android emulator install/launch/screenshot on emulator-5554; `MainActivity` resumed and logcat showed no fatal crash.

## Notes
Build warnings are existing repository warnings: SQLitePCLRaw NU1903 advisories and the local Android JDK path validation warning.
