### PR TITLE
[codex] Add OneGate Game SDK package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,6 +198,11 @@ PublishScripts/
 *.snupkg
 # The packages folder can be ignored because of Package Restore
 **/[Pp]ackages/*
+
+# Node SDK artifacts
+node_modules/
+sdk/**/dist/
+sdk/**/*.tsbuildinfo
 # except build/, which is used as an MSBuild target.
 !**/[Pp]ackages/build/
 # Uncomment if necessary however generally it will be regenerated when needed

--- a/sdk/onegate-game-sdk/README.md
+++ b/sdk/onegate-game-sdk/README.md
@@ -1,0 +1,98 @@
+# OneGate Game SDK
+
+Small TypeScript helpers for GameFi dApps running inside OneGate.
+
+The SDK is a thin wrapper over OneGate's injected dAPI provider and optional
+native game capabilities. It does not create new wallet authorization semantics:
+`authenticate` remains an explicit website authentication call, and wallet
+signing or sending still goes through the existing OneGate confirmation flows.
+
+## Install
+
+This package is currently kept in the OneGate repository as source. A game can
+copy it into a workspace or consume it after the package is published.
+
+```bash
+npm install @onegate/game-sdk
+```
+
+## Basic usage
+
+```ts
+import { createOneGateGameClient } from "@onegate/game-sdk";
+
+const onegate = await createOneGateGameClient();
+const accounts = await onegate.getAccounts();
+
+if (onegate.hasCapability("pickAddress")) {
+  const address = await onegate.pickAddress("Choose a payout address");
+  console.log(address);
+}
+```
+
+## Wallet authentication
+
+Do not call `authenticate` on page load. Use it only when the player chooses an
+action that needs website authentication.
+
+```ts
+const response = await onegate.authenticate({
+  domain: location.host,
+  nonce: crypto.randomUUID(),
+  issuedAt: new Date().toISOString()
+});
+```
+
+## Optional native capabilities
+
+The SDK treats these capabilities as optional because they may land in different
+OneGate app versions:
+
+- `pickAddress`
+- `scanQRCode`
+- `pickAsset`
+- `share`
+
+Use `hasCapability` before showing UI that depends on one of them.
+
+```ts
+if (onegate.hasCapability("share")) {
+  await onegate.share({
+    title: "My OneGate run",
+    text: "I just cleared this stage.",
+    uri: location.href
+  });
+}
+```
+
+## Game runtime events
+
+Game runtime lifecycle events can be handled through the client. The returned
+function removes the listener.
+
+```ts
+const dispose = onegate.onRuntimeEvent("runtimepause", () => {
+  pauseGameLoop();
+});
+
+dispose();
+```
+
+## Orientation
+
+Games should still be responsive and mobile-first. Orientation locking is only a
+runtime hint and can fail on some platforms.
+
+```ts
+import { lockOrientation } from "@onegate/game-sdk";
+
+await lockOrientation("landscape");
+```
+
+## Development principles
+
+- Feature-detect optional OneGate capabilities.
+- Keep wallet requests tied to user intent.
+- Keep loading, progress, and error states inside the game.
+- Do not depend on OneGate adapting a third-party game's DOM or CSS.
+- Do not store private keys, seed phrases, or signing payloads in game storage.

--- a/sdk/onegate-game-sdk/README.md
+++ b/sdk/onegate-game-sdk/README.md
@@ -86,7 +86,10 @@ runtime hint and can fail on some platforms.
 ```ts
 import { lockOrientation } from "@onegate/game-sdk";
 
-await lockOrientation("landscape");
+const orientationLocked = await lockOrientation("landscape");
+if (!orientationLocked) {
+  // Keep the responsive layout active when the host cannot lock orientation.
+}
 ```
 
 ## Development principles

--- a/sdk/onegate-game-sdk/package-lock.json
+++ b/sdk/onegate-game-sdk/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "@onegate/game-sdk",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@onegate/game-sdk",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "5.9.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/sdk/onegate-game-sdk/package.json
+++ b/sdk/onegate-game-sdk/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@onegate/game-sdk",
+  "version": "0.1.0",
+  "description": "TypeScript helpers for GameFi dApps running inside OneGate.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "devDependencies": {
+    "typescript": "5.9.3"
+  }
+}

--- a/sdk/onegate-game-sdk/src/index.ts
+++ b/sdk/onegate-game-sdk/src/index.ts
@@ -259,7 +259,7 @@ export function getOneGateGameRuntime(): OneGateGameRuntime | undefined {
   return window.OneGateGameRuntime;
 }
 
