### PR TITLE
Fix wallet password persistence

### DIFF
--- a/OneGateApp.slnx
+++ b/OneGateApp.slnx
@@ -6,4 +6,5 @@
   <Project Path="OneGate.DebugProtocol/OneGate.DebugProtocol.csproj" />
   <Project Path="OneGate.DebugProtocol.Tests/OneGate.DebugProtocol.Tests.csproj" />
   <Project Path="OneGate.Tools/OneGate.Tools.csproj" />
+  <Project Path="tests/P1-01/PasswordPersistence.Tests.csproj" />
 </Solution>

--- a/OneGateApp/Pages/ChangePasswordPage.xaml.cs
+++ b/OneGateApp/Pages/ChangePasswordPage.xaml.cs
@@ -4,6 +4,7 @@ using NeoOrder.OneGate.Controls;
 using NeoOrder.OneGate.Controls.Views;
 using NeoOrder.OneGate.Data;
 using NeoOrder.OneGate.Properties;
+using NeoOrder.OneGate.Services;
 using Plugin.Maui.ScreenSecurity;
 
 namespace NeoOrder.OneGate.Pages;
@@ -44,7 +45,16 @@ public partial class ChangePasswordPage : ContentPage
         Submit submit = (Submit)sender;
         using (submit.EnterBusyState())
         {
-            bool success = await Task.Run(() => wallet.ChangePassword(CurrentPassword, Password));
+            bool success;
+            try
+            {
+                success = await Task.Run(() => WalletPasswordService.ChangePassword(wallet, CurrentPassword, Password));
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                errMsg.SetError(ex.Message);
+                return;
+            }
             if (success)
             {
                 await Shell.Current.GoToAsync("..");

--- a/OneGateApp/Pages/ChangePasswordPage.xaml.cs
+++ b/OneGateApp/Pages/ChangePasswordPage.xaml.cs
@@ -52,7 +52,7 @@ public partial class ChangePasswordPage : ContentPage
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
-                errMsg.SetError(ex.Message);
+                errMsg.SetError(Strings.WalletPasswordSaveFailed);
                 return;
             }
             if (success)

--- a/OneGateApp/Properties/Strings.Designer.cs
+++ b/OneGateApp/Properties/Strings.Designer.cs
@@ -3491,6 +3491,10 @@ namespace NeoOrder.OneGate.Properties {
             }
         }
 
+        internal static string WalletPasswordSaveFailed {
+            get { return ResourceManager.GetString("WalletPasswordSaveFailed", resourceCulture); }
+        }
+
         internal static string RemoteDebug {
             get { return ResourceManager.GetString("RemoteDebug", resourceCulture); }
         }

--- a/OneGateApp/Properties/Strings.resx
+++ b/OneGateApp/Properties/Strings.resx
@@ -1288,4 +1288,7 @@ It is recommended to store the NEP-2 key and password separately and back them u
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>Waiting for a trusted remote debugger</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Pair remote debugger</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>Remote debugger “{0}” is requesting access. Fingerprint: {1}. Authorize only if you trust this remote debugger.</value></data>
+  <data name="WalletPasswordSaveFailed" xml:space="preserve">
+    <value>Could not save the new password. Your current password is unchanged. Please try again.</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.zh-Hans.resx
+++ b/OneGateApp/Properties/Strings.zh-Hans.resx
@@ -1288,4 +1288,7 @@
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>正在等待已信任的远程调试器</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>配对远程调试器</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>远程调试器“{0}”正在请求访问。指纹：{1}。仅在你信任此远程调试器时授权。</value></data>
+  <data name="WalletPasswordSaveFailed" xml:space="preserve">
+    <value>无法保存新密码。当前密码未更改，请重试。</value>
+  </data>
 </root>

