### PR TITLE
Add switchable gallery layout to Games tab

### DIFF
--- a/OneGateApp/Data/DApp.cs
+++ b/OneGateApp/Data/DApp.cs
@@ -34,6 +34,7 @@ public class DApp : IComparable<DApp>, IShareable, IVersioned
 
     public bool IsGamingApp => !string.IsNullOrWhiteSpace(GameType);
     public bool IsRegularApp => !IsGamingApp;
+    public string? PreviewUrl => Previews?.FirstOrDefault(p => !string.IsNullOrWhiteSpace(p)) ?? IconUrl;
     public string? GameTypeDisplayName => LocalizeGameType(GameType);
     public Dictionary<string, string> NameLocalizer => field ??= JsonSerializer.Deserialize<Dictionary<string, string>>(Name)!;
     public Dictionary<string, string>? DescriptionLocalizer => Description is null ? null : field ??= JsonSerializer.Deserialize<Dictionary<string, string>>(Description);

--- a/OneGateApp/Data/DApp.cs
+++ b/OneGateApp/Data/DApp.cs
@@ -35,7 +35,7 @@ public class DApp : IComparable<DApp>, IShareable, IVersioned
 
     public bool IsGamingApp => !string.IsNullOrWhiteSpace(GameType);
     public bool IsRegularApp => !IsGamingApp;
-    public string? PreviewUrl => Previews?.FirstOrDefault(p => !string.IsNullOrWhiteSpace(p)) ?? IconUrl;
+    public string? PreviewUrl => Previews?.FirstOrDefault(p => !string.IsNullOrWhiteSpace(p));
     public string? GameTypeDisplayName => LocalizeGameType(GameType);
     public Dictionary<string, string> NameLocalizer => field ??= JsonSerializer.Deserialize<Dictionary<string, string>>(Name)!;
     public Dictionary<string, string>? DescriptionLocalizer => Description is null ? null : field ??= JsonSerializer.Deserialize<Dictionary<string, string>>(Description);

--- a/OneGateApp/Pages/GamingPage.xaml
+++ b/OneGateApp/Pages/GamingPage.xaml
@@ -73,7 +73,7 @@
                                         <DataTemplate x:DataType="og:DApp">
                                             <Border StyleClass="Card" WidthRequest="112" HeightRequest="120" Padding="0">
                                                 <Grid RowDefinitions="76,44">
-                                                    <Image Margin="14" Aspect="AspectFit">
+                                                    <Image Margin="14" Aspect="AspectFit" ZIndex="1">
                                                         <Image.Source>
                                                             <UriImageSource Uri="{Binding IconUrl}" CacheValidity="30:00:00:00" />
                                                         </Image.Source>
@@ -107,7 +107,7 @@
                                 <Border StyleClass="Card" HeightRequest="208" Padding="0">
                                     <Grid>
                                         <Image Source="gaming_banner.webp" Aspect="AspectFill" />
-                                        <Image Margin="52" Aspect="AspectFit">
+                                        <Image Margin="52" Aspect="AspectFit" ZIndex="1">
                                             <Image.Source>
                                                 <UriImageSource Uri="{Binding SpotlightGame.IconUrl}" CacheValidity="30:00:00:00" />
                                             </Image.Source>
@@ -161,7 +161,7 @@
                                         <DataTemplate x:DataType="og:DApp">
                                             <Border StyleClass="Card" WidthRequest="154" HeightRequest="132" Padding="0">
                                                 <Grid RowDefinitions="88,44">
-                                                    <Image Margin="16" Aspect="AspectFit">
+                                                    <Image Margin="16" Aspect="AspectFit" ZIndex="1">
                                                         <Image.Source>
                                                             <UriImageSource Uri="{Binding IconUrl}" CacheValidity="30:00:00:00" />
                                                         </Image.Source>
@@ -200,7 +200,7 @@
                             <Border StyleClass="Card" HeightRequest="164" Padding="0">
                                 <Grid RowDefinitions="112,52">
                                     <Grid>
-                                        <Image Margin="18" Aspect="AspectFit">
+                                        <Image Margin="18" Aspect="AspectFit" ZIndex="1">
                                             <Image.Source>
                                                 <UriImageSource Uri="{Binding IconUrl}" CacheValidity="30:00:00:00" />
                                             </Image.Source>

--- a/OneGateApp/Pages/GamingPage.xaml
+++ b/OneGateApp/Pages/GamingPage.xaml
@@ -9,6 +9,7 @@
     <ContentPage.Resources>
         <toolkit:InvertedBoolConverter x:Key="InvertedBoolConverter" />
         <og:LocalizerConverter x:Key="LocalizerConverter" />
+        <og:StringSelectConverter x:Key="StringSelectConverter" />
     </ContentPage.Resources>
     <ContentPage.ToolbarItems>
         <ToolbarItem Order="Primary" IconImageSource="{FontImageSource &#xe69a;, FontFamily=Icons, Color={toolkit:AppThemeResource Primary}}" Command="{x:Static og:Commands.ScanQRCode}" />
@@ -30,42 +31,291 @@
         </og:DAppSearchHandler>
     </Shell.SearchHandler>
     <RefreshView Margin="20,0" IsRefreshing="{Binding LoadingService.IsReloading}" Command="{Binding LoadingService}">