-export async function lockOrientation(orientation: OneGateOrientationLockType): Promise<void> {
+export async function lockOrientation(orientation: OneGateOrientationLockType): Promise<boolean> {
   if (typeof window === "undefined") {
     throw new Error("Orientation locking requires a browser or WebView runtime.");
   }
@@ -268,27 +268,33 @@ export async function lockOrientation(orientation: OneGateOrientationLockType): 
   const nativeLock = screenOrientation?.lock;
   if (typeof nativeLock === "function") {
     await nativeLock.call(screenOrientation, orientation);
-    return;
+    return true;
   }
 
   if (window.__OneGateSystemInvoke) {
     await window.__OneGateSystemInvoke("screen.orientation.lock", [orientation]);
+    return true;
   }
+
+  return false;
 }
 
-export async function unlockOrientation(): Promise<void> {
+export async function unlockOrientation(): Promise<boolean> {
   if (typeof window === "undefined") {
-    return;
+    return false;
   }
 
   const screenOrientation = window.screen.orientation as LockableScreenOrientation | undefined;
   const nativeUnlock = screenOrientation?.unlock;
   if (typeof nativeUnlock === "function") {
     nativeUnlock.call(screenOrientation);
-    return;
+    return true;
   }
 
   if (window.__OneGateSystemInvoke) {
     await window.__OneGateSystemInvoke("screen.orientation.unlock", []);
+    return true;
   }
+
+  return false;
 }

--- a/sdk/onegate-game-sdk/src/index.ts
+++ b/sdk/onegate-game-sdk/src/index.ts
@@ -1,0 +1,294 @@
+export type OneGateJson = null | boolean | number | string | OneGateJson[] | { [key: string]: OneGateJson };
+
+export interface OneGateAccount {
+  address?: string;
+  label?: string;
+  publicKey?: string;
+  scriptHash?: string;
+  [key: string]: unknown;
+}
+
+export interface AuthenticationChallengePayload {
+  [key: string]: unknown;
+}
+
+export interface AuthenticationResponsePayload {
+  [key: string]: unknown;
+}
+
+export interface OneGateInvocation {
+  hash: string;
+  operation: string;
+  args?: OneGateJson[];
+  [key: string]: unknown;
+}
+
+export interface OneGateTransactionOptions {
+  suggestedSystemFee?: number | string;
+  extraSystemFee?: number | string;
+  [key: string]: unknown;
+}
+
+export interface OneGateShareRequest {
+  title?: string;
+  text?: string;
+  uri?: string;
+}
+
+export interface OneGateAsset {
+  hash?: string;
+  symbol?: string;
+  decimals?: number;
+  name?: string;
+  [key: string]: unknown;
+}
+
+export interface OneGateSignedMessage {
+  [key: string]: unknown;
+}
+
+export interface OneGateProvider {
+  name: string;
+  version: string;
+  dapiVersion: string;
+  compatibility: readonly string[];
+  connected: boolean;
+  network: number;
+  supportedNetworks: readonly number[];
+  icon: string;
+  website: string;
+  extra: Record<string, unknown>;
+
+  on(event: string, listener: EventListener): void;
+  removeListener(event: string, listener: EventListener): void;
+
+  authenticate(payload: AuthenticationChallengePayload): Promise<AuthenticationResponsePayload>;
+  getAccounts(): Promise<OneGateAccount[]>;
+  getBalance(asset: string, account: string): Promise<string | number>;
+  send(asset: string, from: string | null, to: string, amount: string | number, data?: OneGateJson): Promise<string>;
+  call(invocation: OneGateInvocation): Promise<unknown>;
+  invoke(
+    invocations: OneGateInvocation[],
+    signers?: unknown[],
+    attributes?: unknown[],
+    options?: OneGateTransactionOptions
+  ): Promise<string>;
+  makeTransaction(
+    invocations: OneGateInvocation[],
+    signers?: unknown[],
+    attributes?: unknown[],
+    options?: OneGateTransactionOptions
+  ): Promise<unknown>;
+  sign(context: unknown): Promise<unknown>;
+  signMessage(message: string, account?: string | null, options?: Record<string, unknown>): Promise<OneGateSignedMessage>;
+  relay(context: unknown): Promise<string>;
+  getBlock(hashOrIndex: string | number): Promise<unknown>;
+  getBlockCount(): Promise<number>;
+  getTransaction(txid: string): Promise<unknown>;
+  getApplicationLog(txid: string): Promise<unknown>;
+  getStorage(hash: string, key: string): Promise<string>;
+  getTokenInfo(hash: string): Promise<unknown>;
+
+  pickAddress?(prompt?: string): Promise<string>;
+  scanQRCode?(): Promise<string>;
+  pickAsset?(): Promise<OneGateAsset>;
+  share?(request: OneGateShareRequest): Promise<boolean>;
+}
+
+export interface OneGateGameRuntime {
+  version: number;
+  reload(): void;
+  on(eventName: string, listener: EventListener): void;
+  removeListener(eventName: string, listener: EventListener): void;
+}
+
+export interface GetProviderOptions {
+  timeoutMs?: number;
+  requestProviderEvent?: boolean;
+}
+
+export type OptionalOneGateCapability = "pickAddress" | "scanQRCode" | "pickAsset" | "share";
+
+export type OneGateOrientationLockType =
+  | "any"
+  | "natural"
+  | "landscape"
+  | "portrait"
+  | "portrait-primary"
+  | "portrait-secondary"
+  | "landscape-primary"
+  | "landscape-secondary";
+
+type LockableScreenOrientation = ScreenOrientation & {
+  lock?: (orientation: OneGateOrientationLockType) => Promise<void>;
+};
+
+export class OneGateCapabilityError extends Error {
+  constructor(readonly capability: OptionalOneGateCapability) {
+    super(`OneGate capability is not available: ${capability}`);
+    this.name = "OneGateCapabilityError";
+  }
+}
+
+export class OneGateProviderTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`OneGate provider was not available within ${timeoutMs} ms.`);
+    this.name = "OneGateProviderTimeoutError";
+  }
+}
+
+declare global {
+  interface Window {
+    OneGateDapiProvider?: OneGateProvider;
+    OneGateGameRuntime?: OneGateGameRuntime;
+    __OneGateSystemInvoke?: (method: string, params?: unknown[]) => Promise<unknown>;
+  }
+}
+
+export async function getOneGateProvider(options: GetProviderOptions = {}): Promise<OneGateProvider> {
+  if (typeof window === "undefined") {
+    throw new Error("OneGate provider is only available in a browser or WebView runtime.");
+  }
+
+  const timeoutMs = options.timeoutMs ?? 5_000;
+  if (window.OneGateDapiProvider) {
+    return window.OneGateDapiProvider;
+  }
+
+  return new Promise<OneGateProvider>((resolve, reject) => {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    const cleanup = () => {
+      window.removeEventListener("Neo.DapiProvider.ready", onReady);
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+    };
+
+    const resolveProvider = (provider: OneGateProvider) => {
+      cleanup();
+      resolve(provider);
+    };
+
+    const onReady = (event: Event) => {
+      const detail = (event as CustomEvent<{ provider?: OneGateProvider }>).detail;
+      const provider = detail?.provider ?? window.OneGateDapiProvider;
+      if (provider) {
+        resolveProvider(provider);
+      }
+    };
+
+    window.addEventListener("Neo.DapiProvider.ready", onReady);
+    timeoutId = setTimeout(() => {
+      cleanup();
+      reject(new OneGateProviderTimeoutError(timeoutMs));
+    }, timeoutMs);
+
+    if (options.requestProviderEvent !== false) {
+      window.dispatchEvent(new CustomEvent("Neo.DapiProvider.request"));
+    }
+
+    if (window.OneGateDapiProvider) {
+      resolveProvider(window.OneGateDapiProvider);
+    }
+  });
+}
+
+export class OneGateGameClient {
+  constructor(readonly provider: OneGateProvider) {}
+
+  hasCapability(capability: OptionalOneGateCapability): boolean {
+    return typeof this.provider[capability] === "function";
+  }
+
+  requireCapability(capability: OptionalOneGateCapability): void {
+    if (!this.hasCapability(capability)) {
+      throw new OneGateCapabilityError(capability);
+    }
+  }
+
+  getAccounts(): Promise<OneGateAccount[]> {
+    return this.provider.getAccounts();
+  }
+
+  authenticate(payload: AuthenticationChallengePayload): Promise<AuthenticationResponsePayload> {
+    return this.provider.authenticate(payload);
+  }
+
+  pickAddress(prompt?: string): Promise<string> {
+    this.requireCapability("pickAddress");
+    return this.provider.pickAddress!(prompt);
+  }
+
+  scanQRCode(): Promise<string> {
+    this.requireCapability("scanQRCode");
+    return this.provider.scanQRCode!();
+  }
+
+  pickAsset(): Promise<OneGateAsset> {
+    this.requireCapability("pickAsset");
+    return this.provider.pickAsset!();
+  }
+
+  share(request: OneGateShareRequest): Promise<boolean> {
+    this.requireCapability("share");
+    return this.provider.share!(request);
+  }
+
+  onRuntimeEvent(eventName: string, listener: EventListener): () => void {
+    const runtime = getOneGateGameRuntime();
+    if (runtime) {
+      runtime.on(eventName, listener);
+      return () => runtime.removeListener(eventName, listener);
+    }
+
+    const browserEventName = `OneGate.GameRuntime.${eventName}`;
+    window.addEventListener(browserEventName, listener);
+    return () => window.removeEventListener(browserEventName, listener);
+  }
+}
+
+export async function createOneGateGameClient(options?: GetProviderOptions): Promise<OneGateGameClient> {
+  return new OneGateGameClient(await getOneGateProvider(options));
+}
+
+export function getOneGateGameRuntime(): OneGateGameRuntime | undefined {
+  if (typeof window === "undefined") {
+    return undefined;
+  }
+  return window.OneGateGameRuntime;
+}
+
+export async function lockOrientation(orientation: OneGateOrientationLockType): Promise<void> {
+  if (typeof window === "undefined") {
+    throw new Error("Orientation locking requires a browser or WebView runtime.");
+  }
+
+  const screenOrientation = window.screen.orientation as LockableScreenOrientation | undefined;
+  const nativeLock = screenOrientation?.lock;
+  if (typeof nativeLock === "function") {
+    await nativeLock.call(screenOrientation, orientation);
+    return;
+  }
+
+  if (window.__OneGateSystemInvoke) {
+    await window.__OneGateSystemInvoke("screen.orientation.lock", [orientation]);
+  }
+}
+
+export async function unlockOrientation(): Promise<void> {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const screenOrientation = window.screen.orientation as LockableScreenOrientation | undefined;
+  const nativeUnlock = screenOrientation?.unlock;
+  if (typeof nativeUnlock === "function") {
+    nativeUnlock.call(screenOrientation);
+    return;
+  }
+
+  if (window.__OneGateSystemInvoke) {
+    await window.__OneGateSystemInvoke("screen.orientation.unlock", []);
+  }
+}

