### PR TITLE
Show game download status

### DIFF
--- a/OneGateApp/Data/DApp.cs
+++ b/OneGateApp/Data/DApp.cs
@@ -1,14 +1,20 @@
 ﻿using NeoOrder.OneGate.Models;
 using NeoOrder.OneGate.Properties;
 using NeoOrder.OneGate.Services;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 
 namespace NeoOrder.OneGate.Data;
 
-public class DApp : IComparable<DApp>, IShareable, IVersioned
+public class DApp : IComparable<DApp>, IShareable, IVersioned, INotifyPropertyChanged
 {
+    GameDownloadStatus downloadStatus;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
     [DatabaseGenerated(DatabaseGeneratedOption.None)]
     public int Id { get; set; }
     public bool IsActive { get; set; }
@@ -31,6 +37,35 @@ public class DApp : IComparable<DApp>, IShareable, IVersioned
     public string? Description { get; set; }
     public ContentWarnings Warnings { get; set; }
     public int Version { get; set; }
+
+    [NotMapped]
+    public GameDownloadStatus DownloadStatus
+    {
+        get => downloadStatus;
+        set
+        {
+            if (downloadStatus == value) return;
+            downloadStatus = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(IsGameDownloading));
+            OnPropertyChanged(nameof(IsGameDownloaded));
+            OnPropertyChanged(nameof(GameDownloadStatusText));
+        }
+    }
+
+    [NotMapped]
+    public bool IsGameDownloading => DownloadStatus == GameDownloadStatus.Downloading;
+
+    [NotMapped]
+    public bool IsGameDownloaded => DownloadStatus == GameDownloadStatus.Downloaded;
+
+    [NotMapped]
+    public string GameDownloadStatusText => DownloadStatus switch
+    {
+        GameDownloadStatus.Downloading => Strings.GameDownloading,
+        GameDownloadStatus.Downloaded => Strings.GameDownloaded,
+        _ => Strings.GameDownloadRequired
+    };
 
     public bool IsGamingApp => !string.IsNullOrWhiteSpace(GameType);
     public bool IsRegularApp => !IsGamingApp;
@@ -57,4 +92,16 @@ public class DApp : IComparable<DApp>, IShareable, IVersioned
         if (string.IsNullOrWhiteSpace(gameType)) return null;
         return Strings.ResourceManager.GetString($"GameType{gameType}") ?? gameType;
     }
+
+    void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new(propertyName));
+    }
+}
+
+public enum GameDownloadStatus
+{
+    Required,
+    Downloading,
+    Downloaded
 }

--- a/OneGateApp/MauiProgram.cs
+++ b/OneGateApp/MauiProgram.cs
@@ -116,6 +116,7 @@ public static class MauiProgram
         builder.Services.AddTransient<AddressBookService>();
         builder.Services.AddSingleton<TokenManager>();
         builder.Services.AddSingleton<ActivityLogService>();
+        builder.Services.AddSingleton<GameDownloadStatusService>();
         builder.Services.AddSingleton<RpcClient>();
         builder.Services.AddSingleton<UpdateService>();
         builder.Services.AddSingleton<RemoteDebugService>();

--- a/OneGateApp/Pages/GamingPage.xaml
+++ b/OneGateApp/Pages/GamingPage.xaml
@@ -17,12 +17,18 @@
         <og:DAppSearchHandler SearchBoxVisibility="Collapsible" ShowsResults="True" DApps="{Binding Games}">
             <og:DAppSearchHandler.ItemTemplate>
                 <DataTemplate x:DataType="og:DApp">
-                    <Grid ColumnDefinitions="auto,*" ColumnSpacing="5" Margin="{OnPlatform iOS='20,0', MacCatalyst='20,0', Default='5'}">
-                        <Image WidthRequest="20" HeightRequest="20" VerticalOptions="Center">
-                            <Image.Source>
-                                <UriImageSource Uri="{Binding IconUrl}" CacheValidity="30:00:00:00" />
-                            </Image.Source>
-                        </Image>
+                    <Grid ColumnDefinitions="auto,*" ColumnSpacing="5" Margin="{OnPlatform iOS='20,0', MacCatalyst='20,0', Default='5'}" SemanticProperties.Hint="{Binding GameDownloadStatusText}">
+                        <Grid WidthRequest="22" HeightRequest="22" VerticalOptions="Center">
+                            <Image WidthRequest="20" HeightRequest="20" VerticalOptions="Center">
+                                <Image.Source>
+                                    <UriImageSource Uri="{Binding IconUrl}" CacheValidity="30:00:00:00" />
+                                </Image.Source>
+                            </Image>
+                            <ActivityIndicator IsRunning="{Binding IsGameDownloading}" IsVisible="{Binding IsGameDownloading}" Color="{toolkit:AppThemeResource Success}" WidthRequest="12" HeightRequest="12" HorizontalOptions="End" VerticalOptions="End" InputTransparent="True" />
+                            <Border IsVisible="{Binding IsGameDownloaded}" BackgroundColor="{toolkit:AppThemeResource Success}" StrokeThickness="0" StrokeShape="RoundRectangle 6" WidthRequest="12" HeightRequest="12" Padding="0" HorizontalOptions="End" VerticalOptions="End" InputTransparent="True">
+                                <Label Text="&#xe9b0;" FontFamily="Icons" FontSize="7" TextColor="{toolkit:AppThemeResource Accent}" HorizontalTextAlignment="Center" VerticalTextAlignment="Center" />
+                            </Border>
+                        </Grid>
                         <Label Grid.Column="1" Text="{Binding Name, Converter={StaticResource LocalizerConverter}}" VerticalOptions="Center" />
                     </Grid>
                 </DataTemplate>