-        <CollectionView ItemsSource="{Binding GamesFiltered}" MinimumHeightRequest="20">
-            <CollectionView.Header>
-                <VerticalStackLayout Spacing="16">
-                    <Border StrokeShape="RoundRectangle 10" StrokeThickness="0" HeightRequest="132">
-                        <Image Source="gaming_banner.webp" Aspect="AspectFill" />
-                    </Border>
-                    <VerticalStackLayout Spacing="8" IsVisible="{Binding HasRecentGames}">
-                        <Label Text="{x:Static og:Strings.GamingRecentPlayed}" FontAttributes="Bold" />
-                        <CollectionView ItemsSource="{Binding GamesRecent}" HeightRequest="104">
-                            <CollectionView.ItemsLayout>
-                                <LinearItemsLayout Orientation="Horizontal" ItemSpacing="8" />
-                            </CollectionView.ItemsLayout>
-                            <CollectionView.ItemTemplate>
-                                <DataTemplate x:DataType="og:DApp">
-                                    <Border StyleClass="Card" WidthRequest="96" HeightRequest="96" Padding="8,10">
-                                        <Grid RowDefinitions="48,*" RowSpacing="4">
-                                            <Image WidthRequest="44" HeightRequest="44" Aspect="AspectFit" HorizontalOptions="Center" VerticalOptions="Center">
-                                                <Image.Source>
-                                                    <UriImageSource Uri="{Binding IconUrl}" CacheValidity="30:00:00:00" />
-                                                </Image.Source>
-                                            </Image>
-                                            <Label Grid.Row="1" Text="{Binding Name, Converter={StaticResource LocalizerConverter}}" FontAttributes="Bold" FontSize="12" MaxLines="1" LineBreakMode="TailTruncation" HorizontalTextAlignment="Center" VerticalTextAlignment="Center" />
+        <Grid RowDefinitions="auto,*" RowSpacing="12">
+            <Grid ColumnDefinitions="*,auto" ColumnSpacing="10">
+                <og:TabBar x:Name="gameTypeTabBar"
+                           Tabs="{Binding GameTypes}"
+                           IsVisible="{Binding HasGameTypeFilters}"
+                           Spacing="12"
+                           FontSize="12"
+                           HorizontalOptions="Fill"
+                           SelectedTabChanged="OnGameTypeChanged" />
+                <Button Grid.Column="1"
+                        StyleClass="Icon"
+                        Text="{Binding IsGalleryLayout, Converter={StaticResource StringSelectConverter}, ConverterParameter=&#xe792;&#xe7f4;}"
+                        FontSize="22"
+                        WidthRequest="40"
+                        HeightRequest="40"
+                        CornerRadius="10"
+                        BackgroundColor="{toolkit:AppThemeResource TextBox}"
+                        HorizontalOptions="End"
+                        SemanticProperties.Description="{Binding LayoutToggleDescription}"
+                        Clicked="OnLayoutToggleClicked" />
+            </Grid>
+
+            <Grid Grid.Row="1">
+                <CollectionView ItemsSource="{Binding GamesFiltered}"
+                                IsVisible="{Binding ShowGalleryLayout}"
+                                MinimumHeightRequest="20">
+                    <CollectionView.Header>
+                        <VerticalStackLayout Spacing="18" Padding="0,0,0,14">
+                            <Border StrokeShape="RoundRectangle 8" StrokeThickness="0" HeightRequest="132">
+                                <Image Source="gaming_banner.webp" Aspect="AspectFill" />
+                            </Border>
+
+                            <VerticalStackLayout Spacing="8" IsVisible="{Binding HasRecentGames}">
+                                <Label Text="{x:Static og:Strings.GamingRecentPlayed}" FontAttributes="Bold" FontSize="18" />
+                                <CollectionView ItemsSource="{Binding GamesRecent}" HeightRequest="126">
+                                    <CollectionView.ItemsLayout>
+                                        <LinearItemsLayout Orientation="Horizontal" ItemSpacing="10" />
+                                    </CollectionView.ItemsLayout>
+                                    <CollectionView.ItemTemplate>
+                                        <DataTemplate x:DataType="og:DApp">
+                                            <Border StyleClass="Card" WidthRequest="112" HeightRequest="120" Padding="0">
+                                                <Grid RowDefinitions="76,44">
+                                                    <Image Margin="14" Aspect="AspectFit">
+                                                        <Image.Source>
+                                                            <UriImageSource Uri="{Binding IconUrl}" CacheValidity="30:00:00:00" />
+                                                        </Image.Source>
+                                                    </Image>
+                                                    <Image Aspect="AspectFill">
+                                                        <Image.Source>
+                                                            <UriImageSource Uri="{Binding PreviewUrl}" CacheValidity="30:00:00:00" />
+                                                        </Image.Source>
+                                                    </Image>
+                                                    <Label Grid.Row="1"
+                                                           Margin="8,0"
+                                                           Text="{Binding Name, Converter={StaticResource LocalizerConverter}}"
+                                                           FontAttributes="Bold"
+                                                           FontSize="12"
+                                                           MaxLines="1"
+                                                           LineBreakMode="TailTruncation"
+                                                           HorizontalTextAlignment="Center"
+                                                           VerticalTextAlignment="Center" />
+                                                </Grid>
+                                                <Border.GestureRecognizers>
+                                                    <TapGestureRecognizer Command="{x:Static og:Commands.LaunchDApp}" CommandParameter="{Binding .}" />
+                                                </Border.GestureRecognizers>
+                                            </Border>
+                                        </DataTemplate>
+                                    </CollectionView.ItemTemplate>
+                                </CollectionView>
+                            </VerticalStackLayout>
+
+                            <VerticalStackLayout Spacing="8" IsVisible="{Binding HasSpotlightGame}">
+                                <Label Text="{x:Static og:Strings.GamingSpotlight}" FontAttributes="Bold" FontSize="18" />
+                                <Border StyleClass="Card" HeightRequest="208" Padding="0">
+                                    <Grid>
+                                        <Image Source="gaming_banner.webp" Aspect="AspectFill" />
+                                        <Image Margin="52" Aspect="AspectFit">
+                                            <Image.Source>
+                                                <UriImageSource Uri="{Binding SpotlightGame.IconUrl}" CacheValidity="30:00:00:00" />
+                                            </Image.Source>
+                                        </Image>
+                                        <Image Aspect="AspectFill">
+                                            <Image.Source>
+                                                <UriImageSource Uri="{Binding SpotlightGame.PreviewUrl}" CacheValidity="30:00:00:00" />
+                                            </Image.Source>
+                                        </Image>
+                                        <Grid Padding="16"
+                                              ColumnDefinitions="*,auto"
+                                              ColumnSpacing="12"
+                                              BackgroundColor="#99000000"
+                                              VerticalOptions="End">
+                                            <VerticalStackLayout Spacing="2" VerticalOptions="Center">
+                                                <Label Text="{Binding SpotlightGame.Name, Converter={StaticResource LocalizerConverter}}"
+                                                       TextColor="White"
+                                                       FontAttributes="Bold"
+                                                       FontSize="20"
+                                                       MaxLines="1"
+                                                       LineBreakMode="TailTruncation" />
+                                                <Label Text="{Binding SpotlightGame.GameTypeDisplayName}"
+                                                       TextColor="#DDE4EE"
+                                                       FontSize="12"
+                                                       MaxLines="1"
+                                                       LineBreakMode="TailTruncation" />
+                                            </VerticalStackLayout>
+                                            <Button Grid.Column="1"
+                                                    Text="{x:Static og:Strings.Open}"
+                                                    TextColor="White"
+                                                    Command="{x:Static og:Commands.LaunchDApp}"
+                                                    CommandParameter="{Binding SpotlightGame}"
+                                                    Padding="18,10"
+                                                    MinimumHeightRequest="44"
+                                                    VerticalOptions="Center" />
                                         </Grid>
