### PR TITLE
[codex] Add DApp search placeholder

### DIFF
--- a/OneGateApp/Controls/Handlers/DAppSearchHandler.cs
+++ b/OneGateApp/Controls/Handlers/DAppSearchHandler.cs
@@ -1,5 +1,6 @@
 ﻿using NeoOrder.OneGate.Data;
 using NeoOrder.OneGate.Pages;
+using NeoOrder.OneGate.Properties;
 using NeoOrder.OneGate.Services;
 
 namespace NeoOrder.OneGate.Controls.Handlers;
@@ -7,6 +8,11 @@ namespace NeoOrder.OneGate.Controls.Handlers;
 partial class DAppSearchHandler : SearchHandler
 {
     public readonly static BindableProperty DAppsProperty = BindableProperty.Create(nameof(DApps), typeof(IList<DApp>), typeof(DAppSearchHandler));
+
+    public DAppSearchHandler()
+    {
+        Placeholder = Strings.Search;
+    }
 
     public IList<DApp>? DApps
     {


### PR DESCRIPTION
## Summary

- Set the shared `DAppSearchHandler` placeholder to the localized `Strings.Search` value.
- Covers both DApps and Gaming pages without editing either page layout.
- Keeps the change out of #56 Gaming Hub UI polish and #54 Global Search scope.

## Why

Game QA noted that the iOS search field could appear without placeholder text. The shared handler previously relied on each page to set a placeholder, but the DApps/Gaming pages instantiate it without one. Setting the default in the handler makes the behavior consistent and localized wherever the handler is used.

## Validation

- `git diff --check`
- Android: `dotnet build OneGateApp/OneGateApp.csproj -f net10.0-android -p:EmbedAssembliesIntoApk=true -p:AndroidSdkDirectory=/opt/homebrew/share/android-commandlinetools -p:JavaSdkDirectory=/opt/homebrew/Cellar/openjdk@17/17.0.19/libexec/openjdk.jdk/Contents/Home`
- Android emulator: installed the APK and launched OneGate; no native crash logs were emitted.
- iOS: `DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer MD_APPLE_SDK_ROOT=/Applications/Xcode-26.5.0.app dotnet build OneGateApp/OneGateApp.csproj -f net10.0-ios -p:RuntimeIdentifier=iossimulator-arm64 -p:BuildIpa=false -p:EnableCodeSigning=true -p:CodesignKey=- -p:CodesignProvision= -p:ProvisioningType=automatic`
- iOS simulator: installed and launched the signed app successfully.

Known existing warnings: SQLitePCLRaw `NU1903` advisories remain unrelated to this PR.

## Screenshots

Uploaded in PR comments as external GitHub assets; screenshots are not committed to the repository.
