### PR TITLE
[codex] Add game runtime diagnostics export

### DIFF
--- a/OneGateApp/Pages/LaunchDAppPage.xaml
+++ b/OneGateApp/Pages/LaunchDAppPage.xaml
@@ -23,6 +23,7 @@
         <ToolbarItem x:Name="addToHomeScreenButton" Order="Primary" IconImageSource="{FontImageSource &#xe612;, FontFamily=Icons, Color={toolkit:AppThemeResource Primary}}" IsEnabled="{Binding DApp.IsActive}" Command="{x:Static og:Commands.AddToHomeScreen}" CommandParameter="{Binding DApp}" />
         <ToolbarItem Order="Primary" IconImageSource="{FontImageSource &#xe68b;, FontFamily=Icons, Color={toolkit:AppThemeResource Primary}}" IsEnabled="{Binding DApp.IsActive}" Command="{x:Static og:Commands.Share}" CommandParameter="{Binding DApp}" />
         <ToolbarItem x:Name="developerToolsButton" Order="Primary" IconImageSource="{FontImageSource &#xe716;, FontFamily=Icons, Color={toolkit:AppThemeResource Primary}}" Clicked="OnDeveloperToolsClicked" />
+        <ToolbarItem x:Name="exportDiagnosticsButton" Order="Secondary" Text="Export diagnostics" Clicked="OnExportDiagnosticsClicked" />
     </ContentPage.ToolbarItems>
     <og:BridgeWebView x:Name="webView" Source="{Binding Url}" Navigating="OnNavigating" InvokedFromJavaScript="OnInvokedFromJavaScript" />
 </ContentPage>

--- a/OneGateApp/Pages/LaunchDAppPage.xaml
+++ b/OneGateApp/Pages/LaunchDAppPage.xaml
@@ -23,7 +23,7 @@
         <ToolbarItem x:Name="addToHomeScreenButton" Order="Primary" IconImageSource="{FontImageSource &#xe612;, FontFamily=Icons, Color={toolkit:AppThemeResource Primary}}" IsEnabled="{Binding DApp.IsActive}" Command="{x:Static og:Commands.AddToHomeScreen}" CommandParameter="{Binding DApp}" />
         <ToolbarItem Order="Primary" IconImageSource="{FontImageSource &#xe68b;, FontFamily=Icons, Color={toolkit:AppThemeResource Primary}}" IsEnabled="{Binding DApp.IsActive}" Command="{x:Static og:Commands.Share}" CommandParameter="{Binding DApp}" />
         <ToolbarItem x:Name="developerToolsButton" Order="Primary" IconImageSource="{FontImageSource &#xe716;, FontFamily=Icons, Color={toolkit:AppThemeResource Primary}}" Clicked="OnDeveloperToolsClicked" />
-        <ToolbarItem x:Name="exportDiagnosticsButton" Order="Secondary" Text="Export diagnostics" Clicked="OnExportDiagnosticsClicked" />
+        <ToolbarItem x:Name="exportDiagnosticsButton" Order="Secondary" Text="{x:Static og:Strings.ExportDiagnostics}" Clicked="OnExportDiagnosticsClicked" />
     </ContentPage.ToolbarItems>
     <og:BridgeWebView x:Name="webView" Source="{Binding Url}" Navigating="OnNavigating" InvokedFromJavaScript="OnInvokedFromJavaScript" />
 </ContentPage>

--- a/OneGateApp/Pages/LaunchDAppPage.xaml.cs
+++ b/OneGateApp/Pages/LaunchDAppPage.xaml.cs
@@ -10,6 +10,7 @@ using NeoOrder.OneGate.Services;
 using NeoOrder.OneGate.Services.RPC;
 using System.Net;
 using System.Net.Http.Json;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace NeoOrder.OneGate.Pages;
@@ -48,7 +49,14 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
         if (!homeShortcutService.IsSupported)
             ToolbarItems.Remove(addToHomeScreenButton);
         if (!IsDeveloperToolsEnabled)
+        {
             ToolbarItems.Remove(developerToolsButton);
+            ToolbarItems.Remove(exportDiagnosticsButton);
+        }
+        else
+        {
+            ToolbarItems.Remove(exportDiagnosticsButton);
+        }
     }
 
     public async void ApplyQueryAttributes(IDictionary<string, object> query)
@@ -100,6 +108,7 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
             await dbContext.Settings.PutAsync("dapps/recent", recents);
             if (DApp.IsRegularApp) GlobalStates.Invalidate<DAppsPage>();
         }
