### PR TITLE
[codex] Add dAPI getProvider metadata

### DIFF
--- a/OneGateApp/Pages/LaunchDAppPage.xaml.cs
+++ b/OneGateApp/Pages/LaunchDAppPage.xaml.cs
@@ -194,6 +194,21 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable
                         listeners[event].forEach(function(fn) {
                             try { fn(e); } catch (_) {}
                         });
+                    },
+
+                    getProvider: function() {
+                        return Promise.resolve(deepFreeze({
+                            name: provider.name,
+                            website: provider.website,
+                            version: provider.version,
+                            dapiVersion: provider.dapiVersion,
+                            compatibility: provider.compatibility.slice(),
+                            extra: Object.assign({}, provider.extra, {
+                                icon: provider.icon,
+                                network: provider.network,
+                                supportedNetworks: provider.supportedNetworks.slice()
+                            })
+                        }));
                     }
                 };
             


### PR DESCRIPTION
## Summary
- Add a safe `getProvider()` method to the injected `window.OneGateDapiProvider` object.
- Return frozen OneGate wallet metadata (`name`, `website`, `version`, `dapiVersion`, compatibility, icon/network fields).
- Keep wallet authorization, signing, transaction, and account request behavior unchanged.

## Why
Some dApps need a lightweight provider-discovery path before they request accounts or signing. This gives them a OneGate-native way to detect the embedded provider without pretending to be Neon or NeoLine.

This intentionally does **not** add `window.NeoLine`, does **not** emulate Neon/NeoLine APIs, and does **not** bypass OneGate permission prompts. That keeps the change aligned with prior review guidance: expose OneGate capabilities directly and avoid compatibility shims that misrepresent the wallet.

## Validation
- `git diff --check`
- Android: `dotnet build OneGateApp/OneGateApp.csproj -f net10.0-android -p:EmbedAssembliesIntoApk=true -p:AndroidSdkDirectory=/opt/homebrew/share/android-commandlinetools -p:JavaSdkDirectory=/opt/homebrew/Cellar/openjdk@17/17.0.19/libexec/openjdk.jdk/Contents/Home`
- Android emulator: installed the APK and opened `https://onegate.space/app/28`; app reached the dApp runtime without native crash logs.
- iOS: `DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer MD_APPLE_SDK_ROOT=/Applications/Xcode-26.5.0.app dotnet build OneGateApp/OneGateApp.csproj -f net10.0-ios -p:RuntimeIdentifier=iossimulator-arm64 -p:BuildIpa=false -p:EnableCodeSigning=true -p:CodesignKey=- -p:CodesignProvision= -p:ProvisioningType=automatic`
- iOS simulator: installed and launched the signed app successfully.

Known existing warnings: SQLitePCLRaw `NU1903` advisories remain unrelated to this PR.

## Screenshots
Uploaded in PR comments as external GitHub assets; screenshots are not committed to the repository.

## Known Limitations
- iOS local dApp deep-link tap-through is not covered on this branch because custom `onegate://` fallback is handled separately in #86 and production Associated Domains behavior is not reproducible with this ad-hoc simulator build.