--- a/OneGateApp/Services/WalletPasswordService.cs
+++ b/OneGateApp/Services/WalletPasswordService.cs
@@ -1,11 +1,14 @@
 using Neo.Wallets;
 using Neo.Wallets.NEP6;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace NeoOrder.OneGate.Services;
 
 static class WalletPasswordService
 {
+    static readonly ConditionalWeakTable<Wallet, object> walletLocks = new();
+
     public static bool ChangePassword(Wallet wallet, string oldPassword, string newPassword)
         => ChangePassword(wallet, oldPassword, newPassword, SaveAtomically);
 
@@ -15,7 +18,7 @@ static class WalletPasswordService
             throw new NotSupportedException("Password changes require a NEP-6 wallet.");
 
         // Keep concurrent password changes on this wallet from interleaving.
-        lock (wallet)
+        lock (walletLocks.GetValue(wallet, static _ => new object()))
         {
             if (!wallet.ChangePassword(oldPassword, newPassword)) return false;
             try
@@ -50,7 +53,16 @@ static class WalletPasswordService
         }
         finally
         {
-            if (File.Exists(temporaryPath)) File.Delete(temporaryPath);
+            CleanupTemporaryFile(temporaryPath, File.Delete);
         }
+    }
+
+    static void CleanupTemporaryFile(string temporaryPath, Action<string> delete)
+    {
+        // A failed cleanup must not hide the original write/replace error.
+        // File.Delete is already harmless if the rename removed the temp file.
+        try { delete(temporaryPath); }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
     }
 }

--- a/OneGateApp/Services/WalletPasswordService.cs
+++ b/OneGateApp/Services/WalletPasswordService.cs
@@ -1,0 +1,56 @@
+using Neo.Wallets;
+using Neo.Wallets.NEP6;
+using System.Text;
+
+namespace NeoOrder.OneGate.Services;
+
+static class WalletPasswordService
+{
+    public static bool ChangePassword(Wallet wallet, string oldPassword, string newPassword)
+        => ChangePassword(wallet, oldPassword, newPassword, SaveAtomically);
+
+    internal static bool ChangePassword(Wallet wallet, string oldPassword, string newPassword, Action<NEP6Wallet> persist)
+    {
+        if (wallet is not NEP6Wallet nep6Wallet)
+            throw new NotSupportedException("Password changes require a NEP-6 wallet.");
+
+        // Keep concurrent password changes on this wallet from interleaving.
+        lock (wallet)
+        {
+            if (!wallet.ChangePassword(oldPassword, newPassword)) return false;
+            try
+            {
+                persist(nep6Wallet);
+                return true;
+            }
+            catch
+            {
+                // The original file was not replaced. Keep the live wallet using
+                // that same password, including when biometric settings remain.
+                wallet.ChangePassword(newPassword, oldPassword);
+                throw;
+            }
+        }
+    }
+
+    static void SaveAtomically(NEP6Wallet wallet)
+    {
+        string path = Path.GetFullPath(wallet.Path);
+        string temporaryPath = Path.Combine(Path.GetDirectoryName(path)!, $".{Path.GetFileName(path)}.{Guid.NewGuid():N}.tmp");
+        try
+        {
+            byte[] contents = Encoding.UTF8.GetBytes(wallet.ToJson().ToString());
+            using (var file = new FileStream(temporaryPath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+            {
+                file.Write(contents);
+                file.Flush(flushToDisk: true);
+            }
+            // Staging beside the wallet keeps the rename on the same filesystem.
+            File.Move(temporaryPath, path, overwrite: true);
+        }
+        finally
+        {
+            if (File.Exists(temporaryPath)) File.Delete(temporaryPath);
+        }
+    }
+}

--- a/tests/P1-01/PageStubs.cs
+++ b/tests/P1-01/PageStubs.cs
@@ -18,15 +18,21 @@ namespace NeoOrder.OneGate.Pages
     public partial class ChangePasswordPage
     {
         readonly ErrorMessage errMsg = new();
+        public string? ErrorForTest => errMsg.LastError;
         void InitializeComponent() { }
         public async Task SubmitForTestAsync()
         {
             CommunityToolkit.Maui.Alerts.Toast.Shown = new(TaskCreationOptions.RunContinuationsAsynchronously);
             OnSubmitted(new Submit(), EventArgs.Empty);
-            await CommunityToolkit.Maui.Alerts.Toast.Shown.Task.WaitAsync(TimeSpan.FromSeconds(30));
+            await Task.WhenAny(CommunityToolkit.Maui.Alerts.Toast.Shown.Task, errMsg.Shown.Task).WaitAsync(TimeSpan.FromSeconds(30));
         }
     }
-    public sealed class ErrorMessage { public void SetError(string message) { } }
+    public sealed class ErrorMessage
+    {
+        public string? LastError { get; private set; }
+        public TaskCompletionSource Shown { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public void SetError(string message) { LastError = message; Shown.TrySetResult(); }
+    }
 }
 namespace NeoOrder.OneGate.Controls { public sealed class Placeholder { } }
 namespace NeoOrder.OneGate.Controls.Views
@@ -54,6 +60,7 @@ namespace NeoOrder.OneGate.Properties
         public const string BiometricResetText = "Biometric reset";
         public const string PasswordChanged = "Password changed";
         public const string ErrorMessageIncorrectPassword = "Incorrect password";
+        public const string WalletPasswordSaveFailed = "Could not save the new password. Your current password is unchanged. Please try again.";
     }
 }
 namespace Plugin.Maui.ScreenSecurity