-                                        <Border.GestureRecognizers>
-                                            <TapGestureRecognizer Command="{x:Static og:Commands.LaunchDApp}" CommandParameter="{Binding .}" />
-                                        </Border.GestureRecognizers>
-                                    </Border>
-                                </DataTemplate>
-                            </CollectionView.ItemTemplate>
-                        </CollectionView>
-                    </VerticalStackLayout>
-                    <og:TabBar x:Name="gameTypeTabBar" Tabs="{Binding GameTypes}" IsVisible="{Binding HasGameTypeFilters}" Spacing="18" Margin="0,10" SelectedTabChanged="OnGameTypeChanged" />
-                </VerticalStackLayout>
-            </CollectionView.Header>
-            <CollectionView.EmptyView>
-                <Border StyleClass="Card" HeightRequest="120">
+                                        <Grid.GestureRecognizers>
+                                            <TapGestureRecognizer Command="{x:Static og:Commands.LaunchDApp}" CommandParameter="{Binding SpotlightGame}" />
+                                        </Grid.GestureRecognizers>
+                                    </Grid>
+                                </Border>
+                            </VerticalStackLayout>
+
+                            <VerticalStackLayout Spacing="8" IsVisible="{Binding HasQuickPicks}">
+                                <Label Text="{x:Static og:Strings.GamingQuickPicks}" FontAttributes="Bold" FontSize="18" />
+                                <CollectionView ItemsSource="{Binding GamesQuickPicks}" HeightRequest="138">
+                                    <CollectionView.ItemsLayout>
+                                        <LinearItemsLayout Orientation="Horizontal" ItemSpacing="10" />
+                                    </CollectionView.ItemsLayout>
+                                    <CollectionView.ItemTemplate>
+                                        <DataTemplate x:DataType="og:DApp">
+                                            <Border StyleClass="Card" WidthRequest="154" HeightRequest="132" Padding="0">
+                                                <Grid RowDefinitions="88,44">
+                                                    <Image Margin="16" Aspect="AspectFit">
+                                                        <Image.Source>
+                                                            <UriImageSource Uri="{Binding IconUrl}" CacheValidity="30:00:00:00" />
+                                                        </Image.Source>
+                                                    </Image>
+                                                    <Image Aspect="AspectFill">
+                                                        <Image.Source>
+                                                            <UriImageSource Uri="{Binding PreviewUrl}" CacheValidity="30:00:00:00" />
+                                                        </Image.Source>
+                                                    </Image>
+                                                    <Label Grid.Row="1"
+                                                           Margin="10,0"
+                                                           Text="{Binding Name, Converter={StaticResource LocalizerConverter}}"
+                                                           FontAttributes="Bold"
+                                                           FontSize="12"
+                                                           MaxLines="1"
+                                                           LineBreakMode="TailTruncation"
+                                                           VerticalTextAlignment="Center" />
+                                                </Grid>
+                                                <Border.GestureRecognizers>
+                                                    <TapGestureRecognizer Command="{x:Static og:Commands.LaunchDApp}" CommandParameter="{Binding .}" />
+                                                </Border.GestureRecognizers>
+                                            </Border>
+                                        </DataTemplate>
+                                    </CollectionView.ItemTemplate>
+                                </CollectionView>
+                            </VerticalStackLayout>
+
+                            <Label Text="{x:Static og:Strings.GamingAllGames}" FontAttributes="Bold" FontSize="18" />
+                        </VerticalStackLayout>
+                    </CollectionView.Header>
+                    <CollectionView.ItemsLayout>
+                        <GridItemsLayout x:Name="GalleryItemsLayout" Orientation="Vertical" Span="3" HorizontalItemSpacing="10" VerticalItemSpacing="14" />
+                    </CollectionView.ItemsLayout>
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate x:DataType="og:DApp">
+                            <Border StyleClass="Card" HeightRequest="164" Padding="0">
+                                <Grid RowDefinitions="112,52">
+                                    <Grid>
+                                        <Image Margin="18" Aspect="AspectFit">
+                                            <Image.Source>
+                                                <UriImageSource Uri="{Binding IconUrl}" CacheValidity="30:00:00:00" />
+                                            </Image.Source>
+                                        </Image>
+                                        <Image Aspect="AspectFill">
+                                            <Image.Source>
+                                                <UriImageSource Uri="{Binding PreviewUrl}" CacheValidity="30:00:00:00" />
+                                            </Image.Source>
+                                        </Image>
+                                        <Button StyleClass="Icon"
+                                                Text="&#xe605;"
+                                                FontSize="16"
+                                                WidthRequest="32"
+                                                HeightRequest="32"
+                                                CornerRadius="16"
+                                                Margin="6"
+                                                Padding="0"
+                                                BackgroundColor="{toolkit:AppThemeResource Panel}"
+                                                HorizontalOptions="End"
+                                                VerticalOptions="Start"
+                                                Clicked="OnDetailsClicked"
+                                                CommandParameter="{Binding .}" />
+                                    </Grid>
+                                    <VerticalStackLayout Grid.Row="1" Margin="9,6" Spacing="1">
+                                        <Label Text="{Binding Name, Converter={StaticResource LocalizerConverter}}"
+                                               FontAttributes="Bold"
+                                               FontSize="12"
+                                               MaxLines="1"
+                                               LineBreakMode="TailTruncation" />
+                                        <Label StyleClass="Secondary"
+                                               Text="{Binding GameTypeDisplayName}"
+                                               FontSize="10"
+                                               MaxLines="1"
+                                               LineBreakMode="TailTruncation" />
+                                    </VerticalStackLayout>
+                                    <Grid.GestureRecognizers>
+                                        <TapGestureRecognizer Command="{x:Static og:Commands.LaunchDApp}" CommandParameter="{Binding .}" />
+                                    </Grid.GestureRecognizers>
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+
+                <CollectionView ItemsSource="{Binding GamesFiltered}"
+                                IsVisible="{Binding ShowListLayout}"
+                                MinimumHeightRequest="20">
+                    <CollectionView.Header>
+                        <VerticalStackLayout Spacing="16" Padding="0,0,0,8">
+                            <Border StrokeShape="RoundRectangle 8" StrokeThickness="0" HeightRequest="132">
+                                <Image Source="gaming_banner.webp" Aspect="AspectFill" />
+                            </Border>
+                            <VerticalStackLayout Spacing="8" IsVisible="{Binding HasRecentGames}">
+                                <Label Text="{x:Static og:Strings.GamingRecentPlayed}" FontAttributes="Bold" />
+                                <CollectionView ItemsSource="{Binding GamesRecent}" HeightRequest="104">
+                                    <CollectionView.ItemsLayout>
+                                        <LinearItemsLayout Orientation="Horizontal" ItemSpacing="8" />
+                                    </CollectionView.ItemsLayout>
+                                    <CollectionView.ItemTemplate>
+                                        <DataTemplate x:DataType="og:DApp">
+                                            <Border StyleClass="Card" WidthRequest="96" HeightRequest="96" Padding="8,10">
+                                                <Grid RowDefinitions="48,*" RowSpacing="4">
+                                                    <Image WidthRequest="44" HeightRequest="44" Aspect="AspectFit" HorizontalOptions="Center" VerticalOptions="Center">
+                                                        <Image.Source>
+                                                            <UriImageSource Uri="{Binding IconUrl}" CacheValidity="30:00:00:00" />
+                                                        </Image.Source>
+                                                    </Image>
+                                                    <Label Grid.Row="1" Text="{Binding Name, Converter={StaticResource LocalizerConverter}}" FontAttributes="Bold" FontSize="12" MaxLines="1" LineBreakMode="TailTruncation" HorizontalTextAlignment="Center" VerticalTextAlignment="Center" />
+                                                </Grid>
+                                                <Border.GestureRecognizers>
+                                                    <TapGestureRecognizer Command="{x:Static og:Commands.LaunchDApp}" CommandParameter="{Binding .}" />
+                                                </Border.GestureRecognizers>
+                                            </Border>
+                                        </DataTemplate>
+                                    </CollectionView.ItemTemplate>
+                                </CollectionView>
+                            </VerticalStackLayout>
+                        </VerticalStackLayout>
+                    </CollectionView.Header>
+                    <CollectionView.ItemsLayout>
+                        <GridItemsLayout x:Name="GamesItemsLayout" Orientation="Vertical" Span="1" HorizontalItemSpacing="28" />
+                    </CollectionView.ItemsLayout>
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate x:DataType="og:DApp">
+                            <Grid RowDefinitions="*,1" HeightRequest="96">
+                                <Grid ColumnDefinitions="60,*,40" ColumnSpacing="12" Padding="0,8" MinimumHeightRequest="88">
+                                    <Image WidthRequest="56" HeightRequest="56" Aspect="AspectFit" HorizontalOptions="Center" VerticalOptions="Center">
+                                        <Image.Source>
+                                            <UriImageSource Uri="{Binding IconUrl}" CacheValidity="30:00:00:00" />
+                                        </Image.Source>
+                                    </Image>
+                                    <VerticalStackLayout Grid.Column="1" Spacing="3" VerticalOptions="Center">
+                                        <Label Text="{Binding Name, Converter={StaticResource LocalizerConverter}}" FontAttributes="Bold" FontSize="14" LineBreakMode="TailTruncation" MaxLines="1" />
+                                        <HorizontalStackLayout Spacing="6">
+                                            <Label StyleClass="Link" Text="{Binding Developer}" FontSize="11" LineBreakMode="TailTruncation" MaxLines="1" />
+                                            <Label StyleClass="Secondary" Text="·" FontSize="11" />
+                                            <Label StyleClass="Secondary" Text="{Binding GameTypeDisplayName}" FontSize="11" LineBreakMode="TailTruncation" MaxLines="1" />
+                                        </HorizontalStackLayout>
+                                        <Label StyleClass="Secondary" Text="{Binding Description, Converter={StaticResource LocalizerConverter}}" FontSize="11" MaxLines="2" LineBreakMode="TailTruncation" />
+                                    </VerticalStackLayout>
+                                    <Button Grid.Column="2" StyleClass="Icon, IconSecondary" Text="&#xe605;" FontSize="18" Margin="-12" Padding="12" VerticalOptions="Center" Clicked="OnDetailsClicked" CommandParameter="{Binding .}" />
+                                </Grid>
+                                <BoxView Grid.Row="1" Margin="72,0,0,0" HeightRequest="1" Color="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray600}}" />
+                                <Grid.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{x:Static og:Commands.LaunchDApp}" CommandParameter="{Binding .}" />
+                                </Grid.GestureRecognizers>
+                            </Grid>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+
+                <Border StyleClass="Card"
+                        IsVisible="{Binding ShowEmptyState}"
+                        HeightRequest="120"
+                        VerticalOptions="Start">
                     <Grid>
                         <Label IsVisible="{Binding LoadingService.IsLoading}" HorizontalOptions="Center" VerticalOptions="Center">
                             <Label.FormattedText>
@@ -75,43 +325,16 @@
                                 </FormattedString>
                             </Label.FormattedText>
                         </Label>
-                        <VerticalStackLayout Spacing="4" IsVisible="{Binding LoadingService.IsLoading, Converter={StaticResource InvertedBoolConverter}}" HorizontalOptions="Center" VerticalOptions="Center">
+                        <VerticalStackLayout Spacing="4"
+                                             IsVisible="{Binding LoadingService.IsLoading, Converter={StaticResource InvertedBoolConverter}}"
+                                             HorizontalOptions="Center"
+                                             VerticalOptions="Center">
                             <Label Text="{x:Static og:Strings.DefaultEmptyViewMessage}" HorizontalTextAlignment="Center" />
                             <Label StyleClass="Secondary" Text="{x:Static og:Strings.GamingEmptyState}" FontSize="12" HorizontalTextAlignment="Center" />
                         </VerticalStackLayout>
                     </Grid>
                 </Border>
