### PR TITLE
Prevent Android dApp window startup ANRs

### DIFF
--- a/OneGateApp/App.xaml.cs
+++ b/OneGateApp/App.xaml.cs
@@ -65,10 +65,36 @@ public partial class App : Application
         }
         else
         {
+#if ANDROID
+            if (appLinkAction is AppLinkAction action)
+            {
+                appLinkAction = null;
+                var loadingPage = new ContentPage
+                {
+                    Content = new ActivityIndicator
+                    {
+                        IsRunning = true,
+                        HorizontalOptions = LayoutOptions.Center,
+                        VerticalOptions = LayoutOptions.Center
+                    }
+                };
+                var window = CreateOneGateWindow(new NavigationPage(loadingPage));
+                window.Created += (_, _) => window.Dispatcher.DispatchDelayed(
+                    TimeSpan.FromMilliseconds(100),
+                    () => window.Page = action.GetPage(serviceProvider));
+                return window;
+            }
+#endif
             page = appLinkAction?.GetPage(serviceProvider)
                 ?? serviceProvider.GetServiceOrCreateInstance<AppShell>();
             appLinkAction = null;
         }
+
+        return CreateOneGateWindow(page);
+    }
+
+    static Window CreateOneGateWindow(Page page)
+    {
         return new Window(page)
         {
             Title = "OneGate",

--- a/OneGateApp/App.xaml.cs
+++ b/OneGateApp/App.xaml.cs
@@ -9,6 +9,10 @@ namespace NeoOrder.OneGate;
 
 public partial class App : Application
 {
+#if ANDROID
+    static readonly TimeSpan DAppWindowActivationDelay = TimeSpan.FromMilliseconds(100);
+#endif
+
     readonly IServiceProvider serviceProvider;
     readonly IWalletProvider walletProvider;
 
@@ -79,10 +83,16 @@ public partial class App : Application
                     }
                 };
                 var window = CreateOneGateWindow(new NavigationPage(loadingPage));
-                window.Created += (_, _) => window.Dispatcher.DispatchDelayed(
-                    TimeSpan.FromMilliseconds(100),
-                    () => window.Page = action.GetPage(serviceProvider));
+                window.Created += OnWindowCreated;
                 return window;
+
+                void OnWindowCreated(object? sender, EventArgs args)
+                {
+                    window.Created -= OnWindowCreated;
+                    window.Dispatcher.DispatchDelayed(
+                        DAppWindowActivationDelay,
+                        () => window.Page = action.GetPage(serviceProvider));
+                }
             }
 #endif
             page = appLinkAction?.GetPage(serviceProvider)


### PR DESCRIPTION
## Summary
- Draw a lightweight Android app-link window before constructing the dApp WebView page.
- Replace the placeholder with the existing app-link page after the first window is created.
- Preserve the existing `DocumentLinkActivity`, `NEW_DOCUMENT`, and multiple-dApp-window behavior.

## Why
Constructing a heavy game WebView before the new Android activity's first draw can trigger an input-dispatch timeout and ANR. This change gives the document activity a drawable first frame without routing the dApp back into the main Shell.

## Validation
- Android build passed.
- Android emulator: first dApp document window drew in 946 ms; a second independent dApp window drew in 371 ms.
- Android emulator: both document tasks remained present, Super Monkey Ball loaded, and no ANR or fatal exception was recorded.
- iOS simulator build, install, launch, and Super Monkey Ball load passed.

## Scope
One app file changed. No changes to dApp routing semantics, wallet APIs, WebView bridge behavior, or non-Android window creation.