--- a/tests/P1-01/PageStubs.cs
+++ b/tests/P1-01/PageStubs.cs
@@ -1,0 +1,79 @@
+// The production page and Neo wallet implementation are linked unchanged.
+// Only MAUI navigation, rendering and the unrelated settings store are replaced.
+using NeoOrder.OneGate.Controls.Views;
+
+namespace NeoOrder.OneGate.Pages
+{
+    public class ContentPage
+    {
+        protected void OnPropertyChanged() { }
+        protected virtual void OnAppearing() { }
+        protected virtual void OnDisappearing() { }
+    }
+    public sealed class Shell
+    {
+        public static Shell Current { get; } = new();
+        public Task GoToAsync(string route) => Task.CompletedTask;
+    }
+    public partial class ChangePasswordPage
+    {
+        readonly ErrorMessage errMsg = new();
+        void InitializeComponent() { }
+        public async Task SubmitForTestAsync()
+        {
+            CommunityToolkit.Maui.Alerts.Toast.Shown = new(TaskCreationOptions.RunContinuationsAsynchronously);
+            OnSubmitted(new Submit(), EventArgs.Empty);
+            await CommunityToolkit.Maui.Alerts.Toast.Shown.Task.WaitAsync(TimeSpan.FromSeconds(30));
+        }
+    }
+    public sealed class ErrorMessage { public void SetError(string message) { } }
+}
+namespace NeoOrder.OneGate.Controls { public sealed class Placeholder { } }
+namespace NeoOrder.OneGate.Controls.Views
+{
+    public sealed class Submit
+    {
+        public IDisposable EnterBusyState() => new BusyState();
+        sealed class BusyState : IDisposable { public void Dispose() { } }
+    }
+}
+namespace NeoOrder.OneGate.Data
+{
+    public sealed class ApplicationDbContext { public SettingsStore Settings { get; } = new(); }
+    public sealed class SettingsStore
+    {
+        public bool HasBiometricCredential { get; private set; } = true;
+        public Task<bool> ExistsAsync(string key) => Task.FromResult(HasBiometricCredential);
+        public Task DeleteAsync(string key) { HasBiometricCredential = false; return Task.CompletedTask; }
+    }
+}
+namespace NeoOrder.OneGate.Properties
+{
+    public static class Strings
+    {
+        public const string BiometricResetText = "Biometric reset";
+        public const string PasswordChanged = "Password changed";
+        public const string ErrorMessageIncorrectPassword = "Incorrect password";
+    }
+}
+namespace Plugin.Maui.ScreenSecurity
+{
+    public interface IScreenSecurity
+    {
+        void ActivateScreenSecurityProtection();
+        void DeactivateScreenSecurityProtection();
+    }
+}
+public sealed class ScreenSecurity : Plugin.Maui.ScreenSecurity.IScreenSecurity
+{
+    public void ActivateScreenSecurityProtection() { }
+    public void DeactivateScreenSecurityProtection() { }
+}
+namespace CommunityToolkit.Maui.Alerts
+{
+    public static class Toast
+    {
+        public static TaskCompletionSource Shown { get; set; } = new();
+        public static Task Show(string message) { Shown.TrySetResult(); return Task.CompletedTask; }
+    }
+}