-            </CollectionView.EmptyView>
-            <CollectionView.ItemsLayout>
-                <GridItemsLayout x:Name="GamesItemsLayout" Orientation="Vertical" Span="1" HorizontalItemSpacing="28" />
-            </CollectionView.ItemsLayout>
-            <CollectionView.ItemTemplate>
-                <DataTemplate x:DataType="og:DApp">
-                    <Grid RowDefinitions="*,1" HeightRequest="96">
-                        <Grid ColumnDefinitions="60,*,40" ColumnSpacing="12" Padding="0,8" MinimumHeightRequest="88">
-                            <Image WidthRequest="56" HeightRequest="56" Aspect="AspectFit" HorizontalOptions="Center" VerticalOptions="Center">
-                                <Image.Source>
-                                    <UriImageSource Uri="{Binding IconUrl}" CacheValidity="30:00:00:00" />
-                                </Image.Source>
-                            </Image>
-                            <VerticalStackLayout Grid.Column="1" Spacing="3" VerticalOptions="Center">
-                                <Label Text="{Binding Name, Converter={StaticResource LocalizerConverter}}" FontAttributes="Bold" FontSize="14" LineBreakMode="TailTruncation" MaxLines="1" />
-                                <HorizontalStackLayout Spacing="6">
-                                    <Label StyleClass="Link" Text="{Binding Developer}" FontSize="11" LineBreakMode="TailTruncation" MaxLines="1" />
-                                    <Label StyleClass="Secondary" Text="·" FontSize="11" />
-                                    <Label StyleClass="Secondary" Text="{Binding GameTypeDisplayName}" FontSize="11" LineBreakMode="TailTruncation" MaxLines="1" />
-                                </HorizontalStackLayout>
-                                <Label StyleClass="Secondary" Text="{Binding Description, Converter={StaticResource LocalizerConverter}}" FontSize="11" MaxLines="2" LineBreakMode="TailTruncation" />
-                            </VerticalStackLayout>
-                            <Button Grid.Column="2" StyleClass="Icon, IconSecondary" Text="&#xe605;" FontSize="18" Margin="-12" Padding="12" VerticalOptions="Center" Clicked="OnDetailsClicked" CommandParameter="{Binding .}" />
-                        </Grid>
-                        <BoxView Grid.Row="1" Margin="72,0,0,0" HeightRequest="1" Color="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray600}}" />
-                        <Grid.GestureRecognizers>
-                            <TapGestureRecognizer Command="{x:Static og:Commands.LaunchDApp}" CommandParameter="{Binding .}" />
-                        </Grid.GestureRecognizers>
-                    </Grid>
-                </DataTemplate>
-            </CollectionView.ItemTemplate>
-        </CollectionView>
+            </Grid>
+        </Grid>
     </RefreshView>
 </ContentPage>

--- a/OneGateApp/Pages/GamingPage.xaml
+++ b/OneGateApp/Pages/GamingPage.xaml
@@ -30,8 +30,9 @@
             </og:DAppSearchHandler.ItemTemplate>
         </og:DAppSearchHandler>
     </Shell.SearchHandler>
-    <RefreshView Margin="20,0" IsRefreshing="{Binding LoadingService.IsReloading}" Command="{Binding LoadingService}">
-        <Grid RowDefinitions="auto,*" RowSpacing="12">
+    <Grid>
+        <RefreshView Margin="20,0" IsRefreshing="{Binding LoadingService.IsReloading}" Command="{Binding LoadingService}">
+            <Grid RowDefinitions="auto,*" RowSpacing="12">
             <Grid ColumnDefinitions="*,auto" ColumnSpacing="10">
                 <og:TabBar x:Name="gameTypeTabBar"
                            Tabs="{Binding GameTypes}"
@@ -192,6 +193,9 @@
                             <Label Text="{x:Static og:Strings.GamingAllGames}" FontAttributes="Bold" FontSize="18" />
                         </VerticalStackLayout>
                     </CollectionView.Header>
+                    <CollectionView.Footer>
+                        <BoxView HeightRequest="76" />
+                    </CollectionView.Footer>
                     <CollectionView.ItemsLayout>
                         <GridItemsLayout x:Name="GalleryItemsLayout" Orientation="Vertical" Span="3" HorizontalItemSpacing="10" VerticalItemSpacing="14" />
                     </CollectionView.ItemsLayout>
@@ -280,6 +284,9 @@
                             </VerticalStackLayout>
                         </VerticalStackLayout>
                     </CollectionView.Header>
+                    <CollectionView.Footer>
+                        <BoxView HeightRequest="76" />
+                    </CollectionView.Footer>
                     <CollectionView.ItemsLayout>
                         <GridItemsLayout x:Name="GamesItemsLayout" Orientation="Vertical" Span="1" HorizontalItemSpacing="28" />
                     </CollectionView.ItemsLayout>
@@ -334,7 +341,27 @@
                         </VerticalStackLayout>
                     </Grid>
                 </Border>
+                </Grid>
             </Grid>
-        </Grid>
-    </RefreshView>
+        </RefreshView>
+
+        <ImageButton Source="gaming_random.svg"
+                     WidthRequest="58"
+                     HeightRequest="58"
+                     CornerRadius="29"
+                     Padding="15"
+                     Margin="20,0,20,20"
+                     BackgroundColor="{AppThemeBinding Light=#151922, Dark=#4B7BFF}"
+                     HorizontalOptions="End"
+                     VerticalOptions="End"
+                     ZIndex="10"
+                     IsVisible="{Binding HasFilteredGames}"
+                     SemanticProperties.Description="{x:Static og:Strings.GamingRandomPlay}"
+                     ToolTipProperties.Text="{x:Static og:Strings.GamingRandomPlay}"
+                     Clicked="OnRandomGameClicked">
+            <ImageButton.Shadow>
+                <Shadow Brush="Black" Offset="0,6" Radius="12" Opacity="0.24" />
+            </ImageButton.Shadow>
+        </ImageButton>
+    </Grid>
 </ContentPage>

--- a/OneGateApp/Pages/GamingPage.xaml.cs
+++ b/OneGateApp/Pages/GamingPage.xaml.cs
@@ -62,7 +62,9 @@ public partial class GamingPage : ContentPage
         }
     } = true;
     public bool IsListLayout => !IsGalleryLayout;
-    public string LayoutToggleDescription => IsGalleryLayout ? Strings.GamingList : Strings.GamingGallery;
+    public string LayoutToggleDescription => IsGalleryLayout
+        ? Strings.GamingSwitchToListLayout
+        : Strings.GamingSwitchToGalleryLayout;
     public bool ShowGalleryLayout => IsGalleryLayout && GamesFiltered.Length > 0;
     public bool ShowListLayout => IsListLayout && GamesFiltered.Length > 0;
     public bool ShowEmptyState => GamesFiltered.Length == 0;

--- a/OneGateApp/Pages/GamingPage.xaml.cs
+++ b/OneGateApp/Pages/GamingPage.xaml.cs
@@ -1,3 +1,5 @@
+using CommunityToolkit.Maui.Alerts;
+using NeoOrder.OneGate.Controls;
 using NeoOrder.OneGate.Data;
 using NeoOrder.OneGate.Models;
 using NeoOrder.OneGate.Properties;
@@ -9,9 +11,14 @@ namespace NeoOrder.OneGate.Pages;
 
 public partial class GamingPage : ContentPage
 {
+    const string LayoutPreferenceKey = "gaming/layout";
+    const string GalleryLayout = "gallery";
+    const string ListLayout = "list";
     const double GameItemMinWidth = 520;
+    const double GalleryItemMinWidth = 112;
     const double HorizontalPageMargin = 40;
     const int MaxGameColumns = 3;
+    const int MaxGalleryColumns = 4;
 
     readonly ApplicationDbContext dbContext;
     bool allowRestrictedContent;
@@ -23,9 +30,44 @@ public partial class GamingPage : ContentPage
     public ObservableCollection<DApp> GamesRecent { get; private set { field = value; OnPropertyChanged(); } } = [];
     public bool HasRecentGames { get; private set { field = value; OnPropertyChanged(); } }
     public DApp[] Games { get; private set { field = value; OnPropertyChanged(); } } = [];
-    public DApp[] GamesFiltered { get; private set { field = value; OnPropertyChanged(); } } = [];
+    public DApp[] GamesFiltered
+    {
+        get;
+        private set
+        {
+            field = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(ShowGalleryLayout));
+            OnPropertyChanged(nameof(ShowListLayout));
+            OnPropertyChanged(nameof(ShowEmptyState));
+        }
+    } = [];
+    public DApp[] GamesQuickPicks { get; private set { field = value; OnPropertyChanged(); OnPropertyChanged(nameof(HasQuickPicks)); } } = [];
+    public bool HasQuickPicks => GamesQuickPicks.Length > 0;
+    public DApp? SpotlightGame { get; private set { field = value; OnPropertyChanged(); OnPropertyChanged(nameof(HasSpotlightGame)); } }
+    public bool HasSpotlightGame => SpotlightGame is not null;
     public string[] GameTypes { get; private set { field = value; OnPropertyChanged(); } } = [Strings.All];
     public bool HasGameTypeFilters { get; private set { field = value; OnPropertyChanged(); } }