+        UpdateDiagnosticsExportButton();
     }
 
     void OnFavoriteClicked(object sender, EventArgs e)
@@ -116,6 +125,41 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
         }
         catch
         {
+        }
+    }
+
+    async void OnExportDiagnosticsClicked(object sender, EventArgs e)
+    {
+        if (!IsDeveloperToolsEnabled || DApp is not { IsGamingApp: true }) return;
+        try
+        {
+            JsonObject report = await CreateRuntimeDiagnosticsReportAsync();
+            string fileName = $"onegate-runtime-diagnostics-{DateTimeOffset.UtcNow:yyyyMMddHHmmss}.json";
+            string filePath = Path.Combine(FileSystem.CacheDirectory, fileName);
+            await File.WriteAllTextAsync(filePath, report.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+            await Microsoft.Maui.ApplicationModel.DataTransfer.Share.RequestAsync(new Microsoft.Maui.ApplicationModel.DataTransfer.ShareFileRequest
+            {
+                Title = "OneGate runtime diagnostics",
+                File = new Microsoft.Maui.ApplicationModel.DataTransfer.ShareFile(filePath, "application/json")
+            });
+        }
+        catch
+        {
+            await Toast.Show("Failed to export diagnostics");
+        }
+    }
+
+    void UpdateDiagnosticsExportButton()
+    {
+        if (!IsDeveloperToolsEnabled) return;
+        if (DApp is { IsGamingApp: true })
+        {
+            if (!ToolbarItems.Contains(exportDiagnosticsButton))
+                ToolbarItems.Add(exportDiagnosticsButton);
+        }
+        else
+        {
+            ToolbarItems.Remove(exportDiagnosticsButton);
         }
     }
 
@@ -166,6 +210,7 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
                     accountchanged: new Set(),
                     networkchanged: new Set()
                 };
+                const nativeApiCallCounts = {};
 
                 const methods = ["authenticate", "getAccounts", "pickAddress", "getBalance", "send", "call", "invoke", "makeTransaction", "sign", "signMessage", "relay", "getBlock", "getBlockCount", "getTransaction", "getApplicationLog", "getStorage", "getTokenInfo"];
 
@@ -197,8 +242,17 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
                     }
                 };
             
+                window.__OneGateGetDapiDiagnostics = function () {
+                    return {
+                        nativeApiCallCounts: Object.assign({}, nativeApiCallCounts)
+                    };
+                };
+
                 for (let method of methods)
-                    provider[method] = function () { return window.{{BridgeWebView.BridgeInvokeFunctionName}}(method, [...arguments]); };
+                    provider[method] = function () {
+                        nativeApiCallCounts[method] = (nativeApiCallCounts[method] || 0) + 1;
+                        return window.{{BridgeWebView.BridgeInvokeFunctionName}}(method, [...arguments]);
+                    };
             
                 window.OneGateDapiProvider = deepFreeze(provider);
 
@@ -213,6 +267,155 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
                 dispatchReady();
 
                 window.addEventListener('Neo.DapiProvider.request', dispatchReady);
