### PR TITLE
Assert successful token transfer results

### DIFF
--- a/OneGateApp.slnx
+++ b/OneGateApp.slnx
@@ -6,4 +6,5 @@
   <Project Path="OneGate.DebugProtocol/OneGate.DebugProtocol.csproj" />
   <Project Path="OneGate.DebugProtocol.Tests/OneGate.DebugProtocol.Tests.csproj" />
   <Project Path="OneGate.Tools/OneGate.Tools.csproj" />
+  <Project Path="tests/p1-02/TransferScript.Tests.csproj" />
 </Solution>

--- a/OneGateApp/Services/RPC/RpcClient.cs
+++ b/OneGateApp/Services/RPC/RpcClient.cs
@@ -228,9 +228,7 @@ public class RpcClient(IWalletProvider walletProvider, ProtocolSettings protocol
             Account = from,
             Scopes = WitnessScope.CalledByEntry
         };
-        byte[] script;
-        using (var sb = new ScriptBuilder())
-            script = sb.EmitDynamicCall(assetId, "transfer", from, to, amount, data).ToArray();
+        byte[] script = TransferScript.Nep17(assetId, from, to, amount, data);
         return await MakeTransactionAsync(script, from, [signer], []);
     }
 
@@ -242,9 +240,7 @@ public class RpcClient(IWalletProvider walletProvider, ProtocolSettings protocol
             Account = from,
             Scopes = WitnessScope.CalledByEntry
         };
-        byte[] script;
-        using (var sb = new ScriptBuilder())
-            script = sb.EmitDynamicCall(collectionId, "transfer", to, tokenId, data).ToArray();
+        byte[] script = TransferScript.Nep11(collectionId, tokenId, to, data);
         return await MakeTransactionAsync(script, from, [signer], []);
     }
 

--- a/OneGateApp/Services/RPC/TransferScript.cs
+++ b/OneGateApp/Services/RPC/TransferScript.cs
@@ -1,0 +1,22 @@
+using Neo;
+using Neo.Extensions;
+using Neo.SmartContract;
+using Neo.VM;
+using System.Numerics;
+
+namespace NeoOrder.OneGate.Services.RPC;
+
+internal static class TransferScript
+{
+    public static byte[] Nep17(UInt160 assetId, UInt160 from, UInt160 to, BigInteger amount, ContractParameter? data)
+    {
+        using var builder = new ScriptBuilder();
+        return builder.EmitDynamicCall(assetId, "transfer", from, to, amount, data).Emit(OpCode.ASSERT).ToArray();
+    }
+
+    public static byte[] Nep11(UInt160 collectionId, byte[] tokenId, UInt160 to, ContractParameter? data)
+    {
+        using var builder = new ScriptBuilder();
+        return builder.EmitDynamicCall(collectionId, "transfer", to, tokenId, data).Emit(OpCode.ASSERT).ToArray();
+    }
+}

--- a/tests/p1-02/TransferScript.Tests.csproj
+++ b/tests/p1-02/TransferScript.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" PrivateAssets="all" />
+    <PackageReference Include="Neo" Version="3.10.0" />
+    <Compile Include="../../OneGateApp/Services/RPC/TransferScript.cs" Link="TransferScript.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../OneGateApp/OneGateApp.csproj" ReferenceOutputAssembly="false" BuildReference="false" SkipGetTargetFrameworkProperties="true" />
+  </ItemGroup>
+</Project>

--- a/tests/p1-02/TransferScriptTests.cs
+++ b/tests/p1-02/TransferScriptTests.cs
@@ -1,0 +1,50 @@
+using Neo;
+using Neo.VM;
+using NeoOrder.OneGate.Services.RPC;
+using Xunit;
+
+public class TransferScriptTests
+{
+    [Theory]
+    [InlineData(false, true, VMState.HALT)]
+    [InlineData(false, false, VMState.FAULT)]
+    [InlineData(true, true, VMState.HALT)]
+    [InlineData(true, false, VMState.FAULT)]
+    public void TransferMustReturnTrue(bool nft, bool result, VMState expected)
+    {
+        Assert.Equal(expected, Execute(Script(nft), result));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void ChangedResultAfterSimulationFaults(bool nft)
+    {
+        byte[] script = Script(nft);
+        Assert.Equal(VMState.HALT, Execute(script, true));
+        Assert.Equal(VMState.FAULT, Execute(script, false));
+        Assert.Equal(VMState.FAULT, Execute(script, null));
+    }
+
+    static byte[] Script(bool nft) => nft
+        ? TransferScript.Nep11(UInt160.Zero, [1], UInt160.Zero, null)
+        : TransferScript.Nep17(UInt160.Zero, UInt160.Zero, UInt160.Zero, 1, null);
+
+    // Run the real emitted script in Neo VM, substituting only the contract syscall.
+    static VMState Execute(byte[] script, bool? contractResult)
+    {
+        var table = new JumpTable();
+        table[OpCode.SYSCALL] = (engine, instruction) =>
+        {
+            engine.Pop(); // contract hash
+            engine.Pop(); // method
+            engine.Pop(); // call flags
+            engine.Pop(); // arguments
+            if (!contractResult.HasValue) throw new InvalidOperationException("Contract FAULT");
+            engine.Push(contractResult.Value);
+        };
+        using var engine = new ExecutionEngine(table);
+        engine.LoadScript(script);
+        return engine.Execute();
+    }
+}


### PR DESCRIPTION
## Problem

The wallet's NEP-17 and NEP-11 transfer scripts discarded the contract's boolean return value. A contract returning `false` could therefore leave the VM in HALT without completing a transfer.

## Change

Append `ASSERT` to both emitted transfer scripts so failure is enforced in the transaction script itself, including when execution differs from preflight simulation. Add focused Neo VM regressions to the solution.

This independent PR addresses audit P1-02 only, based on master `623603d`.

## Validation

- 6 regression tests passed, using the real emitted scripts and Neo VM. Four cases failed against the original implementation.
- iOS 26.5 iPhone 17 simulator and Android API 36 arm64 emulator: each ran 11 native-app assertions through the production `RpcClient` and Neo VM. Both token standards accepted true, rejected false/FAULT during simulation, and faulted on false/FAULT when executing an already-created script.
- The node HTTP responses and contract syscall outcomes were controlled local fixtures. No live chain transaction was signed or broadcast; this is not a live-token integration test.
- Removed the local fixture, rebuilt and smoke-launched the normal product on both platforms. Both product builds had zero warnings/errors.

Simulator screenshots, result JSON and test-only fixture code remain outside the repository.