+    public bool IsGalleryLayout
+    {
+        get;
+        private set
+        {
+            field = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(IsListLayout));
+            OnPropertyChanged(nameof(LayoutToggleDescription));
+            OnPropertyChanged(nameof(ShowGalleryLayout));
+            OnPropertyChanged(nameof(ShowListLayout));
+        }
+    } = true;
+    public bool IsListLayout => !IsGalleryLayout;
+    public string LayoutToggleDescription => IsGalleryLayout ? Strings.GamingList : Strings.GamingGallery;
+    public bool ShowGalleryLayout => IsGalleryLayout && GamesFiltered.Length > 0;
+    public bool ShowListLayout => IsListLayout && GamesFiltered.Length > 0;
+    public bool ShowEmptyState => GamesFiltered.Length == 0;
+
+    bool layoutPreferenceLoaded;
 
     public GamingPage(IServiceProvider serviceProvider, ApplicationDbContext dbContext)
     {
@@ -54,6 +96,7 @@ public partial class GamingPage : ContentPage
     {
         base.OnSizeAllocated(width, height);
         UpdateGamesItemsLayout(width);
+        UpdateGalleryItemsLayout(width);
     }
 
     async Task LoadSettingsAsync()
@@ -61,6 +104,8 @@ public partial class GamingPage : ContentPage
         allowRestrictedContent = await DAppCatalogPolicy.GetAllowRestrictedContentAsync(dbContext);
         developerModeEnabled = await DAppCatalogPolicy.GetDeveloperModeEnabledAsync(dbContext);
         GamesIdRecent = await dbContext.Settings.GetAsync<List<int>>("dapps/recent") ?? [];
+        IsGalleryLayout = !string.Equals(await dbContext.Settings.GetAsync(LayoutPreferenceKey), ListLayout, StringComparison.OrdinalIgnoreCase);
+        layoutPreferenceLoaded = true;
     }
 
     async Task LoadDAppsAsync()
@@ -80,6 +125,15 @@ public partial class GamingPage : ContentPage
         var span = Math.Clamp((int)(contentWidth / GameItemMinWidth), 1, MaxGameColumns);
         if (GamesItemsLayout.Span != span)
             GamesItemsLayout.Span = span;
+    }
+
+    void UpdateGalleryItemsLayout(double pageWidth)
+    {
+        if (pageWidth <= 0) return;
+        var contentWidth = Math.Max(0, pageWidth - HorizontalPageMargin);
+        var span = Math.Clamp((int)(contentWidth / GalleryItemMinWidth), 2, MaxGalleryColumns);
+        if (GalleryItemsLayout.Span != span)
+            GalleryItemsLayout.Span = span;
     }
 
     void OnDataLoaded(object? sender, EventArgs e)
@@ -110,11 +164,23 @@ public partial class GamingPage : ContentPage
         HasRecentGames = GamesRecent.Count > 0;
     }
 
+    void UpdateGallerySections()
+    {
+        SpotlightGame = GamesFiltered
+            .FirstOrDefault(p => p.Previews?.Any(url => !string.IsNullOrWhiteSpace(url)) == true)
+            ?? GamesFiltered.FirstOrDefault();
+        GamesQuickPicks = GamesFiltered
+            .Where(p => !ReferenceEquals(p, SpotlightGame))
+            .Take(6)
+            .ToArray();
+    }
+
     void ApplyGameTypeFilter(TabBar tabBar)
     {
         if (tabBar.Tabs is not { Count: > 0 } tabs)
         {
             GamesFiltered = Games;
+            UpdateGallerySections();
             return;
         }
 
@@ -127,12 +193,32 @@ public partial class GamingPage : ContentPage
         if (tabBar.SelectedTab == tabs[0])
         {
             GamesFiltered = Games;
+            UpdateGallerySections();
             return;
         }
 
         GamesFiltered = Games
             .Where(p => string.Equals(p.GameTypeDisplayName, tabBar.SelectedTab, StringComparison.CurrentCulture))
             .ToArray();
+        UpdateGallerySections();
+    }
+
+    async void OnLayoutToggleClicked(object sender, EventArgs e)
+    {
+        if (!layoutPreferenceLoaded)
+            return;
+
+        bool previousLayout = IsGalleryLayout;
+        IsGalleryLayout = !previousLayout;
+        try
+        {
+            await dbContext.Settings.PutAsync(LayoutPreferenceKey, IsGalleryLayout ? GalleryLayout : ListLayout);
+        }
+        catch (Exception ex)
+        {
+            IsGalleryLayout = previousLayout;
+            await Toast.Show(ex.Message);
+        }
     }
 
     async void OnDetailsClicked(object sender, EventArgs e)

--- a/OneGateApp/Pages/GamingPage.xaml.cs
+++ b/OneGateApp/Pages/GamingPage.xaml.cs
@@ -23,6 +23,7 @@ public partial class GamingPage : ContentPage
     readonly ApplicationDbContext dbContext;
     bool allowRestrictedContent;
     bool developerModeEnabled;
+    int? lastRandomGameId;
 
     public LoadingService LoadingService { get; }
     public CachedCollection<DApp> DApps { get; }
@@ -40,6 +41,7 @@ public partial class GamingPage : ContentPage
             OnPropertyChanged(nameof(ShowGalleryLayout));
             OnPropertyChanged(nameof(ShowListLayout));
             OnPropertyChanged(nameof(ShowEmptyState));
+            OnPropertyChanged(nameof(HasFilteredGames));
         }
     } = [];
     public DApp[] GamesQuickPicks { get; private set { field = value; OnPropertyChanged(); OnPropertyChanged(nameof(HasQuickPicks)); } } = [];
@@ -68,6 +70,7 @@ public partial class GamingPage : ContentPage
     public bool ShowGalleryLayout => IsGalleryLayout && GamesFiltered.Length > 0;
     public bool ShowListLayout => IsListLayout && GamesFiltered.Length > 0;
     public bool ShowEmptyState => GamesFiltered.Length == 0;
+    public bool HasFilteredGames => GamesFiltered.Length > 0;
 
     bool layoutPreferenceLoaded;
 
@@ -229,5 +232,23 @@ public partial class GamingPage : ContentPage
         {
             ["dapp"] = ((Button)sender).CommandParameter
         });
+    }
+
+    async void OnRandomGameClicked(object sender, EventArgs e)
+    {
+        if (GamesFiltered.Length == 0)
+            return;
+
+        DApp[] candidates = GamesFiltered;
+        if (candidates.Length > 1 && lastRandomGameId is int previousId)
+        {
+            DApp[] withoutPrevious = candidates.Where(p => p.Id != previousId).ToArray();
+            if (withoutPrevious.Length > 0)
+                candidates = withoutPrevious;
+        }
+
+        DApp game = candidates[Random.Shared.Next(candidates.Length)];
+        lastRandomGameId = game.Id;
+        await Commands.LaunchDApp.ExecuteAsync(game);
     }
 }

--- a/OneGateApp/Properties/Strings.Designer.cs
+++ b/OneGateApp/Properties/Strings.Designer.cs
@@ -1463,6 +1463,51 @@ namespace NeoOrder.OneGate.Properties {
         }
 
         /// <summary>