+            })();
+            """.ReplaceLineEndings("");
+    }
+
+    async Task<JsonObject> CreateRuntimeDiagnosticsReportAsync()
+    {
+        JsonNode? webViewSnapshot = await TryReadWebViewDiagnosticsAsync();
+        return new JsonObject
+        {
+            ["schemaVersion"] = 1,
+            ["generatedAt"] = DateTimeOffset.UtcNow.ToString("O"),
+            ["oneGate"] = new JsonObject
+            {
+                ["version"] = AppInfo.Current.VersionString,
+                ["build"] = AppInfo.Current.BuildString,
+                ["packageName"] = AppInfo.Current.PackageName
+            },
+            ["device"] = new JsonObject
+            {
+                ["platform"] = DeviceInfo.Platform.ToString(),
+                ["version"] = DeviceInfo.VersionString,
+                ["model"] = DeviceInfo.Model,
+                ["manufacturer"] = DeviceInfo.Manufacturer,
+                ["idiom"] = DeviceInfo.Idiom.ToString()
+            },
+            ["dapp"] = new JsonObject
+            {
+                ["id"] = DApp.Id,
+                ["isActive"] = DApp.IsActive,
+                ["isGamingApp"] = DApp.IsGamingApp,
+                ["gameType"] = DApp.GameType,
+                ["origin"] = TryGetOrigin(DApp.Url),
+                ["currentUrl"] = CreateRedactedUrl(Url)
+            },
+            ["webView"] = webViewSnapshot
+        };
+    }
+
+    async Task<JsonNode?> TryReadWebViewDiagnosticsAsync()
+    {
+        try
+        {
+            string? result = await webView.EvaluateJavaScriptAsync(CreateWebViewDiagnosticsScript());
+            if (string.IsNullOrWhiteSpace(result))
+                return null;
+
+            JsonNode? parsed = JsonNode.Parse(result);
+            if (parsed is JsonValue value && value.TryGetValue<string>(out string? nested) && !string.IsNullOrWhiteSpace(nested))
+                parsed = JsonNode.Parse(nested);
+            return parsed;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    static string? TryGetOrigin(string? url)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            return null;
+        return uri.GetLeftPart(UriPartial.Authority);
+    }
+
+    static JsonObject? CreateRedactedUrl(string? url)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+            return null;
+        return new JsonObject
+        {
+            ["origin"] = uri.GetLeftPart(UriPartial.Authority),
+            ["path"] = uri.AbsolutePath,
+            ["hasQuery"] = !string.IsNullOrEmpty(uri.Query),
+            ["hasFragment"] = !string.IsNullOrEmpty(uri.Fragment)
+        };
+    }
+
+    static string CreateWebViewDiagnosticsScript()
+    {
+        return """
+            (function () {
+                function redactUrl(value) {
+                    try {
+                        const url = new URL(value, location.href);
+                        return {
+                            origin: url.origin,
+                            path: url.pathname,
+                            hasQuery: url.search.length > 0,
+                            hasFragment: url.hash.length > 0
+                        };
+                    } catch (_) {
+                        return null;
+                    }
+                }
+
+                function navigationTiming() {
+                    const nav = performance.getEntriesByType("navigation")[0];
+                    if (!nav) return null;
+                    return {
+                        type: nav.type,
+                        startTime: Math.round(nav.startTime),
+                        duration: Math.round(nav.duration),
+                        domInteractive: Math.round(nav.domInteractive),
+                        domContentLoadedEventEnd: Math.round(nav.domContentLoadedEventEnd),
+                        loadEventEnd: Math.round(nav.loadEventEnd),
+                        transferSize: nav.transferSize || 0,
+                        encodedBodySize: nav.encodedBodySize || 0,
+                        decodedBodySize: nav.decodedBodySize || 0
+                    };
+                }
+
+                function recentResources() {
+                    return performance.getEntriesByType("resource").slice(-50).map(function(entry) {
+                        return {
+                            name: redactUrl(entry.name),
+                            initiatorType: entry.initiatorType,
+                            duration: Math.round(entry.duration),
+                            transferSize: entry.transferSize || 0,
+                            encodedBodySize: entry.encodedBodySize || 0,
+                            decodedBodySize: entry.decodedBodySize || 0
+                        };
+                    });
+                }
+
+                const provider = window.OneGateDapiProvider;
+                const dapiDiagnostics = typeof window.__OneGateGetDapiDiagnostics === "function"
+                    ? window.__OneGateGetDapiDiagnostics()
+                    : null;
+
+                return JSON.stringify({
+                    url: redactUrl(location.href),
+                    title: document.title || null,
+                    visibilityState: document.visibilityState,
+                    userAgent: navigator.userAgent,
+                    provider: provider ? {
+                        name: provider.name,
+                        version: provider.version,
+                        dapiVersion: provider.dapiVersion,
+                        network: provider.network,
+                        supportedNetworks: provider.supportedNetworks,
+                        compatibility: provider.compatibility
+                    } : null,
+                    gameRuntime: window.OneGateGameRuntime ? {
+                        version: window.OneGateGameRuntime.version
+                    } : null,
+                    dapiDiagnostics: dapiDiagnostics,
+                    timing: navigationTiming(),
+                    recentResources: recentResources()
+                });
             })();
             """.ReplaceLineEndings("");
     }

--- a/OneGateApp/Pages/LaunchDAppPage.xaml.cs
+++ b/OneGateApp/Pages/LaunchDAppPage.xaml.cs
@@ -134,18 +134,18 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
         try
         {
             JsonObject report = await CreateRuntimeDiagnosticsReportAsync();
-            string fileName = $"onegate-runtime-diagnostics-{DateTimeOffset.UtcNow:yyyyMMddHHmmss}.json";
+            string fileName = $"onegate-runtime-diagnostics-{DateTimeOffset.UtcNow:yyyyMMddHHmmssfff}-{Guid.NewGuid():N}.json";
             string filePath = Path.Combine(FileSystem.CacheDirectory, fileName);
             await File.WriteAllTextAsync(filePath, report.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
             await Microsoft.Maui.ApplicationModel.DataTransfer.Share.RequestAsync(new Microsoft.Maui.ApplicationModel.DataTransfer.ShareFileRequest
             {
-                Title = "OneGate runtime diagnostics",
+                Title = Strings.OneGateRuntimeDiagnostics,
                 File = new Microsoft.Maui.ApplicationModel.DataTransfer.ShareFile(filePath, "application/json")
             });
         }
         catch
         {
-            await Toast.Show("Failed to export diagnostics");
+            await Toast.Show(Strings.ExportDiagnosticsFailed);
         }
     }
 

--- a/OneGateApp/Properties/Strings.Designer.cs
+++ b/OneGateApp/Properties/Strings.Designer.cs
@@ -10,8 +10,8 @@
 
 namespace NeoOrder.OneGate.Properties {
     using System;
-    
-    
+
+
     /// <summary>
     ///   一个强类型的资源类，用于查找本地化的字符串等。
     /// </summary>
@@ -1040,6 +1040,24 @@ namespace NeoOrder.OneGate.Properties {
         }
         
         /// <summary>
+        ///   查找类似 Export diagnostics 的本地化字符串。
+        /// </summary>
+        internal static string ExportDiagnostics {
+            get {
+                return ResourceManager.GetString("ExportDiagnostics", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   查找类似 Failed to export diagnostics 的本地化字符串。
+        /// </summary>
+        internal static string ExportDiagnosticsFailed {
+            get {
+                return ResourceManager.GetString("ExportDiagnosticsFailed", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   查找类似 Favorites 的本地化字符串。
         /// </summary>
         internal static string Favorite {
@@ -1637,6 +1655,15 @@ namespace NeoOrder.OneGate.Properties {
             }
         }
         
+        /// <summary>
+        ///   查找类似 OneGate runtime diagnostics 的本地化字符串。
+        /// </summary>
+        internal static string OneGateRuntimeDiagnostics {
+            get {
+                return ResourceManager.GetString("OneGateRuntimeDiagnostics", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   查找类似 Open NFT link 的本地化字符串。
         /// </summary>

--- a/OneGateApp/Properties/Strings.resx
+++ b/OneGateApp/Properties/Strings.resx
@@ -843,6 +843,15 @@ By continuing, you acknowledge that you fully understand and accept all associat
   <data name="ExportPrivateKey" xml:space="preserve">
     <value>Export private key</value>
   </data>
+  <data name="ExportDiagnostics" xml:space="preserve">
+    <value>Export diagnostics</value>
+  </data>
+  <data name="ExportDiagnosticsFailed" xml:space="preserve">
+    <value>Failed to export diagnostics</value>
+  </data>
+  <data name="OneGateRuntimeDiagnostics" xml:space="preserve">
+    <value>OneGate runtime diagnostics</value>
+  </data>
   <data name="PrivateKeySecurity" xml:space="preserve">
     <value>Private key security notice</value>
   </data>


### PR DESCRIPTION
## Summary
- Add a developer-mode, game-only runtime diagnostics export action on the dApp launch page.
- Export a JSON diagnostics report through the system share sheet instead of clipboard.
- Include app/device metadata, redacted dApp URL/origin, WebView navigation timing, recent resource timing with redacted resource URLs, provider metadata, game runtime metadata, and dAPI method call counts.
- Avoid collecting accounts, signing payloads, private keys, seed data, wallet passwords, full query strings, or URL fragments.

## Scope
Part of #76, Task 10: Runtime Diagnostics Report Export.

This does not add a persistent trust bar, permission center, local transaction history, clipboard behavior, runtime blocking, or third-party DOM/CSS adaptation.

## Validation
- `git diff --check`
- `dotnet build OneGateApp/OneGateApp.csproj -f net10.0-ios -c Debug -p:RuntimeIdentifier=iossimulator-arm64 -p:CodesignKey=- -p:CodesignProvision= -p:ProvisioningType=automatic --nologo`
- `dotnet build OneGateApp/OneGateApp.csproj -f net10.0-android -c Debug -p:EmbedAssembliesIntoApk=true --nologo`
- iOS simulator install/launch/screenshot on OneGate-PR51-iPhone17.
- Android emulator install/launch/screenshot on emulator-5554; `MainActivity` resumed.

## Notes
Build warnings are existing repository/environment warnings: SQLitePCLRaw NU1903 advisories, iOS duplicate ImageAsset warnings, and the local Android JDK path validation warning.
