### PR TITLE
Remove duplicate iOS asset inclusion

### DIFF
--- a/OneGateApp/OneGateApp.csproj
+++ b/OneGateApp/OneGateApp.csproj
@@ -62,7 +62,6 @@
 
 	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
 		<InterfaceDefinition Include="Platforms\iOS\LaunchScreen.storyboard" />
-		<ImageAsset Include="Platforms\iOS\Assets.xcassets\**\*.*" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Summary

- Remove the redundant explicit iOS asset catalog include.
- Keep MAUI's implicit asset catalog handling as the single source of inclusion.

## Root cause

The iOS asset catalog was included both implicitly by MAUI and explicitly by the project file, producing 16 `MT7158` duplicate `ImageAsset` warnings.

## Validation

- iPhone 17 / iOS 26.5 simulator: verified the launch branding and app assets still render correctly.
- Android 16 / API 36 emulator: verified launch branding and the home screen after the project-file change.
- `dotnet build` passed for `net10.0-ios` with 0 warnings and 0 errors; the 16 `MT7158` warnings are removed.
- `dotnet build` passed for `net10.0-android` with 0 warnings and 0 errors.

## Scope

This PR only removes the duplicate project item. It does not change any asset files or launch-screen design.
