### PR TITLE
Fix mnemonic word deselection

### DIFF
--- a/OneGateApp.slnx
+++ b/OneGateApp.slnx
@@ -6,4 +6,5 @@
   <Project Path="OneGate.DebugProtocol/OneGate.DebugProtocol.csproj" />
   <Project Path="OneGate.DebugProtocol.Tests/OneGate.DebugProtocol.Tests.csproj" />
   <Project Path="OneGate.Tools/OneGate.Tools.csproj" />
+  <Project Path="tests/P2-01/MnemonicSelection.Tests.csproj" />
 </Solution>

--- a/OneGateApp/Pages/VerifyMnemonicPage.xaml.cs
+++ b/OneGateApp/Pages/VerifyMnemonicPage.xaml.cs
@@ -7,6 +7,7 @@ public partial class VerifyMnemonicPage : ContentPage
 {
     readonly IServiceProvider serviceProvider;
     readonly IScreenSecurity screenSecurity;
+    readonly List<Button> selectedWords = [];
 
     public bool ShowSkip { get; set { field = value; OnPropertyChanged(); } }
 
@@ -34,20 +35,16 @@ public partial class VerifyMnemonicPage : ContentPage
     void Word_Clicked(object sender, EventArgs e)
     {
         Button button = (Button)sender;
-        if (button.Opacity < 0.5)
+        if (selectedWords.Remove(button))
         {
-            int index = editorMnemonic.Text.LastIndexOf(button.Text);
-            editorMnemonic.Text = editorMnemonic.Text.Remove(index, 1).Replace("  ", " ").Trim();
             button.Opacity = 1.0;
         }
         else
         {
-            if (string.IsNullOrWhiteSpace(editorMnemonic.Text))
-                editorMnemonic.Text = button.Text;
-            else
-                editorMnemonic.Text += " " + button.Text;
+            selectedWords.Add(button);
             button.Opacity = 0.1;
         }
+        editorMnemonic.Text = string.Join(" ", selectedWords.Select(word => word.Text));
     }
 
     void OnKonamiCodeEntered(object sender, EventArgs e)

--- a/tests/P2-01/MnemonicSelection.Tests.csproj
+++ b/tests/P2-01/MnemonicSelection.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../OneGateApp/OneGateApp.csproj" ReferenceOutputAssembly="false" BuildReference="false" SkipGetTargetFrameworkProperties="true" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <Compile Include="../../OneGateApp/Pages/VerifyMnemonicPage.xaml.cs" Link="VerifyMnemonicPage.cs" />
+  </ItemGroup>
+</Project>

--- a/tests/P2-01/MnemonicSelectionTests.cs
+++ b/tests/P2-01/MnemonicSelectionTests.cs
@@ -1,0 +1,62 @@
+using NeoOrder.OneGate.Pages;
+using Xunit;
+
+public class MnemonicSelectionTests
+{
+    [Fact]
+    public void Deselect_removes_the_whole_word_and_reselection_restores_it()
+    {
+        var page = NewPage();
+        var word = new Button { Text = "abandon" };
+        page.SelectForTest(word);
+        Assert.Equal("abandon", page.PhraseForTest);
+        page.SelectForTest(word);
+        Assert.Equal("", page.PhraseForTest);
+        Assert.Equal(1, word.Opacity);
+        page.SelectForTest(word);
+        Assert.Equal("abandon", page.PhraseForTest);
+    }
+
+    [Fact]
+    public void Deselecting_a_middle_word_preserves_other_whole_words()
+    {
+        var page = NewPage();
+        var first = new Button { Text = "abandon" };
+        var middle = new Button { Text = "ability" };
+        var last = new Button { Text = "able" };
+        page.SelectForTest(first);
+        page.SelectForTest(middle);
+        page.SelectForTest(last);
+        page.SelectForTest(middle);
+        Assert.Equal("abandon able", page.PhraseForTest);
+        page.SelectForTest(middle);
+        Assert.Equal("abandon able ability", page.PhraseForTest);
+    }
+
+    [Fact]
+    public void Equal_words_are_independent_instances_in_the_selected_order()
+    {
+        var page = NewPage();
+        var first = new Button { Text = "abandon" };
+        var middle = new Button { Text = "ability" };
+        var last = new Button { Text = "abandon" };
+        page.SelectForTest(first);
+        page.SelectForTest(middle);
+        page.SelectForTest(last);
+        page.SelectForTest(first);
+        Assert.Equal("ability abandon", page.PhraseForTest);
+        Assert.Equal(1, first.Opacity);
+        Assert.Equal(0.1, last.Opacity);
+    }
+
+    [Fact]
+    public void Complete_phrase_keeps_every_word_in_the_selected_order()
+    {
+        var page = NewPage();
+        string[] words = ["abandon", "ability", "able", "about", "above", "absent", "absorb", "abstract", "absurd", "abuse", "access", "accident"];
+        foreach (string word in words) page.SelectForTest(new Button { Text = word });
+        Assert.Equal(string.Join(" ", words), page.PhraseForTest);
+    }
+
+    static VerifyMnemonicPage NewPage() => new(new EmptyServices(), new ScreenSecurity());
+}

--- a/tests/P2-01/PageStubs.cs
+++ b/tests/P2-01/PageStubs.cs
@@ -1,0 +1,42 @@
+// Link the actual production click handler; replace only MAUI rendering/navigation.
+namespace NeoOrder.OneGate.Pages
+{
+    public class Page { public object? BindingContext { get; set; } }
+    public class ContentPage : Page
+    {
+        public Navigation Navigation { get; } = new();
+        protected void OnPropertyChanged() { }
+        protected virtual void OnAppearing() { }
+        protected virtual void OnDisappearing() { }
+    }
+    public sealed class Navigation { public Task PushAsync(Page page) => Task.CompletedTask; }
+    public sealed class CreatePasswordPage : Page { }
+    public sealed class Button
+    {
+        public string Text { get; set; } = "";
+        public double Opacity { get; set; } = 1;
+    }
+    public sealed class Editor { public string Text { get; set; } = ""; }
+    public partial class VerifyMnemonicPage
+    {
+        readonly Editor editorMnemonic = new();
+        void InitializeComponent() { }
+        public void SelectForTest(Button word) => Word_Clicked(word, EventArgs.Empty);
+        public string PhraseForTest => editorMnemonic.Text;
+    }
+}
+namespace NeoOrder.OneGate.Services
+{
+    public static class ServiceExtensions
+    {
+        public static T GetServiceOrCreateInstance<T>(this IServiceProvider services) where T : new() => new();
+    }
+    public static class ScreenSecurityCoordinator
+    {
+        public static void Enter(Plugin.Maui.ScreenSecurity.IScreenSecurity screenSecurity) { }
+        public static void Exit(Plugin.Maui.ScreenSecurity.IScreenSecurity screenSecurity) { }
+    }
+}
+namespace Plugin.Maui.ScreenSecurity { public interface IScreenSecurity { } }
+public sealed class ScreenSecurity : Plugin.Maui.ScreenSecurity.IScreenSecurity { }
+public sealed class EmptyServices : IServiceProvider { public object? GetService(Type type) => null; }

--- a/tests/P2-01/README.md
+++ b/tests/P2-01/README.md
@@ -1,0 +1,11 @@
+# P2-01 mnemonic word selection regression
+
+Run `dotnet test tests/P2-01/MnemonicSelection.Tests.csproj`.
+
+Tests execute the linked production VerifyMnemonicPage click handler using
+synthetic words and lightweight visual doubles. They cover complete removal,
+middle-word correction, repeated-word identity and complete selection order.
+No real mnemonic or wallet is read or created.
+
+Device check: create a disposable wallet, select a word, tap it again, then
+reselect it. Repeat with a middle word and finish verification normally.


### PR DESCRIPTION
## Problem

Deselecting a mnemonic word removed one character instead of the selected word. Matching by text also could not distinguish repeated-word buttons.

## Change

Track selected button instances in order and rebuild the phrase from the selected words. Removing or reselecting one occurrence no longer damages another occurrence or a substring.

This independent PR addresses audit P2-01 only, based on master `623603d`.

## Validation

- 4 regression tests passed; three failed with the original implementation.
- iOS 26.5 iPhone 17 simulator and Android API 36 arm64 emulator: exercised the actual `VerifyMnemonicPage` controls and handlers. Both passed six checks for whole-word removal, middle-word removal, reselection, independent duplicate occurrences, the complete phrase, and the production validator.
- Used a public synthetic test phrase; wallet creation was disabled in the external fixture. No real seed or funded wallet was accessed.
- Removed the fixture and rebuilt/installed the normal product on both platforms; startup smoke passed with zero build warnings/errors.
- Android screen protection remained enabled; the protected mnemonic screen was not used for the evidence screenshot. The visible result summary was captured instead.

Screenshots, native result JSON and simulator-only fixture code remain outside the repository.
