### PR TITLE
[codex] Add OneGate dApp deeplink fallback

### DIFF
--- a/OneGateApp/Models/AppLinks/AppLinkAction.cs
+++ b/OneGateApp/Models/AppLinks/AppLinkAction.cs
@@ -42,9 +42,16 @@ abstract class AppLinkAction
         {
             "neo" => PaymentAction.TryCreate(uri),
             "neoauth" => AuthenticationAction.TryCreate(uri),
+            SharedOptions.OneGateScheme => ProcessOneGateScheme(uri),
             "https" => ProcessHttpsScheme(uri),
             _ => null
         };
+    }
+
+    static AppLinkAction? ProcessOneGateScheme(Uri uri)
+    {
+        if (!TryNormalizeOneGateUri(uri, out Uri? webUri)) return null;
+        return ProcessHttpsScheme(webUri);
     }
 
     static AppLinkAction? ProcessHttpsScheme(Uri uri)
@@ -56,5 +63,27 @@ abstract class AppLinkAction
             ["/", "news/", _] => ViewNewsAction.TryCreate(uri),
             _ => null
         };
+    }
+
+    static bool TryNormalizeOneGateUri(Uri uri, out Uri webUri)
+    {
+        webUri = null!;
+        string path = uri.Authority switch
+        {
+            "" => uri.AbsolutePath,
+            SharedOptions.OneGateDomain => uri.AbsolutePath,
+            _ => $"/{uri.Authority}{uri.AbsolutePath}"
+        };
+
+        if (string.IsNullOrWhiteSpace(path) || path == "/") return false;
+
+        var builder = new UriBuilder(Uri.UriSchemeHttps, SharedOptions.OneGateDomain)
+        {
+            Path = path.TrimStart('/'),
+            Query = uri.Query.TrimStart('?'),
+            Fragment = uri.Fragment.TrimStart('#')
+        };
+        webUri = builder.Uri;
+        return true;
     }
 }

--- a/OneGateApp/Platforms/Android/DocumentLinkActivity.cs
+++ b/OneGateApp/Platforms/Android/DocumentLinkActivity.cs
@@ -9,6 +9,10 @@ namespace NeoOrder.OneGate.Platforms.Android;
 [Activity(Theme = "@style/OneGate.SplashTheme", LaunchMode = LaunchMode.Multiple, DocumentLaunchMode = DocumentLaunchMode.IntoExisting, TaskAffinity = "org.neoorder.onegate.document", ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density, Exported = true)]
 [IntentFilter([Intent.ActionView], Categories = [Intent.CategoryDefault, Intent.CategoryBrowsable], DataScheme = "https", DataHost = SharedOptions.OneGateDomain, DataPathPrefix = "/app/", AutoVerify = true)]
 [IntentFilter([Intent.ActionView], Categories = [Intent.CategoryDefault, Intent.CategoryBrowsable], DataScheme = "https", DataHost = SharedOptions.OneGateDomain, DataPathPrefix = "/news/", AutoVerify = true)]