@@ -44,13 +50,19 @@
                             </CollectionView.ItemsLayout>
                             <CollectionView.ItemTemplate>
                                 <DataTemplate x:DataType="og:DApp">
-                                    <Border StyleClass="Card" WidthRequest="96" HeightRequest="96" Padding="8,10">
+                                    <Border StyleClass="Card" WidthRequest="96" HeightRequest="96" Padding="8,10" SemanticProperties.Hint="{Binding GameDownloadStatusText}">
                                         <Grid RowDefinitions="48,*" RowSpacing="4">
-                                            <Image WidthRequest="44" HeightRequest="44" Aspect="AspectFit" HorizontalOptions="Center" VerticalOptions="Center">
-                                                <Image.Source>
-                                                    <UriImageSource Uri="{Binding IconUrl}" CacheValidity="30:00:00:00" />
-                                                </Image.Source>
-                                            </Image>
+                                            <Grid WidthRequest="48" HeightRequest="48" HorizontalOptions="Center" VerticalOptions="Center">
+                                                <Image WidthRequest="44" HeightRequest="44" Aspect="AspectFit" HorizontalOptions="Center" VerticalOptions="Center">
+                                                    <Image.Source>
+                                                        <UriImageSource Uri="{Binding IconUrl}" CacheValidity="30:00:00:00" />
+                                                    </Image.Source>
+                                                </Image>
+                                                <ActivityIndicator IsRunning="{Binding IsGameDownloading}" IsVisible="{Binding IsGameDownloading}" Color="{toolkit:AppThemeResource Success}" WidthRequest="16" HeightRequest="16" HorizontalOptions="End" VerticalOptions="End" InputTransparent="True" />
+                                                <Border IsVisible="{Binding IsGameDownloaded}" BackgroundColor="{toolkit:AppThemeResource Success}" StrokeThickness="0" StrokeShape="RoundRectangle 8" WidthRequest="16" HeightRequest="16" Padding="0" HorizontalOptions="End" VerticalOptions="End" InputTransparent="True">
+                                                    <Label Text="&#xe9b0;" FontFamily="Icons" FontSize="9" TextColor="{toolkit:AppThemeResource Accent}" HorizontalTextAlignment="Center" VerticalTextAlignment="Center" />
+                                                </Border>
+                                            </Grid>
                                             <Label Grid.Row="1" Text="{Binding Name, Converter={StaticResource LocalizerConverter}}" FontAttributes="Bold" FontSize="12" MaxLines="1" LineBreakMode="TailTruncation" HorizontalTextAlignment="Center" VerticalTextAlignment="Center" />
                                         </Grid>
                                         <Border.GestureRecognizers>
@@ -87,13 +99,19 @@
             </CollectionView.ItemsLayout>
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="og:DApp">
-                    <Grid RowDefinitions="*,1" HeightRequest="96">
+                    <Grid RowDefinitions="*,1" HeightRequest="96" SemanticProperties.Hint="{Binding GameDownloadStatusText}">
                         <Grid ColumnDefinitions="60,*,40" ColumnSpacing="12" Padding="0,8" MinimumHeightRequest="88">
