### PR TITLE
[codex] Fix Android dApp WebView file chooser

### DIFF
--- a/OneGateApp/Controls/Handlers/BridgeWebViewHandler.Android.cs
+++ b/OneGateApp/Controls/Handlers/BridgeWebViewHandler.Android.cs
@@ -1,13 +1,18 @@
 ﻿#if ANDROID
 
+using Android.App;
+using Android.Content;
 using Android.Webkit;
 using AndroidX.WebKit;
 using Java.Interop;
+using NeoOrder.OneGate.Platforms.Android;
 
 namespace NeoOrder.OneGate.Controls.Handlers;
 
 partial class BridgeWebViewHandler
 {
+    static int nextFileChooserRequestCode = 8300;
+
     class ScriptHandler(Action<string> onMessage, Func<string, string> onSyncMessage) : Java.Lang.Object
     {
         [JavascriptInterface]
@@ -25,11 +30,81 @@ partial class BridgeWebViewHandler
         }
     }
 
+    class BridgeWebChromeClient : WebChromeClient
+    {
+        readonly int fileChooserRequestCode = Interlocked.Increment(ref nextFileChooserRequestCode);
+        IValueCallback? pendingFilePathCallback;
+
+        public BridgeWebChromeClient()
+        {
+            OneGateActivity.ActivityResultReceived += OnActivityResultReceived;
+        }
+
+        public override bool OnShowFileChooser(Android.Webkit.WebView? webView, IValueCallback? filePathCallback, FileChooserParams? fileChooserParams)
+        {
+            CancelPendingFileChooser();
+            if (filePathCallback is null || fileChooserParams is null)
+                return false;
+
+            Activity? activity = Platform.CurrentActivity;
+            if (activity is null)
+                return false;
+
+            pendingFilePathCallback = filePathCallback;
+            try
+            {
+                Intent? intent = fileChooserParams.CreateIntent();
+                if (intent is null)
+                {
+                    CompleteFileChooser(null);
+                    return true;
+                }
+                intent.AddFlags(ActivityFlags.GrantReadUriPermission);
+                activity.StartActivityForResult(intent, fileChooserRequestCode);
+            }
+            catch
+            {
+                CompleteFileChooser(null);
+            }
+            return true;
+        }
+
+        public void Disconnect()
+        {
+            OneGateActivity.ActivityResultReceived -= OnActivityResultReceived;
+            CancelPendingFileChooser();
+        }
+
+        void OnActivityResultReceived(object? sender, OneGateActivity.ActivityResultReceivedEventArgs e)
+        {
+            if (e.RequestCode != fileChooserRequestCode || pendingFilePathCallback is null)
+                return;
+
+            Android.Net.Uri[]? uris = FileChooserParams.ParseResult((int)e.ResultCode, e.Data);
+            CompleteFileChooser(uris);
+        }
+
+        void CancelPendingFileChooser()
+        {
+            CompleteFileChooser(null);
+        }
+
+        void CompleteFileChooser(Android.Net.Uri[]? uris)
+        {
+            IValueCallback? callback = pendingFilePathCallback;
+            pendingFilePathCallback = null;
+            callback?.OnReceiveValue(uris is null ? null : Java.Lang.Object.FromArray(uris));
+        }
+    }
+
+    BridgeWebChromeClient? webChromeClient;
+
     protected override void ConnectHandler(Android.Webkit.WebView platformView)
     {
         base.ConnectHandler(platformView);
         platformView.Settings.DomStorageEnabled = true;
         platformView.Settings.JavaScriptEnabled = true;
+        platformView.SetWebChromeClient(webChromeClient = new BridgeWebChromeClient());
         platformView.AddJavascriptInterface(new ScriptHandler(BridgeWebView.OnMessage, BridgeWebView.OnSyncMessage), "__OneGateBridge");
         if (WebViewFeature.IsFeatureSupported(WebViewFeature.DocumentStartScript))
         {
@@ -38,6 +113,16 @@ partial class BridgeWebViewHandler
                 script += BridgeWebView.DocumentStartScript;
             WebViewCompat.AddDocumentStartJavaScript(platformView, script, ["*"]);
         }
+    }
+
+    protected override void DisconnectHandler(Android.Webkit.WebView platformView)
+    {
+        webChromeClient?.Disconnect();
+        webChromeClient = null;
+        platformView.StopLoading();
+        platformView.RemoveJavascriptInterface("__OneGateBridge");
+        platformView.SetWebChromeClient(null);
+        base.DisconnectHandler(platformView);
     }
 }
 #endif