--- a/tests/P1-01/PasswordPersistence.Tests.csproj
+++ b/tests/P1-01/PasswordPersistence.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../OneGateApp/OneGateApp.csproj" ReferenceOutputAssembly="false" BuildReference="false" SkipGetTargetFrameworkProperties="true" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="Neo" Version="3.10.0" />
+    <Compile Include="../../OneGateApp/Pages/ChangePasswordPage.xaml.cs" Link="ChangePasswordPage.cs" />
+    <Compile Include="../../OneGateApp/Services/WalletPasswordService.cs" Link="WalletPasswordService.cs" Condition="Exists('../../OneGateApp/Services/WalletPasswordService.cs')" />
+  </ItemGroup>
+</Project>

--- a/tests/P1-01/PasswordPersistenceTests.cs
+++ b/tests/P1-01/PasswordPersistenceTests.cs
@@ -3,6 +3,8 @@ using Neo.Wallets;
 using NeoOrder.OneGate.Data;
 using NeoOrder.OneGate.Pages;
 using NeoOrder.OneGate.Services;
+using NeoOrder.OneGate.Properties;
+using System.Reflection;
 using Xunit;
 
 public class PasswordPersistenceTests
@@ -51,6 +53,110 @@ public class PasswordPersistenceTests
         Wallet reopened = Wallet.Open(fixture.Wallet.Path, null, ProtocolSettings.Default)!;
         Assert.True(reopened.VerifyPassword(WalletFixture.OldPassword));
         Assert.Single(Directory.GetFiles(Path.GetDirectoryName(fixture.Wallet.Path)!));