-                            <Image WidthRequest="56" HeightRequest="56" Aspect="AspectFit" HorizontalOptions="Center" VerticalOptions="Center">
-                                <Image.Source>
-                                    <UriImageSource Uri="{Binding IconUrl}" CacheValidity="30:00:00:00" />
-                                </Image.Source>
-                            </Image>
+                            <Grid WidthRequest="60" HeightRequest="60" HorizontalOptions="Center" VerticalOptions="Center">
+                                <Image WidthRequest="56" HeightRequest="56" Aspect="AspectFit" HorizontalOptions="Center" VerticalOptions="Center">
+                                    <Image.Source>
+                                        <UriImageSource Uri="{Binding IconUrl}" CacheValidity="30:00:00:00" />
+                                    </Image.Source>
+                                </Image>
+                                <ActivityIndicator IsRunning="{Binding IsGameDownloading}" IsVisible="{Binding IsGameDownloading}" Color="{toolkit:AppThemeResource Success}" WidthRequest="18" HeightRequest="18" HorizontalOptions="End" VerticalOptions="End" InputTransparent="True" />
+                                <Border IsVisible="{Binding IsGameDownloaded}" BackgroundColor="{toolkit:AppThemeResource Success}" StrokeThickness="0" StrokeShape="RoundRectangle 9" WidthRequest="18" HeightRequest="18" Padding="0" HorizontalOptions="End" VerticalOptions="End" InputTransparent="True">
+                                    <Label Text="&#xe9b0;" FontFamily="Icons" FontSize="10" TextColor="{toolkit:AppThemeResource Accent}" HorizontalTextAlignment="Center" VerticalTextAlignment="Center" />
+                                </Border>
+                            </Grid>
                             <VerticalStackLayout Grid.Column="1" Spacing="3" VerticalOptions="Center">
                                 <Label Text="{Binding Name, Converter={StaticResource LocalizerConverter}}" FontAttributes="Bold" FontSize="14" LineBreakMode="TailTruncation" MaxLines="1" />
                                 <HorizontalStackLayout Spacing="6">

--- a/OneGateApp/Pages/GamingPage.xaml.cs
+++ b/OneGateApp/Pages/GamingPage.xaml.cs
@@ -14,6 +14,7 @@ public partial class GamingPage : ContentPage
     const int MaxGameColumns = 3;
 
     readonly ApplicationDbContext dbContext;
+    readonly GameDownloadStatusService gameDownloadStatusService;
     bool allowRestrictedContent;
     bool developerModeEnabled;
 
@@ -27,10 +28,11 @@ public partial class GamingPage : ContentPage
     public string[] GameTypes { get; private set { field = value; OnPropertyChanged(); } } = [Strings.All];
     public bool HasGameTypeFilters { get; private set { field = value; OnPropertyChanged(); } }
 
-    public GamingPage(IServiceProvider serviceProvider, ApplicationDbContext dbContext)
+    public GamingPage(IServiceProvider serviceProvider, ApplicationDbContext dbContext, GameDownloadStatusService gameDownloadStatusService)
     {
         this.LoadingService = new(LoadSettingsAsync, LoadDAppsAsync);
         this.dbContext = dbContext;
+        this.gameDownloadStatusService = gameDownloadStatusService;
         this.DApps = serviceProvider.GetServiceOrCreateInstance<CachedCollection<DApp>>();
         InitializeComponent();
 #if WINDOWS
@@ -41,9 +43,10 @@ public partial class GamingPage : ContentPage
         LoadingService.BeginLoad();
     }
 
-    protected override void OnAppearing()
+    protected override async void OnAppearing()
     {
         base.OnAppearing();
+        await gameDownloadStatusService.ApplyStatusesAsync(Games);
         if (this.ShouldRefresh())
             LoadingService.BeginLoad();
         else
@@ -82,12 +85,13 @@ public partial class GamingPage : ContentPage
             GamesItemsLayout.Span = span;
     }
 