--- a/sdk/onegate-game-sdk/tsconfig.json
+++ b/sdk/onegate-game-sdk/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "lib": [
+      "ES2022",
+      "DOM"
+    ],
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "target": "ES2022",
+    "verbatimModuleSyntax": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- Add a standalone `@onegate/game-sdk` TypeScript package under `sdk/onegate-game-sdk`.
- Provide provider discovery, typed OneGate provider interfaces, optional native capability checks, address/QR/asset/share helpers, runtime event helpers, and orientation helpers.
- Document usage patterns that keep wallet authentication explicit and user-initiated.
- Add ignore rules for SDK build artifacts and dependencies.

## Scope
Part of #76, Task 6: OneGate Game SDK Package.

This SDK is a thin wrapper over the injected OneGate provider and optional native capabilities. It does not add new wallet authorization semantics, does not change the MAUI runtime, does not add a permission center, and does not adapt third-party game UI.

## Validation
- `npm install` in `sdk/onegate-game-sdk`
- `npm run build` in `sdk/onegate-game-sdk`
- `git diff --cached --check`
- `dotnet build OneGateApp/OneGateApp.csproj -f net10.0-ios -c Debug -p:RuntimeIdentifier=iossimulator-arm64 -p:CodesignKey=- -p:CodesignProvision= -p:ProvisioningType=automatic --nologo`
- `dotnet build OneGateApp/OneGateApp.csproj -f net10.0-android -c Debug -p:EmbedAssembliesIntoApk=true --nologo`
- iOS simulator install/launch/screenshot on OneGate-PR51-iPhone17.
- Android emulator install/launch/screenshot on emulator-5554; `MainActivity` resumed.

## Notes
Build warnings are existing repository/environment warnings: SQLitePCLRaw NU1903 advisories, iOS duplicate ImageAsset warnings, and the local Android JDK path validation warning.