+        ///   查找类似 Gallery 的本地化字符串。
+        /// </summary>
+        internal static string GamingGallery {
+            get {
+                return ResourceManager.GetString("GamingGallery", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   查找类似 List 的本地化字符串。
+        /// </summary>
+        internal static string GamingList {
+            get {
+                return ResourceManager.GetString("GamingList", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   查找类似 Quick picks 的本地化字符串。
+        /// </summary>
+        internal static string GamingQuickPicks {
+            get {
+                return ResourceManager.GetString("GamingQuickPicks", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   查找类似 All games 的本地化字符串。
+        /// </summary>
+        internal static string GamingAllGames {
+            get {
+                return ResourceManager.GetString("GamingAllGames", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   查找类似 Game spotlight 的本地化字符串。
+        /// </summary>
+        internal static string GamingSpotlight {
+            get {
+                return ResourceManager.GetString("GamingSpotlight", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   查找类似 General 的本地化字符串。
         /// </summary>
         internal static string General {

--- a/OneGateApp/Properties/Strings.Designer.cs
+++ b/OneGateApp/Properties/Strings.Designer.cs
@@ -1490,6 +1490,24 @@ namespace NeoOrder.OneGate.Properties {
         }
 
         /// <summary>
+        ///   查找类似 Switch to gallery layout 的本地化字符串。
+        /// </summary>
+        internal static string GamingSwitchToGalleryLayout {
+            get {
+                return ResourceManager.GetString("GamingSwitchToGalleryLayout", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   查找类似 Switch to list layout 的本地化字符串。
+        /// </summary>
+        internal static string GamingSwitchToListLayout {
+            get {
+                return ResourceManager.GetString("GamingSwitchToListLayout", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   查找类似 Quick picks 的本地化字符串。
         /// </summary>
         internal static string GamingQuickPicks {

--- a/OneGateApp/Properties/Strings.Designer.cs
+++ b/OneGateApp/Properties/Strings.Designer.cs
@@ -1553,6 +1553,15 @@ namespace NeoOrder.OneGate.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Play a random game.
+        /// </summary>
+        internal static string GamingRandomPlay {
+            get {
+                return ResourceManager.GetString("GamingRandomPlay", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   查找类似 Pull down to refresh the game catalog. 的本地化字符串。
         /// </summary>
         internal static string GamingEmptyState {

--- a/OneGateApp/Properties/Strings.de.resx
+++ b/OneGateApp/Properties/Strings.de.resx
@@ -1255,4 +1255,6 @@ Es wird empfohlen, den NEP-2-Schlüssel und das Passwort getrennt aufzubewahren 
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>Warten auf einen vertrauenswürdigen Remote-Debugger</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Remote-Debugger koppeln</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>Remote-Debugger „{0}“ fordert Zugriff an. Fingerabdruck: {1}. Nur autorisieren, wenn du diesem Remote-Debugger vertraust.</value></data>
+  <data name="GamingSwitchToGalleryLayout" xml:space="preserve"><value>Zum Galerie-Layout wechseln</value></data>
+  <data name="GamingSwitchToListLayout" xml:space="preserve"><value>Zum Listen-Layout wechseln</value></data>
 </root>

--- a/OneGateApp/Properties/Strings.de.resx
+++ b/OneGateApp/Properties/Strings.de.resx
@@ -843,6 +843,9 @@ Mit dem Fortfahren bestätigen Sie, dass Sie alle damit verbundenen Risiken voll
   <data name="Gaming" xml:space="preserve">
     <value>Gaming</value>
   </data>
+  <data name="GamingRandomPlay" xml:space="preserve">
+    <value>Ein zufälliges Spiel starten</value>
+  </data>
   <data name="GamingEmptyState" xml:space="preserve">
     <value>Zum Aktualisieren des Spielekatalogs nach unten ziehen.</value>
   </data>

--- a/OneGateApp/Properties/Strings.es.resx
+++ b/OneGateApp/Properties/Strings.es.resx
@@ -1255,4 +1255,6 @@ Se recomienda almacenar la clave NEP-2 y la contraseña por separado y realizar 
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>Esperando un depurador remoto de confianza</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Emparejar depurador remoto</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>El depurador remoto «{0}» solicita acceso. Huella: {1}. Autoriza solo si confías en este depurador remoto.</value></data>
+  <data name="GamingSwitchToGalleryLayout" xml:space="preserve"><value>Cambiar al diseño de galería</value></data>
+  <data name="GamingSwitchToListLayout" xml:space="preserve"><value>Cambiar al diseño de lista</value></data>
 </root>

--- a/OneGateApp/Properties/Strings.es.resx
+++ b/OneGateApp/Properties/Strings.es.resx
@@ -843,6 +843,9 @@ Al continuar, usted reconoce que comprende plenamente y acepta todos los riesgos
   <data name="Gaming" xml:space="preserve">
     <value>Juegos</value>
   </data>
+  <data name="GamingRandomPlay" xml:space="preserve">
+    <value>Jugar a un juego aleatorio</value>
+  </data>
   <data name="GamingEmptyState" xml:space="preserve">
     <value>Desliza hacia abajo para actualizar el catálogo de juegos.</value>
   </data>

--- a/OneGateApp/Properties/Strings.fr.resx
+++ b/OneGateApp/Properties/Strings.fr.resx
@@ -1255,4 +1255,6 @@ Il est recommandé de conserver séparément la clé NEP-2 et le mot de passe, e
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>En attente d’un débogueur distant approuvé</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Associer le débogueur distant</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>Le débogueur distant « {0} » demande l’accès. Empreinte : {1}. Autorisez uniquement si vous faites confiance à ce débogueur distant.</value></data>
+  <data name="GamingSwitchToGalleryLayout" xml:space="preserve"><value>Passer à l’affichage en galerie</value></data>
+  <data name="GamingSwitchToListLayout" xml:space="preserve"><value>Passer à l’affichage en liste</value></data>
 </root>

--- a/OneGateApp/Properties/Strings.fr.resx
+++ b/OneGateApp/Properties/Strings.fr.resx
@@ -843,6 +843,9 @@ En continuant, vous reconnaissez comprendre pleinement et accepter tous les risq
   <data name="Gaming" xml:space="preserve">
     <value>Jeux</value>
   </data>
+  <data name="GamingRandomPlay" xml:space="preserve">
+    <value>Jouer à un jeu au hasard</value>
+  </data>
   <data name="GamingEmptyState" xml:space="preserve">
     <value>Tirez vers le bas pour actualiser le catalogue de jeux.</value>
   </data>

--- a/OneGateApp/Properties/Strings.id.resx
+++ b/OneGateApp/Properties/Strings.id.resx
@@ -1255,4 +1255,6 @@ Disarankan untuk menyimpan kunci NEP-2 dan kata sandinya secara terpisah serta m
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>Menunggu debugger jarak jauh tepercaya</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Pasangkan debugger jarak jauh</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>Debugger jarak jauh “{0}” meminta akses. Sidik jari: {1}. Izinkan hanya jika Anda memercayai debugger jarak jauh ini.</value></data>
+  <data name="GamingSwitchToGalleryLayout" xml:space="preserve"><value>Beralih ke tata letak galeri</value></data>
+  <data name="GamingSwitchToListLayout" xml:space="preserve"><value>Beralih ke tata letak daftar</value></data>
 </root>

--- a/OneGateApp/Properties/Strings.id.resx
+++ b/OneGateApp/Properties/Strings.id.resx
@@ -843,6 +843,9 @@ Dengan melanjutkan, Anda menyatakan bahwa Anda sepenuhnya memahami dan menerima 
   <data name="Gaming" xml:space="preserve">
     <value>Game</value>
   </data>
+  <data name="GamingRandomPlay" xml:space="preserve">
+    <value>Mainkan game acak</value>
+  </data>
   <data name="GamingEmptyState" xml:space="preserve">
     <value>Tarik ke bawah untuk menyegarkan katalog game.</value>
   </data>

--- a/OneGateApp/Properties/Strings.it.resx
+++ b/OneGateApp/Properties/Strings.it.resx
@@ -1255,4 +1255,6 @@ Si consiglia di conservare separatamente la chiave NEP-2 e la password e di eseg
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>In attesa di un debugger remoto attendibile</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Associa debugger remoto</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>Il debugger remoto “{0}” richiede l’accesso. Impronta: {1}. Autorizza solo se ritieni attendibile questo debugger remoto.</value></data>
+  <data name="GamingSwitchToGalleryLayout" xml:space="preserve"><value>Passa al layout galleria</value></data>
+  <data name="GamingSwitchToListLayout" xml:space="preserve"><value>Passa al layout elenco</value></data>
 </root>

--- a/OneGateApp/Properties/Strings.it.resx
+++ b/OneGateApp/Properties/Strings.it.resx
@@ -843,6 +843,9 @@ Continuando, confermi di aver compreso pienamente e accettato tutti i rischi ass
   <data name="Gaming" xml:space="preserve">
     <value>Giochi</value>
   </data>
+  <data name="GamingRandomPlay" xml:space="preserve">
+    <value>Gioca a un gioco casuale</value>
+  </data>
   <data name="GamingEmptyState" xml:space="preserve">
     <value>Trascina verso il basso per aggiornare il catalogo dei giochi.</value>
   </data>

--- a/OneGateApp/Properties/Strings.ja.resx
+++ b/OneGateApp/Properties/Strings.ja.resx
@@ -1255,4 +1255,6 @@ NEP-2 とパスワードは別々に保管し、それぞれを安全にバッ�
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>信頼済みリモートデバッガーを待機中</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>リモートデバッガーをペアリング</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>リモートデバッガー「{0}」がアクセスを要求しています。フィンガープリント: {1}。このリモートデバッガーを信頼する場合のみ許可してください。</value></data>
+  <data name="GamingSwitchToGalleryLayout" xml:space="preserve"><value>ギャラリーレイアウトに切り替え</value></data>
+  <data name="GamingSwitchToListLayout" xml:space="preserve"><value>リストレイアウトに切り替え</value></data>
 </root>

--- a/OneGateApp/Properties/Strings.ja.resx
+++ b/OneGateApp/Properties/Strings.ja.resx
@@ -843,6 +843,9 @@
   <data name="Gaming" xml:space="preserve">
     <value>ゲーム</value>
   </data>
+  <data name="GamingRandomPlay" xml:space="preserve">
+    <value>ランダムなゲームをプレイ</value>
+  </data>
   <data name="GamingEmptyState" xml:space="preserve">
     <value>下に引いてゲームカタログを更新します。</value>
   </data>

--- a/OneGateApp/Properties/Strings.ko.resx
+++ b/OneGateApp/Properties/Strings.ko.resx
@@ -1255,4 +1255,6 @@ NEP-2와 비밀번호는 별도로 보관하고 각각 안전하게 백업하는
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>신뢰할 수 있는 원격 디버거 대기 중</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>원격 디버거 페어링</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>원격 디버거 “{0}”이(가) 액세스를 요청합니다. 지문: {1}. 이 원격 디버거를 신뢰하는 경우에만 허용하세요.</value></data>
+  <data name="GamingSwitchToGalleryLayout" xml:space="preserve"><value>갤러리 레이아웃으로 전환</value></data>
+  <data name="GamingSwitchToListLayout" xml:space="preserve"><value>목록 레이아웃으로 전환</value></data>
 </root>

--- a/OneGateApp/Properties/Strings.ko.resx
+++ b/OneGateApp/Properties/Strings.ko.resx
@@ -843,6 +843,9 @@
   <data name="Gaming" xml:space="preserve">
     <value>게임</value>
   </data>
+  <data name="GamingRandomPlay" xml:space="preserve">
+    <value>무작위 게임 플레이</value>
+  </data>
   <data name="GamingEmptyState" xml:space="preserve">
     <value>아래로 당겨 게임 카탈로그를 새로고침하세요.</value>
   </data>

--- a/OneGateApp/Properties/Strings.nl.resx
+++ b/OneGateApp/Properties/Strings.nl.resx
@@ -1255,4 +1255,6 @@ Het wordt aanbevolen om de NEP-2-sleutel en het wachtwoord apart op te slaan en 
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>Wachten op een vertrouwde externe debugger</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Externe debugger koppelen</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>Externe debugger ‘{0}’ vraagt toegang. Vingerafdruk: {1}. Autoriseer alleen als je deze externe debugger vertrouwt.</value></data>
+  <data name="GamingSwitchToGalleryLayout" xml:space="preserve"><value>Overschakelen naar galerijweergave</value></data>
+  <data name="GamingSwitchToListLayout" xml:space="preserve"><value>Overschakelen naar lijstweergave</value></data>
 </root>

--- a/OneGateApp/Properties/Strings.nl.resx
+++ b/OneGateApp/Properties/Strings.nl.resx
@@ -843,6 +843,9 @@ Door door te gaan bevestigt u dat u alle bijbehorende risico's volledig begrijpt
   <data name="Gaming" xml:space="preserve">
     <value>Games</value>
   </data>
+  <data name="GamingRandomPlay" xml:space="preserve">
+    <value>Speel een willekeurig spel</value>
+  </data>
   <data name="GamingEmptyState" xml:space="preserve">
     <value>Trek omlaag om de gamecatalogus te vernieuwen.</value>
   </data>

--- a/OneGateApp/Properties/Strings.pt-BR.resx
+++ b/OneGateApp/Properties/Strings.pt-BR.resx
@@ -1255,4 +1255,6 @@ Recomenda-se armazenar a chave NEP-2 e a senha separadamente e fazer backups seg
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>Aguardando um depurador remoto confiável</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Parear depurador remoto</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>O depurador remoto “{0}” está solicitando acesso. Impressão digital: {1}. Autorize apenas se confiar neste depurador remoto.</value></data>
+  <data name="GamingSwitchToGalleryLayout" xml:space="preserve"><value>Mudar para o layout de galeria</value></data>
+  <data name="GamingSwitchToListLayout" xml:space="preserve"><value>Mudar para o layout de lista</value></data>
 </root>

--- a/OneGateApp/Properties/Strings.pt-BR.resx
+++ b/OneGateApp/Properties/Strings.pt-BR.resx
@@ -843,6 +843,9 @@ Ao continuar, você reconhece que compreende totalmente e aceita todos os riscos
   <data name="Gaming" xml:space="preserve">
     <value>Jogos</value>
   </data>
+  <data name="GamingRandomPlay" xml:space="preserve">
+    <value>Jogar um jogo aleatório</value>
+  </data>
   <data name="GamingEmptyState" xml:space="preserve">
     <value>Puxe para baixo para atualizar o catálogo de jogos.</value>
   </data>

--- a/OneGateApp/Properties/Strings.resx
+++ b/OneGateApp/Properties/Strings.resx
@@ -1270,4 +1270,6 @@ It is recommended to store the NEP-2 key and password separately and back them u
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>Waiting for a trusted remote debugger</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Pair remote debugger</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>Remote debugger “{0}” is requesting access. Fingerprint: {1}. Authorize only if you trust this remote debugger.</value></data>
+  <data name="GamingSwitchToGalleryLayout" xml:space="preserve"><value>Switch to gallery layout</value></data>
+  <data name="GamingSwitchToListLayout" xml:space="preserve"><value>Switch to list layout</value></data>
 </root>

--- a/OneGateApp/Properties/Strings.resx
+++ b/OneGateApp/Properties/Strings.resx
@@ -846,6 +846,21 @@ By continuing, you acknowledge that you fully understand and accept all associat
   <data name="GamingRecentPlayed" xml:space="preserve">
     <value>Recently played</value>
   </data>
+  <data name="GamingGallery" xml:space="preserve">
+    <value>Gallery</value>
+  </data>
+  <data name="GamingList" xml:space="preserve">
+    <value>List</value>
+  </data>
+  <data name="GamingQuickPicks" xml:space="preserve">
+    <value>Quick picks</value>
+  </data>
+  <data name="GamingAllGames" xml:space="preserve">
+    <value>All games</value>
+  </data>
+  <data name="GamingSpotlight" xml:space="preserve">
+    <value>Game spotlight</value>
+  </data>
   <data name="GameType" xml:space="preserve">
     <value>Game type</value>
   </data>

--- a/OneGateApp/Properties/Strings.resx
+++ b/OneGateApp/Properties/Strings.resx
@@ -843,6 +843,9 @@ By continuing, you acknowledge that you fully understand and accept all associat
   <data name="Gaming" xml:space="preserve">
     <value>Gaming</value>
   </data>
+  <data name="GamingRandomPlay" xml:space="preserve">
+    <value>Play a random game</value>
+  </data>
   <data name="GamingEmptyState" xml:space="preserve">
     <value>Pull down to refresh the game catalog.</value>
   </data>

--- a/OneGateApp/Properties/Strings.ru.resx
+++ b/OneGateApp/Properties/Strings.ru.resx
@@ -1255,4 +1255,6 @@
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>Ожидание доверенного удалённого отладчика</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Сопряжение удалённого отладчика</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>Удалённый отладчик «{0}» запрашивает доступ. Отпечаток: {1}. Разрешайте только если доверяете этому удалённому отладчику.</value></data>
+  <data name="GamingSwitchToGalleryLayout" xml:space="preserve"><value>Переключиться на вид галереи</value></data>
+  <data name="GamingSwitchToListLayout" xml:space="preserve"><value>Переключиться на вид списка</value></data>
 </root>

--- a/OneGateApp/Properties/Strings.ru.resx
+++ b/OneGateApp/Properties/Strings.ru.resx
@@ -843,6 +843,9 @@
   <data name="Gaming" xml:space="preserve">
     <value>Игры</value>
   </data>
+  <data name="GamingRandomPlay" xml:space="preserve">
+    <value>Сыграть в случайную игру</value>
+  </data>
   <data name="GamingEmptyState" xml:space="preserve">
     <value>Потяните вниз, чтобы обновить каталог игр.</value>
   </data>

--- a/OneGateApp/Properties/Strings.tr.resx
+++ b/OneGateApp/Properties/Strings.tr.resx
@@ -1255,4 +1255,6 @@ NEP-2 anahtarı ile şifreyi ayrı ayrı saklamanız ve güvenli şekilde yedekl
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>Güvenilir bir uzaktan hata ayıklayıcı bekleniyor</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Uzaktan hata ayıklayıcıyı eşleştir</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>“{0}” uzaktan hata ayıklayıcısı erişim istiyor. Parmak izi: {1}. Yalnızca bu uzaktan hata ayıklayıcıya güveniyorsanız izin verin.</value></data>
+  <data name="GamingSwitchToGalleryLayout" xml:space="preserve"><value>Galeri düzenine geç</value></data>
+  <data name="GamingSwitchToListLayout" xml:space="preserve"><value>Liste düzenine geç</value></data>
 </root>

--- a/OneGateApp/Properties/Strings.tr.resx
+++ b/OneGateApp/Properties/Strings.tr.resx
@@ -843,6 +843,9 @@ Devam ederek, ilgili tüm riskleri tamamen anladığınızı ve kabul ettiğiniz
   <data name="Gaming" xml:space="preserve">
     <value>Oyun</value>
   </data>
+  <data name="GamingRandomPlay" xml:space="preserve">
+    <value>Rastgele bir oyun oyna</value>
+  </data>
   <data name="GamingEmptyState" xml:space="preserve">
     <value>Oyun kataloğunu yenilemek için aşağı çekin.</value>
   </data>

--- a/OneGateApp/Properties/Strings.vi.resx
+++ b/OneGateApp/Properties/Strings.vi.resx
@@ -1255,4 +1255,6 @@ Nên lưu trữ riêng khóa NEP-2 và mật khẩu, đồng thời sao lưu ch�
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>Đang chờ trình gỡ lỗi từ xa đáng tin cậy</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Ghép nối trình gỡ lỗi từ xa</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>Trình gỡ lỗi từ xa “{0}” đang yêu cầu quyền truy cập. Dấu vân tay: {1}. Chỉ cho phép nếu bạn tin cậy trình gỡ lỗi từ xa này.</value></data>
+  <data name="GamingSwitchToGalleryLayout" xml:space="preserve"><value>Chuyển sang bố cục thư viện</value></data>
+  <data name="GamingSwitchToListLayout" xml:space="preserve"><value>Chuyển sang bố cục danh sách</value></data>
 </root>

--- a/OneGateApp/Properties/Strings.vi.resx
+++ b/OneGateApp/Properties/Strings.vi.resx
@@ -843,6 +843,9 @@ Khi tiếp tục, bạn xác nhận rằng bạn đã hiểu đầy đủ và ch
   <data name="Gaming" xml:space="preserve">
     <value>Trò chơi</value>
   </data>
+  <data name="GamingRandomPlay" xml:space="preserve">
+    <value>Chơi một trò chơi ngẫu nhiên</value>
+  </data>
   <data name="GamingEmptyState" xml:space="preserve">
     <value>Kéo xuống để làm mới danh mục trò chơi.</value>
   </data>

--- a/OneGateApp/Properties/Strings.zh-Hans.resx
+++ b/OneGateApp/Properties/Strings.zh-Hans.resx
@@ -846,6 +846,21 @@
   <data name="GamingRecentPlayed" xml:space="preserve">
     <value>最近玩过</value>
   </data>
+  <data name="GamingGallery" xml:space="preserve">
+    <value>画廊</value>
+  </data>
+  <data name="GamingList" xml:space="preserve">
+    <value>列表</value>
+  </data>
+  <data name="GamingQuickPicks" xml:space="preserve">
+    <value>精选速览</value>
+  </data>
+  <data name="GamingAllGames" xml:space="preserve">
+    <value>全部游戏</value>
+  </data>
+  <data name="GamingSpotlight" xml:space="preserve">
+    <value>游戏推荐</value>
+  </data>
   <data name="GameType" xml:space="preserve">
     <value>游戏类型</value>
   </data>

--- a/OneGateApp/Properties/Strings.zh-Hans.resx
+++ b/OneGateApp/Properties/Strings.zh-Hans.resx
@@ -1270,4 +1270,6 @@
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>正在等待已信任的远程调试器</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>配对远程调试器</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>远程调试器“{0}”正在请求访问。指纹：{1}。仅在你信任此远程调试器时授权。</value></data>
+  <data name="GamingSwitchToGalleryLayout" xml:space="preserve"><value>切换到画廊布局</value></data>
+  <data name="GamingSwitchToListLayout" xml:space="preserve"><value>切换到列表布局</value></data>
 </root>

--- a/OneGateApp/Properties/Strings.zh-Hans.resx
+++ b/OneGateApp/Properties/Strings.zh-Hans.resx
@@ -843,6 +843,9 @@
   <data name="Gaming" xml:space="preserve">
     <value>游戏</value>
   </data>
+  <data name="GamingRandomPlay" xml:space="preserve">
+    <value>随机玩一个游戏</value>
+  </data>
   <data name="GamingEmptyState" xml:space="preserve">
     <value>下拉刷新游戏目录。</value>
   </data>

--- a/OneGateApp/Properties/Strings.zh-Hant.resx
+++ b/OneGateApp/Properties/Strings.zh-Hant.resx
@@ -1255,4 +1255,6 @@
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>正在等待已信任的遠端偵錯器</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>配對遠端偵錯器</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>遠端偵錯器「{0}」正在要求存取。指紋：{1}。僅在你信任此遠端偵錯器時授權。</value></data>
+  <data name="GamingSwitchToGalleryLayout" xml:space="preserve"><value>切換至圖庫版面</value></data>
+  <data name="GamingSwitchToListLayout" xml:space="preserve"><value>切換至列表版面</value></data>
 </root>

--- a/OneGateApp/Properties/Strings.zh-Hant.resx
+++ b/OneGateApp/Properties/Strings.zh-Hant.resx
@@ -819,6 +819,9 @@
   <data name="Gaming" xml:space="preserve">
     <value>遊戲</value>
   </data>
+  <data name="GamingRandomPlay" xml:space="preserve">
+    <value>隨機玩一個遊戲</value>
+  </data>
   <data name="GamingEmptyState" xml:space="preserve">
     <value>下拉重新整理遊戲目錄。</value>
   </data>

--- a/OneGateApp/Resources/Images/gaming_random.svg
+++ b/OneGateApp/Resources/Images/gaming_random.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <rect x="3" y="3" width="18" height="18" rx="4" fill="none" stroke="#FFFFFF" stroke-width="2"/>
+  <circle cx="8" cy="8" r="1.5" fill="#FFFFFF"/>
+  <circle cx="16" cy="8" r="1.5" fill="#FFFFFF"/>
+  <circle cx="12" cy="12" r="1.5" fill="#FFFFFF"/>
+  <circle cx="8" cy="16" r="1.5" fill="#FFFFFF"/>
+  <circle cx="16" cy="16" r="1.5" fill="#FFFFFF"/>
+</svg>


### PR DESCRIPTION
## Summary

- add a responsive gallery layout to the Games tab while retaining the existing list layout
- replace the Gallery/List text controls with a compact icon-only state toggle
- persist the selected layout across app restarts
- add game-type filters, recently played, spotlight, quick picks, and responsive all-games sections
- add image fallbacks and English/Simplified Chinese localization

## Validation

- OneGate.DebugProtocol.Tests: 6/6 passed
- Android arm64 APK build: passed with 0 warnings and 0 errors
- Android API 36 emulator: gallery/list toggle, accessibility labels, restart persistence, filters, details, and launch validated
- iOS simulator-arm64 build: passed with 0 warnings and 0 errors
- iPhone 17 Pro / iOS 26.5 simulator: gallery/list toggle, accessibility labels, and restart persistence validated
- git diff --check: passed