### PR TITLE
Prevent submit reentry while busy

### DIFF
--- a/OneGateApp/Controls/Views/SpinnerButton.xaml
+++ b/OneGateApp/Controls/Views/SpinnerButton.xaml
@@ -2,8 +2,10 @@
 <ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:og="http://schemas.neoorder.org/onegate/controls"
+             xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
              x:Class="NeoOrder.OneGate.Controls.Views.SpinnerButton">
     <ContentView.Resources>
+        <toolkit:InvertedBoolConverter x:Key="InvertedBoolConverter" />
         <og:SpinnerButtonTextConverter x:Key="SpinnerButtonTextConverter" />
     </ContentView.Resources>
     <Grid BindingContext="{Binding Source={RelativeSource AncestorType={x:Type og:SpinnerButton}}}">
@@ -14,6 +16,7 @@
                 BackgroundColor="{Binding ButtonColor}"
                 BorderWidth="{Binding BorderWidth}"
                 BorderColor="{Binding BorderColor}"
+                IsEnabled="{Binding IsBusy, Converter={StaticResource InvertedBoolConverter}}"
                 SemanticProperties.Description="{Binding Text}"
                 Clicked="Button_Clicked">
             <VisualStateManager.VisualStateGroups>

--- a/OneGateApp/Controls/Views/SpinnerButton.xaml.cs
+++ b/OneGateApp/Controls/Views/SpinnerButton.xaml.cs
@@ -54,6 +54,7 @@ public partial class SpinnerButton : ContentView
 
     private void Button_Clicked(object sender, EventArgs e)
     {
+        if (IsBusy) return;
         Clicked?.Invoke(this, EventArgs.Empty);
     }
 }


### PR DESCRIPTION
## Summary
- ignore spinner button clicks while the control is already in its busy state
- prevent async submit handlers from being invoked again before the previous operation finishes

## Validation
- MD_APPLE_SDK_ROOT=/Applications/Xcode-26.5.0.app dotnet build OneGateApp/OneGateApp.csproj -f net10.0-ios -p:RuntimeIdentifier=iossimulator-arm64 -p:EnableCodeSigning=false -p:CodesignKey= -p:CodesignProvision= -p:ProvisioningType=automatic
- dotnet test OneGate.DebugProtocol.Tests/OneGate.DebugProtocol.Tests.csproj