-    void OnDataLoaded(object? sender, EventArgs e)
+    async void OnDataLoaded(object? sender, EventArgs e)
     {
         Games = DApps
             .Where(p => p.IsGamingApp
                 && DAppCatalogPolicy.IsVisible(p, allowRestrictedContent, developerModeEnabled))
             .ToArray();
+        await gameDownloadStatusService.ApplyStatusesAsync(Games);
         GameTypes = Games
             .Select(p => p.GameType)
             .Where(p => !string.IsNullOrWhiteSpace(p))

--- a/OneGateApp/Pages/LaunchDAppPage.xaml
+++ b/OneGateApp/Pages/LaunchDAppPage.xaml
@@ -26,5 +26,5 @@
         <ToolbarItem x:Name="developerToolsButton" Order="Secondary" Text="{x:Static og:Strings.DAppDebugPanel}" Clicked="OnDeveloperToolsClicked" />
         <ToolbarItem x:Name="reportButton" Order="Secondary" Text="{x:Static og:Strings.Report}" Clicked="OnReportClicked" />
     </ContentPage.ToolbarItems>
-    <og:BridgeWebView x:Name="webView" Source="{Binding Url}" Navigating="OnNavigating" InvokedFromJavaScript="OnInvokedFromJavaScript" />
+    <og:BridgeWebView x:Name="webView" Source="{Binding Url}" Navigating="OnNavigating" Navigated="OnNavigated" InvokedFromJavaScript="OnInvokedFromJavaScript" />
 </ContentPage>

--- a/OneGateApp/Pages/LaunchDAppPage.xaml.cs
+++ b/OneGateApp/Pages/LaunchDAppPage.xaml.cs
@@ -268,17 +268,26 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable, IRemoteDe
 
     async void OnNavigated(object sender, WebNavigatedEventArgs e)
     {
-        if (DApp is not { IsGamingApp: true } || !Uri.TryCreate(e.Url, UriKind.Absolute, out var uri))
-            return;
+        if (DApp is not { IsGamingApp: true }) return;
 
-        Uri gameUri = new(DApp.Url);
-        if (uri.Scheme == "about" || IsCrossDomain(gameUri, uri))
-            return;
+        try
+        {
+            if (!Uri.TryCreate(e.Url, UriKind.Absolute, out var uri))
+                return;
 
-        if (e.Result == WebNavigationResult.Success)
-            await gameDownloadStatusService.MarkDownloadedAsync(DApp);
-        else
+            Uri gameUri = new(DApp.Url);
+            if (uri.Scheme == "about" || IsCrossDomain(gameUri, uri))
+                return;
+
+            if (e.Result == WebNavigationResult.Success)
+                await gameDownloadStatusService.MarkDownloadedAsync(DApp);
+            else
+                gameDownloadStatusService.ResetDownloading(DApp);
+        }
+        catch
+        {
             gameDownloadStatusService.ResetDownloading(DApp);
+        }
     }
 
     string CreateDocumentStartScript()

--- a/OneGateApp/Pages/LaunchDAppPage.xaml.cs
+++ b/OneGateApp/Pages/LaunchDAppPage.xaml.cs
@@ -23,6 +23,7 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable, IRemoteDe
     readonly ProtocolSettings protocolSettings;
     readonly IWalletProvider walletProvider;
     readonly WalletAuthorizationService walletAuthorizationService;
+    readonly GameDownloadStatusService gameDownloadStatusService;
     readonly ApplicationDbContext dbContext;
     readonly ActivityLogService activityLogService;
     readonly HttpClient httpClient;
@@ -37,12 +38,13 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable, IRemoteDe
     public bool IsDeveloperToolsEnabled { get; set { field = value; OnPropertyChanged(); } }
     bool IsRemoteDebugSession => remoteDebugSessionId is not null;
 
-    public LaunchDAppPage(IServiceProvider serviceProvider, ProtocolSettings protocolSettings, IWalletProvider walletProvider, WalletAuthorizationService walletAuthorizationService, ApplicationDbContext dbContext, ActivityLogService activityLogService, HttpClient httpClient, RpcClient rpcClient, IHomeShortcutService homeShortcutService)
+    public LaunchDAppPage(IServiceProvider serviceProvider, ProtocolSettings protocolSettings, IWalletProvider walletProvider, WalletAuthorizationService walletAuthorizationService, GameDownloadStatusService gameDownloadStatusService, ApplicationDbContext dbContext, ActivityLogService activityLogService, HttpClient httpClient, RpcClient rpcClient, IHomeShortcutService homeShortcutService)
     {
         this.serviceProvider = serviceProvider;
         this.protocolSettings = protocolSettings;
         this.walletProvider = walletProvider;
         this.walletAuthorizationService = walletAuthorizationService;
+        this.gameDownloadStatusService = gameDownloadStatusService;
         this.dbContext = dbContext;
         this.activityLogService = activityLogService;
         this.httpClient = httpClient;
@@ -69,6 +71,8 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable, IRemoteDe
     protected override void OnDisappearing()
     {
         base.OnDisappearing();
+        if (DApp is { IsGamingApp: true })
+            gameDownloadStatusService.ResetDownloading(DApp);
         if (remoteDebugSessionId is not null && remoteDebugService is not null)
             remoteDebugService.NotifySessionHostClosed(remoteDebugSessionId, this);
     }
@@ -210,6 +214,7 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable, IRemoteDe
             if (DApp.IsRegularApp) GlobalStates.Invalidate<DAppsPage>();
             if (DApp.IsGamingApp) GlobalStates.Invalidate<GamingPage>();
         }
+        await gameDownloadStatusService.MarkDownloadingAsync(DApp);
         await activityLogService.RecordDAppConnectionAsync(DApp);
     }
 
@@ -255,6 +260,21 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable, IRemoteDe
             e.Cancel = true;
             await Toast.Show(Strings.RedirectionBlockedText);
         }
+    }
+
+    async void OnNavigated(object sender, WebNavigatedEventArgs e)
+    {
+        if (DApp is not { IsGamingApp: true } || !Uri.TryCreate(e.Url, UriKind.Absolute, out var uri))
+            return;
+
+        Uri gameUri = new(DApp.Url);
+        if (uri.Scheme == "about" || IsCrossDomain(gameUri, uri))
+            return;
+
+        if (e.Result == WebNavigationResult.Success)
+            await gameDownloadStatusService.MarkDownloadedAsync(DApp);
+        else
+            gameDownloadStatusService.ResetDownloading(DApp);
     }
 
     string CreateDocumentStartScript()