--- a/OneGateApp/Controls/Handlers/BridgeWebViewHandler.Android.cs
+++ b/OneGateApp/Controls/Handlers/BridgeWebViewHandler.Android.cs
@@ -43,12 +43,20 @@ partial class BridgeWebViewHandler
         public override bool OnShowFileChooser(Android.Webkit.WebView? webView, IValueCallback? filePathCallback, FileChooserParams? fileChooserParams)
         {
             CancelPendingFileChooser();
-            if (filePathCallback is null || fileChooserParams is null)
+            if (filePathCallback is null)
                 return false;
+            if (fileChooserParams is null)
+            {
+                filePathCallback.OnReceiveValue(null);
+                return true;
+            }
 
             Activity? activity = Platform.CurrentActivity;
             if (activity is null)
-                return false;
+            {
+                filePathCallback.OnReceiveValue(null);
+                return true;
+            }
 
             pendingFilePathCallback = filePathCallback;
             try

--- a/OneGateApp/Platforms/Android/OneGateActivity.cs
+++ b/OneGateApp/Platforms/Android/OneGateActivity.cs
@@ -1,3 +1,4 @@
+using Android.App;
 using Android.Content;
 using Android.Content.Res;
 using AndroidX.Core.View;
@@ -7,6 +8,15 @@ namespace NeoOrder.OneGate.Platforms.Android;
 
 public abstract class OneGateActivity : MauiAppCompatActivity
 {
+    internal sealed class ActivityResultReceivedEventArgs(int requestCode, Result resultCode, Intent? data) : EventArgs
+    {
+        public int RequestCode { get; } = requestCode;
+        public Result ResultCode { get; } = resultCode;
+        public Intent? Data { get; } = data;
+    }
+
+    internal static event EventHandler<ActivityResultReceivedEventArgs>? ActivityResultReceived;
+
     protected static bool TryGetUri(Intent intent, out Uri uri)
     {
         string url = intent.GetStringExtra("org.neoorder.onegate.ORIGINAL_URI")
@@ -48,6 +58,12 @@ public abstract class OneGateActivity : MauiAppCompatActivity
     {
         base.OnConfigurationChanged(newConfig);
         ApplySystemBarStyle();
+    }
+
+    protected override void OnActivityResult(int requestCode, Result resultCode, Intent? data)
+    {
+        base.OnActivityResult(requestCode, resultCode, data);
+        ActivityResultReceived?.Invoke(this, new ActivityResultReceivedEventArgs(requestCode, resultCode, data));
     }
 
     void ApplySystemBarStyle()


### PR DESCRIPTION
## Summary

Fixes the Android WebView container path that prevented dApps/games from using HTML file inputs.

- Adds an Android `WebChromeClient` for `BridgeWebView` so `<input type="file">` opens the system file picker.
- Routes the Android activity result back to the active WebView file chooser callback and returns the selected content URIs to the WebView.
- Cancels pending file chooser callbacks and removes Android WebView bridge hooks during handler disconnect to avoid stale callbacks/interfaces.

## Scope

This is intentionally limited to Android WebView container behavior.

It does not change dApp wallet authorization, dApp metadata/layout, the OneGate custom deeplink fallback covered by #86, or the game runtime lifecycle work covered by #78.

## Validation

- `git diff --check` passed.
- Android build passed:
  `dotnet build OneGateApp/OneGateApp.csproj -f net10.0-android -r android-arm64 -p:AndroidSdkDirectory=/opt/homebrew/share/android-commandlinetools -p:JavaSdkDirectory=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home -p:EmbedAssembliesIntoApk=true`
- Android emulator validation on `emulator-5554`:
  - Installed final `org.neoorder.onegate-Signed.apk`.
  - Opened `https://onegate.space/app/24` through OneGate `DocumentLinkActivity`.
  - Verified RetroPort loads inside the OneGate WebView.
  - Tapped `Choose ROM`; Android system `DocumentsUI` file picker opens instead of doing nothing.
- iOS simulator regression validation on `OneGate-PR51-iPhone17` / iOS 26.5:
  - `net10.0-ios` / `iossimulator-arm64` build passed.
  - Installed and launched OneGate successfully.

Existing warnings only: `SQLitePCLRaw.*` NU1903 advisories.

## Screenshots

Screenshots are external GitHub release assets only; none are committed to the repository.

- Android RetroPort loaded: https://github.com/Jim8y/OneGateApp/releases/download/onegate-pr-android-webview-file-picker-20260704-da84862/android-final-retroport.png
- Android file picker opened from `Choose ROM`: https://github.com/Jim8y/OneGateApp/releases/download/onegate-pr-android-webview-file-picker-20260704-da84862/android-final-file-picker.png
- iOS simulator launch regression: https://github.com/Jim8y/OneGateApp/releases/download/onegate-pr-android-webview-file-picker-20260704-da84862/ios-final-launch-regression.png
