### PR TITLE
Require authorization before disabling biometrics

### DIFF
--- a/OneGateApp/Pages/DisableBiometricPage.xaml.cs
+++ b/OneGateApp/Pages/DisableBiometricPage.xaml.cs
@@ -9,27 +9,18 @@ namespace NeoOrder.OneGate.Pages;
 public partial class DisableBiometricPage : ContentPage
 {
     readonly ApplicationDbContext dbContext;
-    readonly WalletAuthorizationService authorizationService;
+    readonly WalletAuthorizationService walletAuthorizationService;
 
-    public DisableBiometricPage(ApplicationDbContext dbContext, WalletAuthorizationService authorizationService)
+    public DisableBiometricPage(ApplicationDbContext dbContext, WalletAuthorizationService walletAuthorizationService)
     {
         this.dbContext = dbContext;
-        this.authorizationService = authorizationService;
+        this.walletAuthorizationService = walletAuthorizationService;
         InitializeComponent();
     }
 
     async void OnDisableClicked(object sender, EventArgs e)
     {
-        bool authorized;
-        try
-        {
-            authorized = await authorizationService.RequestAuthorizationAsync(this, Strings.DisableBiometric, Strings.DisableBiometricText);
-        }
-        catch (OperationCanceledException)
-        {
-            return;
-        }
-        if (!authorized) return;
+        if (!await walletAuthorizationService.RequestAuthorizationAsync(this, Strings.DisableBiometric, Strings.DisableBiometricText)) return;
 
         await dbContext.Settings.DeleteAsync("biometric/credential");
         GlobalStates.Invalidate<SettingsPage>();

--- a/OneGateApp/Pages/DisableBiometricPage.xaml.cs
+++ b/OneGateApp/Pages/DisableBiometricPage.xaml.cs
@@ -9,15 +9,28 @@ namespace NeoOrder.OneGate.Pages;
 public partial class DisableBiometricPage : ContentPage
 {
     readonly ApplicationDbContext dbContext;
+    readonly WalletAuthorizationService authorizationService;
 
-    public DisableBiometricPage(ApplicationDbContext dbContext)
+    public DisableBiometricPage(ApplicationDbContext dbContext, WalletAuthorizationService authorizationService)
     {
         this.dbContext = dbContext;
+        this.authorizationService = authorizationService;
         InitializeComponent();
     }
 
     async void OnDisableClicked(object sender, EventArgs e)
     {
+        bool authorized;
+        try
+        {
+            authorized = await authorizationService.RequestAuthorizationAsync(this, Strings.DisableBiometric, Strings.DisableBiometricText);
+        }
+        catch (OperationCanceledException)
+        {
+            return;
+        }
+        if (!authorized) return;
+
         await dbContext.Settings.DeleteAsync("biometric/credential");
         GlobalStates.Invalidate<SettingsPage>();
         await Shell.Current.GoToAsync("..");


### PR DESCRIPTION
## Summary
- require wallet authorization before deleting the saved biometric credential
- keep biometrics enabled when authorization is cancelled or denied

## Validation
- MD_APPLE_SDK_ROOT=/Applications/Xcode-26.5.0.app dotnet build OneGateApp/OneGateApp.csproj -f net10.0-ios -p:RuntimeIdentifier=iossimulator-arm64 -p:EnableCodeSigning=false -p:CodesignKey= -p:CodesignProvision= -p:ProvisioningType=automatic
- dotnet test OneGate.DebugProtocol.Tests/OneGate.DebugProtocol.Tests.csproj