--- a/OneGateApp/Properties/Strings.Designer.cs
+++ b/OneGateApp/Properties/Strings.Designer.cs
@@ -1391,6 +1391,33 @@ namespace NeoOrder.OneGate.Properties {
         }
 
         /// <summary>
+        ///   查找类似 Downloaded 的本地化字符串。
+        /// </summary>
+        internal static string GameDownloaded {
+            get {
+                return ResourceManager.GetString("GameDownloaded", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   查找类似 Download required 的本地化字符串。
+        /// </summary>
+        internal static string GameDownloadRequired {
+            get {
+                return ResourceManager.GetString("GameDownloadRequired", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   查找类似 Downloading 的本地化字符串。
+        /// </summary>
+        internal static string GameDownloading {
+            get {
+                return ResourceManager.GetString("GameDownloading", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   查找类似 Game type 的本地化字符串。
         /// </summary>
         internal static string GameType {

--- a/OneGateApp/Properties/Strings.de.resx
+++ b/OneGateApp/Properties/Strings.de.resx
@@ -846,6 +846,15 @@ Mit dem Fortfahren bestätigen Sie, dass Sie alle damit verbundenen Risiken voll
   <data name="GamingRecentPlayed" xml:space="preserve">
     <value>Zuletzt gespielt</value>
   </data>
+  <data name="GameDownloadRequired" xml:space="preserve">
+    <value>Download erforderlich</value>
+  </data>
+  <data name="GameDownloading" xml:space="preserve">
+    <value>Wird heruntergeladen</value>
+  </data>
+  <data name="GameDownloaded" xml:space="preserve">
+    <value>Heruntergeladen</value>
+  </data>
   <data name="GameType" xml:space="preserve">
     <value>Spieltyp</value>
   </data>

--- a/OneGateApp/Properties/Strings.es.resx
+++ b/OneGateApp/Properties/Strings.es.resx
@@ -846,6 +846,15 @@ Al continuar, usted reconoce que comprende plenamente y acepta todos los riesgos
   <data name="GamingRecentPlayed" xml:space="preserve">
     <value>Jugados recientemente</value>
   </data>
+  <data name="GameDownloadRequired" xml:space="preserve">
+    <value>Descarga necesaria</value>
+  </data>
+  <data name="GameDownloading" xml:space="preserve">
+    <value>Descargando</value>
+  </data>
+  <data name="GameDownloaded" xml:space="preserve">
+    <value>Descargado</value>
+  </data>
   <data name="GameType" xml:space="preserve">
     <value>Tipo de juego</value>
   </data>

--- a/OneGateApp/Properties/Strings.fr.resx
+++ b/OneGateApp/Properties/Strings.fr.resx
@@ -846,6 +846,15 @@ En continuant, vous reconnaissez comprendre pleinement et accepter tous les risq
   <data name="GamingRecentPlayed" xml:space="preserve">
     <value>Joués récemment</value>
   </data>
+  <data name="GameDownloadRequired" xml:space="preserve">
+    <value>Téléchargement requis</value>
+  </data>
+  <data name="GameDownloading" xml:space="preserve">
+    <value>Téléchargement en cours</value>
+  </data>
+  <data name="GameDownloaded" xml:space="preserve">
+    <value>Téléchargé</value>
+  </data>
   <data name="GameType" xml:space="preserve">
     <value>Type de jeu</value>
   </data>

--- a/OneGateApp/Properties/Strings.id.resx
+++ b/OneGateApp/Properties/Strings.id.resx
@@ -846,6 +846,15 @@ Dengan melanjutkan, Anda menyatakan bahwa Anda sepenuhnya memahami dan menerima 
   <data name="GamingRecentPlayed" xml:space="preserve">
     <value>Baru dimainkan</value>
   </data>
+  <data name="GameDownloadRequired" xml:space="preserve">
+    <value>Perlu diunduh</value>
+  </data>
+  <data name="GameDownloading" xml:space="preserve">
+    <value>Mengunduh</value>
+  </data>
+  <data name="GameDownloaded" xml:space="preserve">
+    <value>Sudah diunduh</value>
+  </data>
   <data name="GameType" xml:space="preserve">
     <value>Jenis game</value>
   </data>

--- a/OneGateApp/Properties/Strings.it.resx
+++ b/OneGateApp/Properties/Strings.it.resx
@@ -846,6 +846,15 @@ Continuando, confermi di aver compreso pienamente e accettato tutti i rischi ass
   <data name="GamingRecentPlayed" xml:space="preserve">
     <value>Giocati di recente</value>
   </data>
+  <data name="GameDownloadRequired" xml:space="preserve">
+    <value>Download richiesto</value>
+  </data>
+  <data name="GameDownloading" xml:space="preserve">
+    <value>Download in corso</value>
+  </data>
+  <data name="GameDownloaded" xml:space="preserve">
+    <value>Scaricato</value>
+  </data>
   <data name="GameType" xml:space="preserve">
     <value>Tipo di gioco</value>
   </data>

--- a/OneGateApp/Properties/Strings.ja.resx
+++ b/OneGateApp/Properties/Strings.ja.resx
@@ -846,6 +846,15 @@
   <data name="GamingRecentPlayed" xml:space="preserve">
     <value>最近プレイ</value>
   </data>
+  <data name="GameDownloadRequired" xml:space="preserve">
+    <value>ダウンロードが必要</value>
+  </data>
+  <data name="GameDownloading" xml:space="preserve">
+    <value>ダウンロード中</value>
+  </data>
+  <data name="GameDownloaded" xml:space="preserve">
+    <value>ダウンロード済み</value>
+  </data>
   <data name="GameType" xml:space="preserve">
     <value>ゲームタイプ</value>
   </data>

--- a/OneGateApp/Properties/Strings.ko.resx
+++ b/OneGateApp/Properties/Strings.ko.resx
@@ -846,6 +846,15 @@
   <data name="GamingRecentPlayed" xml:space="preserve">
     <value>최근 플레이</value>
   </data>
+  <data name="GameDownloadRequired" xml:space="preserve">
+    <value>다운로드 필요</value>
+  </data>
+  <data name="GameDownloading" xml:space="preserve">
+    <value>다운로드 중</value>
+  </data>
+  <data name="GameDownloaded" xml:space="preserve">
+    <value>다운로드됨</value>
+  </data>
   <data name="GameType" xml:space="preserve">
     <value>게임 유형</value>
   </data>

--- a/OneGateApp/Properties/Strings.nl.resx
+++ b/OneGateApp/Properties/Strings.nl.resx
@@ -846,6 +846,15 @@ Door door te gaan bevestigt u dat u alle bijbehorende risico's volledig begrijpt
   <data name="GamingRecentPlayed" xml:space="preserve">
     <value>Recent gespeeld</value>
   </data>
+  <data name="GameDownloadRequired" xml:space="preserve">
+    <value>Download vereist</value>
+  </data>
+  <data name="GameDownloading" xml:space="preserve">
+    <value>Downloaden</value>
+  </data>
+  <data name="GameDownloaded" xml:space="preserve">
+    <value>Gedownload</value>
+  </data>
   <data name="GameType" xml:space="preserve">
     <value>Speltype</value>
   </data>

--- a/OneGateApp/Properties/Strings.pt-BR.resx
+++ b/OneGateApp/Properties/Strings.pt-BR.resx
@@ -846,6 +846,15 @@ Ao continuar, você reconhece que compreende totalmente e aceita todos os riscos
   <data name="GamingRecentPlayed" xml:space="preserve">
     <value>Jogados recentemente</value>
   </data>
+  <data name="GameDownloadRequired" xml:space="preserve">
+    <value>Download necessário</value>
+  </data>
+  <data name="GameDownloading" xml:space="preserve">
+    <value>Baixando</value>
+  </data>
+  <data name="GameDownloaded" xml:space="preserve">
+    <value>Baixado</value>
+  </data>
   <data name="GameType" xml:space="preserve">
     <value>Tipo de jogo</value>
   </data>

--- a/OneGateApp/Properties/Strings.resx
+++ b/OneGateApp/Properties/Strings.resx
@@ -846,6 +846,15 @@ By continuing, you acknowledge that you fully understand and accept all associat
   <data name="GamingRecentPlayed" xml:space="preserve">
     <value>Recently played</value>
   </data>
+  <data name="GameDownloadRequired" xml:space="preserve">
+    <value>Download required</value>
+  </data>
+  <data name="GameDownloading" xml:space="preserve">
+    <value>Downloading</value>
+  </data>
+  <data name="GameDownloaded" xml:space="preserve">
+    <value>Downloaded</value>
+  </data>
   <data name="GameType" xml:space="preserve">
     <value>Game type</value>
   </data>

--- a/OneGateApp/Properties/Strings.ru.resx
+++ b/OneGateApp/Properties/Strings.ru.resx
@@ -846,6 +846,15 @@
   <data name="GamingRecentPlayed" xml:space="preserve">
     <value>Недавно сыгранные</value>
   </data>
+  <data name="GameDownloadRequired" xml:space="preserve">
+    <value>Требуется загрузка</value>
+  </data>
+  <data name="GameDownloading" xml:space="preserve">
+    <value>Загрузка</value>
+  </data>
+  <data name="GameDownloaded" xml:space="preserve">
+    <value>Загружено</value>
+  </data>
   <data name="GameType" xml:space="preserve">
     <value>Тип игры</value>
   </data>

--- a/OneGateApp/Properties/Strings.tr.resx
+++ b/OneGateApp/Properties/Strings.tr.resx
@@ -846,6 +846,15 @@ Devam ederek, ilgili tüm riskleri tamamen anladığınızı ve kabul ettiğiniz
   <data name="GamingRecentPlayed" xml:space="preserve">
     <value>Son oynananlar</value>
   </data>
+  <data name="GameDownloadRequired" xml:space="preserve">
+    <value>İndirme gerekli</value>
+  </data>
+  <data name="GameDownloading" xml:space="preserve">
+    <value>İndiriliyor</value>
+  </data>
+  <data name="GameDownloaded" xml:space="preserve">
+    <value>İndirildi</value>
+  </data>
   <data name="GameType" xml:space="preserve">
     <value>Oyun türü</value>
   </data>

--- a/OneGateApp/Properties/Strings.vi.resx
+++ b/OneGateApp/Properties/Strings.vi.resx
@@ -846,6 +846,15 @@ Khi tiếp tục, bạn xác nhận rằng bạn đã hiểu đầy đủ và ch
   <data name="GamingRecentPlayed" xml:space="preserve">
     <value>Đã chơi gần đây</value>
   </data>
+  <data name="GameDownloadRequired" xml:space="preserve">
+    <value>Cần tải xuống</value>
+  </data>
+  <data name="GameDownloading" xml:space="preserve">
+    <value>Đang tải xuống</value>
+  </data>
+  <data name="GameDownloaded" xml:space="preserve">
+    <value>Đã tải xuống</value>
+  </data>
   <data name="GameType" xml:space="preserve">
     <value>Thể loại trò chơi</value>
   </data>

--- a/OneGateApp/Properties/Strings.zh-Hans.resx
+++ b/OneGateApp/Properties/Strings.zh-Hans.resx
@@ -846,6 +846,15 @@
   <data name="GamingRecentPlayed" xml:space="preserve">
     <value>最近玩过</value>
   </data>
+  <data name="GameDownloadRequired" xml:space="preserve">
+    <value>需要下载</value>
+  </data>
+  <data name="GameDownloading" xml:space="preserve">
+    <value>下载中</value>
+  </data>
+  <data name="GameDownloaded" xml:space="preserve">
+    <value>已下载</value>
+  </data>
   <data name="GameType" xml:space="preserve">
     <value>游戏类型</value>
   </data>

--- a/OneGateApp/Properties/Strings.zh-Hant.resx
+++ b/OneGateApp/Properties/Strings.zh-Hant.resx
@@ -822,6 +822,15 @@
   <data name="GamingRecentPlayed" xml:space="preserve">
     <value>最近玩過</value>
   </data>
+  <data name="GameDownloadRequired" xml:space="preserve">
+    <value>需要下載</value>
+  </data>
+  <data name="GameDownloading" xml:space="preserve">
+    <value>下載中</value>
+  </data>
+  <data name="GameDownloaded" xml:space="preserve">
+    <value>已下載</value>
+  </data>
   <data name="GameType" xml:space="preserve">
     <value>遊戲類型</value>
   </data>

--- a/OneGateApp/Services/GameDownloadStatusService.cs
+++ b/OneGateApp/Services/GameDownloadStatusService.cs
@@ -1,8 +1,9 @@
+using Microsoft.Extensions.Logging;
 using NeoOrder.OneGate.Data;
 
 namespace NeoOrder.OneGate.Services;
 
-public sealed class GameDownloadStatusService(ApplicationDbContext dbContext)
+public sealed class GameDownloadStatusService(ApplicationDbContext dbContext, ILogger<GameDownloadStatusService> logger)
 {
     const string SettingsKey = "games/download-receipts";
 
@@ -42,7 +43,16 @@ public sealed class GameDownloadStatusService(ApplicationDbContext dbContext)
         downloadingGameIds.Remove(game.Id);
         game.DownloadStatus = GameDownloadStatus.Downloaded;
         if (receiptChanged)
-            await dbContext.Settings.PutAsync(SettingsKey, receipts);
+        {
+            try
+            {
+                await dbContext.Settings.PutAsync(SettingsKey, receipts);
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Unable to persist game download receipts");
+            }
+        }
     }
 
     public void ResetDownloading(DApp game)
@@ -58,7 +68,15 @@ public sealed class GameDownloadStatusService(ApplicationDbContext dbContext)
         await initializationLock.WaitAsync();
         try
         {
-            receipts ??= await dbContext.Settings.GetAsync<Dictionary<int, GameDownloadReceipt>>(SettingsKey) ?? [];
+            try
+            {
+                receipts ??= await dbContext.Settings.GetAsync<Dictionary<int, GameDownloadReceipt>>(SettingsKey) ?? [];
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Unable to load game download receipts");
+                receipts ??= [];
+            }
         }
         finally
         {

--- a/OneGateApp/Services/GameDownloadStatusService.cs
+++ b/OneGateApp/Services/GameDownloadStatusService.cs
@@ -1,0 +1,86 @@
+using NeoOrder.OneGate.Data;
+
+namespace NeoOrder.OneGate.Services;
+
+public sealed class GameDownloadStatusService(ApplicationDbContext dbContext)
+{
+    const string SettingsKey = "games/download-receipts";
+
+    readonly SemaphoreSlim initializationLock = new(1, 1);
+    readonly HashSet<int> downloadingGameIds = [];
+    Dictionary<int, GameDownloadReceipt>? receipts;
+
+    public async Task ApplyStatusesAsync(IEnumerable<DApp> games)
+    {
+        await EnsureInitializedAsync();
+        foreach (DApp game in games)
+            game.DownloadStatus = GetStatus(game);
+    }
+
+    public async Task MarkDownloadingAsync(DApp game)
+    {
+        if (!game.IsGamingApp || game.Id <= 0) return;
+
+        await EnsureInitializedAsync();
+        if (HasCurrentReceipt(game))
+        {
+            game.DownloadStatus = GameDownloadStatus.Downloaded;
+            return;
+        }
+
+        downloadingGameIds.Add(game.Id);
+        game.DownloadStatus = GameDownloadStatus.Downloading;
+    }
+
+    public async Task MarkDownloadedAsync(DApp game)
+    {
+        if (!game.IsGamingApp || game.Id <= 0) return;
+
+        await EnsureInitializedAsync();
+        bool receiptChanged = !HasCurrentReceipt(game);
+        receipts![game.Id] = new(game.Version, game.Url);
+        downloadingGameIds.Remove(game.Id);
+        game.DownloadStatus = GameDownloadStatus.Downloaded;
+        if (receiptChanged)
+            await dbContext.Settings.PutAsync(SettingsKey, receipts);
+    }
+
+    public void ResetDownloading(DApp game)
+    {
+        if (receipts is null || !downloadingGameIds.Remove(game.Id)) return;
+        game.DownloadStatus = GetStatus(game);
+    }
+
+    async Task EnsureInitializedAsync()
+    {
+        if (receipts is not null) return;
+
+        await initializationLock.WaitAsync();
+        try
+        {
+            receipts ??= await dbContext.Settings.GetAsync<Dictionary<int, GameDownloadReceipt>>(SettingsKey) ?? [];
+        }
+        finally
+        {
+            initializationLock.Release();
+        }
+    }
+
+    GameDownloadStatus GetStatus(DApp game)
+    {
+        if (downloadingGameIds.Contains(game.Id))
+            return GameDownloadStatus.Downloading;
+        return HasCurrentReceipt(game)
+            ? GameDownloadStatus.Downloaded
+            : GameDownloadStatus.Required;
+    }
+
+    bool HasCurrentReceipt(DApp game)
+    {
+        return receipts!.TryGetValue(game.Id, out var receipt)
+            && receipt.Version == game.Version
+            && string.Equals(receipt.Url, game.Url, StringComparison.Ordinal);
+    }
+
+    sealed record GameDownloadReceipt(int Version, string Url);
+}


### PR DESCRIPTION
## Summary

- show a compact spinner while a game is loading for the first time
- show a small green check badge after the current catalog version and URL load successfully
- persist successful-load receipts locally and invalidate them when a game's version or URL changes
- expose localized, accessible status text for required, downloading, and downloaded states

## Why

OneGate games are HTTPS WebView DApps; the catalog does not expose a native package or installer. This PR therefore treats a successful top-level WebView navigation as the honest local download/cache receipt instead of inferring state from recently played games.

Games that have not loaded successfully remain visually unmarked. A successful receipt is shown in search results, Recently played, and the main game list. Failed or abandoned first loads return to the required state.

## Validation

- Android `net10.0-android` build: 0 warnings, 0 errors
- iOS Simulator `net10.0-ios/iossimulator-arm64` build: 0 warnings, 0 errors
- Debug protocol tests: 6/6 passed
- all localized `.resx` files parse as XML and have matching unique key sets
- iPhone 17 Pro / iOS 26.5: verified unmarked required state, successful Pixudi load, green check in Recently played and the main list, and persistence across app restart
- Android API 36: APK installed and cold-launched with an empty crash buffer; the AVD currently has no QA wallet, so the authenticated Games screen was not traversed and no wallet terms were accepted on the user's behalf

Simulator screenshots are kept outside the repository and will be attached as external GitHub assets.