+[IntentFilter([Intent.ActionView], Categories = [Intent.CategoryDefault, Intent.CategoryBrowsable], DataScheme = SharedOptions.OneGateScheme, DataHost = SharedOptions.OneGateDomain, DataPathPrefix = "/app/")]
+[IntentFilter([Intent.ActionView], Categories = [Intent.CategoryDefault, Intent.CategoryBrowsable], DataScheme = SharedOptions.OneGateScheme, DataHost = SharedOptions.OneGateDomain, DataPathPrefix = "/news/")]
+[IntentFilter([Intent.ActionView], Categories = [Intent.CategoryDefault, Intent.CategoryBrowsable], DataScheme = SharedOptions.OneGateScheme, DataHost = "app", DataPathPrefix = "/")]
+[IntentFilter([Intent.ActionView], Categories = [Intent.CategoryDefault, Intent.CategoryBrowsable], DataScheme = SharedOptions.OneGateScheme, DataHost = "news", DataPathPrefix = "/")]
 public class DocumentLinkActivity : OneGateActivity
 {
     protected override void OnCreate(Bundle? savedInstanceState)

--- a/OneGateApp/Platforms/MacCatalyst/Info.plist
+++ b/OneGateApp/Platforms/MacCatalyst/Info.plist
@@ -40,6 +40,14 @@
 				<string>neoauth</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>org.neoorder.onegate</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>onegate</string>
+			</array>
+		</dict>
 	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>

--- a/OneGateApp/Platforms/iOS/Info.plist
+++ b/OneGateApp/Platforms/iOS/Info.plist
@@ -40,6 +40,14 @@
 				<string>neoauth</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>org.neoorder.onegate</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>onegate</string>
+			</array>
+		</dict>
 	</array>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>

--- a/OneGateApp/Services/SharedOptions.cs
+++ b/OneGateApp/Services/SharedOptions.cs
@@ -6,6 +6,7 @@ namespace NeoOrder.OneGate.Services;
 
 static class SharedOptions
 {
+    public const string OneGateScheme = "onegate";
     public const string OneGateDomain = "onegate.space";
     public const string ContactEmail = "contact@neoorder.org";
     public static readonly string DbPath = Path.Combine(FileSystem.AppDataDirectory, "settings.db3");


### PR DESCRIPTION
## Summary

Adds a native `onegate://` fallback deeplink for dApp/news detail links while preserving the existing `https://onegate.space/...` Universal/App Link flow.

## Root cause

The web detail page can present an "Open in OneGate" button that uses a custom app scheme fallback. iOS did not register a `onegate` URL scheme, so Safari showed the URL as invalid before the app could receive it.

## Changes

- Registers `onegate` in iOS and MacCatalyst `Info.plist`.
- Adds Android intent filters for `onegate://app/{id}`, `onegate://news/{id}`, and `onegate://onegate.space/...` forms.
- Normalizes `onegate://...` links into the existing `https://onegate.space/...` app-link parser so launch behavior stays centralized.

## Validation

- `git diff --check` passed.
- Android build passed:
  `dotnet build OneGateApp/OneGateApp.csproj -f net10.0-android -p:EmbedAssembliesIntoApk=true -p:AndroidSdkDirectory=/opt/homebrew/share/android-commandlinetools -p:JavaSdkDirectory=/opt/homebrew/Cellar/openjdk@17/17.0.19/libexec/openjdk.jdk/Contents/Home`
- iOS clean build passed:
  `DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer MD_APPLE_SDK_ROOT=/Applications/Xcode-26.5.0.app dotnet clean OneGateApp/OneGateApp.csproj -f net10.0-ios`
  `DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer MD_APPLE_SDK_ROOT=/Applications/Xcode-26.5.0.app dotnet build OneGateApp/OneGateApp.csproj -f net10.0-ios -p:EnableCodeSigning=false`
- Android emulator install/open URL passed: `onegate://app/28` resolves to OneGate `DocumentLinkActivity` and opens Angry Birds.
- iOS simulator install/open URL passed at the OS registration layer: `onegate://app/28` no longer shows invalid URL; iOS presents the system "Open in OneGate" confirmation sheet.

Existing warnings only: `SQLitePCLRaw.*` NU1903 advisories and existing iOS asset duplicate `MT7158` warnings after clean build.

## Screenshots

Screenshots are GitHub release assets only; none are committed to the repo.

- Android emulator: https://github.com/Jim8y/OneGateApp/releases/download/onegate-pr-deeplink-fallback-20260704-8c51ccb/android-onegate-scheme-app28.png
- iOS simulator: https://github.com/Jim8y/OneGateApp/releases/download/onegate-pr-deeplink-fallback-20260704-8c51ccb/ios-onegate-scheme-app28.png

## Known limitation

The iOS simulator stopped at the standard system confirmation sheet. The local XcodeBuildMCP UI automation could not tap it because `xcode-select` currently points at CommandLineTools rather than the full Xcode install. The important regression check for this PR is that iOS now recognizes the OneGate scheme and offers to open OneGate instead of rejecting the URL as invalid.