+    }
+
+    [Fact]
+    public async Task Failed_page_save_shows_generic_localized_error_without_private_path()
+    {
+        using var fixture = new WalletFixture();
+        // A directory at the wallet's destination deterministically rejects the
+        // final atomic replacement on every platform, without touching real data.
+        File.Move(fixture.Wallet.Path, fixture.Wallet.Path + ".original");
+        Directory.CreateDirectory(fixture.Wallet.Path);
+        var settings = new ApplicationDbContext();
+        var page = new ChangePasswordPage(new ScreenSecurity(), settings, fixture)
+        {
+            CurrentPassword = WalletFixture.OldPassword,
+            Password = WalletFixture.NewPassword
+        };
+        await page.SubmitForTestAsync();
+        Assert.Equal(Strings.WalletPasswordSaveFailed, page.ErrorForTest);
+        Assert.DoesNotContain(fixture.Wallet.Path, page.ErrorForTest!);
+        Assert.True(settings.Settings.HasBiometricCredential);
+        Assert.True(fixture.Wallet.VerifyPassword(WalletFixture.OldPassword));
+    }
+
+    [Fact]
+    public async Task Password_service_does_not_lock_public_wallet_object()
+    {
+        using var fixture = new WalletFixture();
+        using var releaseMonitor = new ManualResetEventSlim();
+        var monitorEntered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task holder = Task.Run(() =>
+        {
+            lock (fixture.Wallet)
+            {
+                monitorEntered.SetResult();
+                releaseMonitor.Wait();
+            }
+        });
+        await monitorEntered.Task;
+        Task<bool> changing = Task.Run(() => WalletPasswordService.ChangePassword(fixture.Wallet,
+                WalletFixture.OldPassword, WalletFixture.NewPassword, _ => { }));
+        bool completedWhileWalletLocked;
+        try
+        {
+            completedWhileWalletLocked = await Task.WhenAny(changing, Task.Delay(TimeSpan.FromSeconds(8))) == changing;
+        }
+        finally
+        {
+            releaseMonitor.Set();
+            await holder;
+        }
+        Assert.True(await changing);
+        Assert.True(completedWhileWalletLocked, "An unrelated monitor on the wallet must not block the password service.");
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Cleanup_failure_does_not_replace_original_save_exception(bool denied)
+    {
+        using var fixture = new WalletFixture();
+        var cleanup = typeof(WalletPasswordService).GetMethod("CleanupTemporaryFile", BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(cleanup);
+        var original = new IOException("Original staging write failure");
+        Action<string> failingDelete = _ => throw (denied
+            ? new UnauthorizedAccessException("Cleanup denied")
+            : new IOException("Cleanup locked"));
+        Exception actual = Assert.Throws<IOException>(() => WalletPasswordService.ChangePassword(fixture.Wallet,
+            WalletFixture.OldPassword, WalletFixture.NewPassword, _ =>
+            {
+                try { throw original; }
+                finally { cleanup.Invoke(null, ["temporary-regression-file", failingDelete]); }
+            }));
+        Assert.Same(original, actual);
+        Assert.True(fixture.Wallet.VerifyPassword(WalletFixture.OldPassword));
+    }
+
+    [Fact]
+    public async Task Private_gate_still_serializes_changes_for_the_same_wallet()
+    {
+        using var fixture = new WalletFixture();
+        using var releaseFirstSave = new ManualResetEventSlim();
+        var firstSaving = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondSaving = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task<bool> first = Task.Run(() => WalletPasswordService.ChangePassword(fixture.Wallet,
+            WalletFixture.OldPassword, WalletFixture.NewPassword, wallet =>
+            {
+                firstSaving.SetResult();
+                releaseFirstSave.Wait();
+                wallet.Save();
+            }));
+        await firstSaving.Task;
+        const string finalPassword = "final-regression-password";
+        Task<bool> second = Task.Run(() => WalletPasswordService.ChangePassword(fixture.Wallet,
+            WalletFixture.NewPassword, finalPassword, wallet => { secondSaving.SetResult(); wallet.Save(); }));
+        bool overlapped;
+        try
+        {
+            overlapped = await Task.WhenAny(secondSaving.Task, Task.Delay(500)) == secondSaving.Task;
+        }
+        finally { releaseFirstSave.Set(); }
+        Assert.True(await first);
+        Assert.True(await second);
+        Assert.False(overlapped, "The next password change must wait for the first file save.");
+        Assert.True(Wallet.Open(fixture.Wallet.Path, null, ProtocolSettings.Default)!.VerifyPassword(finalPassword));
     }
 }
 

--- a/tests/P1-01/PasswordPersistenceTests.cs
+++ b/tests/P1-01/PasswordPersistenceTests.cs
@@ -1,0 +1,72 @@
+using Neo;
+using Neo.Wallets;
+using NeoOrder.OneGate.Data;
+using NeoOrder.OneGate.Pages;
+using NeoOrder.OneGate.Services;
+using Xunit;
+
+public class PasswordPersistenceTests
+{
+    [Fact]
+    public async Task Successful_page_submission_persists_new_password_before_success()
+    {
+        using var fixture = new WalletFixture();
+        var settings = new ApplicationDbContext();
+        var page = new ChangePasswordPage(new ScreenSecurity(), settings, fixture)
+        {
+            CurrentPassword = WalletFixture.OldPassword,
+            Password = WalletFixture.NewPassword
+        };
+        await page.SubmitForTestAsync();
+
+        Wallet reopened = Wallet.Open(fixture.Wallet.Path, null, ProtocolSettings.Default)!;
+        Assert.True(reopened.VerifyPassword(WalletFixture.NewPassword));
+        Assert.False(reopened.VerifyPassword(WalletFixture.OldPassword));
+        Assert.False(settings.Settings.HasBiometricCredential);
+    }
+
+    [Fact]
+    public void Wrong_password_does_not_write_or_change_wallet()
+    {
+        using var fixture = new WalletFixture();
+        byte[] before = File.ReadAllBytes(fixture.Wallet.Path);
+        bool persisted = false;
+        Assert.False(WalletPasswordService.ChangePassword(fixture.Wallet, "incorrect", WalletFixture.NewPassword, _ => persisted = true));
+        Assert.False(persisted);
+        Assert.Equal(before, File.ReadAllBytes(fixture.Wallet.Path));
+        Assert.True(fixture.Wallet.VerifyPassword(WalletFixture.OldPassword));
+    }
+
+    [Fact]
+    public void Failed_save_preserves_original_file_and_live_password()
+    {
+        using var fixture = new WalletFixture();
+        byte[] before = File.ReadAllBytes(fixture.Wallet.Path);
+        Assert.Throws<IOException>(() => WalletPasswordService.ChangePassword(fixture.Wallet,
+            WalletFixture.OldPassword, WalletFixture.NewPassword, _ => throw new IOException("Simulated full disk")));
+
+        Assert.Equal(before, File.ReadAllBytes(fixture.Wallet.Path));
+        Assert.True(fixture.Wallet.VerifyPassword(WalletFixture.OldPassword));
+        Assert.False(fixture.Wallet.VerifyPassword(WalletFixture.NewPassword));
+        Wallet reopened = Wallet.Open(fixture.Wallet.Path, null, ProtocolSettings.Default)!;
+        Assert.True(reopened.VerifyPassword(WalletFixture.OldPassword));
+        Assert.Single(Directory.GetFiles(Path.GetDirectoryName(fixture.Wallet.Path)!));
+    }
+}
+
+sealed class WalletFixture : IWalletProvider, IDisposable
+{
+    public const string OldPassword = "old-regression-password";
+    public const string NewPassword = "new-regression-password";
+    readonly string directory = Directory.CreateTempSubdirectory("onegate-password-test-").FullName;
+    public Wallet Wallet { get; }
+    public event EventHandler<Wallet?>? WalletChanged { add { } remove { } }
+    public WalletFixture()
+    {
+        Wallet = Neo.Wallets.Wallet.Create("Disposable regression wallet", Path.Combine(directory, "wallet.json"), OldPassword, ProtocolSettings.Default)!;
+        Wallet.CreateAccount();
+        Wallet.Save();
+    }
+    public Wallet? GetWallet() => Wallet;
+    public void Dispose() => Directory.Delete(directory, true);
+}

--- a/tests/P1-01/README.md
+++ b/tests/P1-01/README.md
@@ -10,3 +10,9 @@ directory; no real wallet, credentials, network or funds are used.
 The essential invariant is that a success notification means a newly opened
 wallet file accepts the new password and rejects the old password. Biometric
 configuration must remain intact when a password change is not committed.
+
+PR review regressions also exercise a real failing file replacement through the
+page (show a generic localized message, never a filesystem path), independence
+from external locks on the public wallet object, and serialization of two
+password changes using the private per-wallet gate. Injected cleanup failures
+cover both I/O and access-denied errors without masking the original save error.

--- a/tests/P1-01/README.md
+++ b/tests/P1-01/README.md
@@ -1,0 +1,12 @@
+# P1-01 password persistence regression
+
+Run `dotnet test tests/P1-01/PasswordPersistence.Tests.csproj`.
+
+The test links the production change-password page and the actual Neo 3.10.0
+wallet implementation. MAUI visual/navigation objects are replaced with small
+test doubles. Every wallet is newly generated in a disposable temporary
+directory; no real wallet, credentials, network or funds are used.
+
+The essential invariant is that a success notification means a newly opened
+wallet file accepts the new password and rejects the old password. Biometric
+configuration must remain intact when a password change is not committed.


### PR DESCRIPTION
## Problem

Changing the wallet password updated the live NEP-6 wallet but did not save it. After restarting, the old password still opened the wallet and the new password did not.

## Change

- Persist the updated wallet through a same-directory temporary file, flush it, and replace the wallet file before reporting success.
- Restore the live wallet's old password if persistence fails, and keep the password page open with an error.
- Use a private per-wallet synchronization object, show a localized save-failure message, and preserve the original error if temporary-file cleanup fails.
- Add isolated regression tests registered in the solution.

This PR addresses audit P1-01 only and is based on master `623603d`.

## Validation

- Regression tests: 8 passed; the disk-reload case failed against the previous implementation. Follow-up tests cover private-lock behavior, serialization of concurrent password changes, user-facing error text and best-effort cleanup.
- iOS 26.5 iPhone 17 simulator: used the actual Change Password page, terminated and relaunched the app, then verified the saved wallet accepts the new password, rejects the old password, and preserves its account.
- Android API 36 arm64 emulator: repeated the same native password-change and restart flow with the same three checks passing.
- Both platforms: removed the local test fixture, rebuilt the product, and smoke-launched the normal app successfully. Both product builds had zero warnings/errors.
- Repeated the native password-change/restart checks and fixture-free full product rebuild/smoke on both platforms after the review follow-up.
- Disk-write failure rollback is covered by local regression tests, not simulator filesystem fault injection.

Simulator testing used a separate application ID and disposable unfunded wallet. Screenshots and test-only fixtures remain outside the repository. No live transaction was signed or broadcast.
