### PR TITLE
Preserve exact localized payment amounts

### DIFF
--- a/OneGateApp.slnx
+++ b/OneGateApp.slnx
@@ -6,4 +6,5 @@
   <Project Path="OneGate.DebugProtocol/OneGate.DebugProtocol.csproj" />
   <Project Path="OneGate.DebugProtocol.Tests/OneGate.DebugProtocol.Tests.csproj" />
   <Project Path="OneGate.Tools/OneGate.Tools.csproj" />
+  <Project Path="tests/P2-02/TokenAmount.Tests.csproj" />
 </Solution>

--- a/OneGateApp/Models/AppLinks/PaymentAction.cs
+++ b/OneGateApp/Models/AppLinks/PaymentAction.cs
@@ -2,6 +2,7 @@
 using Neo.SmartContract.Native;
 using NeoOrder.OneGate.Pages;
 using NeoOrder.OneGate.Services;
+using System.Globalization;
 using System.Web;
 
 namespace NeoOrder.OneGate.Models.AppLinks;
@@ -11,7 +12,7 @@ class PaymentAction : AppLinkAction
     protected override string Route => "//wallet/send";
     public string Recipient { get; }
     public UInt160? AssetId { get; }
-    public decimal? Amount { get; }
+    public string? Amount { get; }
 
     public PaymentAction(Uri uri)
     {
@@ -24,7 +25,13 @@ class PaymentAction : AppLinkAction
         if (nv["asset"] is string s_asset && !string.IsNullOrWhiteSpace(s_asset))
             AssetId = ParseAssetId(s_asset);
         if (nv["amount"] is string s_amount)
-            Amount = decimal.Parse(s_amount);
+        {
+            // A payment URI always uses an ungrouped dot-decimal amount. Keep
+            // the digits intact until the selected token's precision is known.
+            if (!TokenAmount.TryParse(s_amount, byte.MaxValue, out _, CultureInfo.InvariantCulture))
+                throw new FormatException("Invalid payment amount.");
+            Amount = s_amount.Trim();
+        }
     }
 
     protected override IDictionary<string, object> CreateQuery()
@@ -34,7 +41,7 @@ class PaymentAction : AppLinkAction
             ["address"] = Recipient
         };
         if (AssetId is not null) query["asset"] = AssetId;
-        if (Amount.HasValue) query["amount"] = Amount.Value;
+        if (Amount is not null) query["amount"] = Amount;
         return query;
     }
 

--- a/OneGateApp/Pages/ScanPage.xaml.cs
+++ b/OneGateApp/Pages/ScanPage.xaml.cs
@@ -164,8 +164,8 @@ public partial class ScanPage : ContentPage, IQueryAttributable
         string query = "?address=" + uri.LocalPath;
         if (payment.AssetId is not null)
             query += $"&asset={payment.AssetId}";
-        if (payment.Amount.HasValue)
-            query += $"&amount={payment.Amount}";
+        if (payment.Amount is not null)
+            query += $"&amount={Uri.EscapeDataString(payment.Amount)}";
         switch (action)
         {
             case "RecognizeAddress":

--- a/OneGateApp/Pages/SendPage.xaml
+++ b/OneGateApp/Pages/SendPage.xaml
@@ -59,14 +59,13 @@
                 <Label StyleClass="Secondary" Text="{x:Static og:Strings.Amount}" />
                 <Border StrokeShape="RoundRectangle 5" Margin="0,-16,0,0">
                     <Grid ColumnDefinitions="*,auto" Padding="10,5" BackgroundColor="{toolkit:AppThemeResource TextBox}">
-                        <Entry x:Name="entryAmount" Text="{Binding Amount}" Keyboard="Numeric" ClearButtonVisibility="Never" og:Border.IsVisible="False" SemanticProperties.Description="{x:Static og:Strings.Amount}" />
+                        <Entry x:Name="entryAmount" Text="{Binding AmountText}" Keyboard="Numeric" ClearButtonVisibility="Never" og:Border.IsVisible="False" SemanticProperties.Description="{x:Static og:Strings.Amount}" />
                         <Button Grid.Column="1" StyleClass="Link" Text="{x:Static og:Strings.All}" Margin="0,-10" Padding="10" VerticalOptions="Center" Clicked="OnSelectAllBalance" />
                     </Grid>
                 </Border>
                 <og:ValidationMessage x:Name="validationAmount" Title="{x:Static og:Strings.Amount}" Margin="0,-16,0,0" Target="{x:Reference entryAmount}">
                     <og:Required />
                     <og:Custom Validate="OnValidateAmount" />
-                    <og:Range x:TypeArguments="x:Decimal" Minimum="0" IsMinimumIncluded="False" Maximum="{Binding SelectedAsset.DecimalBalance, StringFormat='{}{0}'}" />
                 </og:ValidationMessage>
                 <Grid ColumnDefinitions="*,auto" Margin="0,-16,0,0">
                     <Label>

--- a/OneGateApp/Pages/SendPage.xaml.cs
+++ b/OneGateApp/Pages/SendPage.xaml.cs
@@ -16,6 +16,7 @@ using NeoOrder.OneGate.Models.Intents;
 using NeoOrder.OneGate.Properties;
 using NeoOrder.OneGate.Services;
 using NeoOrder.OneGate.Services.RPC;
+using System.Globalization;
 using System.Numerics;
 using Contact = NeoOrder.OneGate.Data.Contact;
 
@@ -45,7 +46,9 @@ public partial class SendPage : ContentPage, IQueryAttributable
             _ = RefreshAddressInsightsAsync();
         }
     }
-    public decimal Amount { get; set { field = value; OnPropertyChanged(); } }
+    public string? AmountText { get; set { field = value; OnPropertyChanged(); OnPropertyChanged(nameof(Amount)); } } = "0";
+    // Fiat valuation is optional; chain amounts never pass through decimal.
+    public decimal? Amount => decimal.TryParse(AmountText, NumberStyles.AllowDecimalPoint, CultureInfo.CurrentCulture, out var amount) ? amount : null;
     public Contact? MatchedContact { get; set { field = value; OnPropertyChanged(); OnPropertyChanged(nameof(HasAddressInsight)); OnPropertyChanged(nameof(AddressInsightTitle)); OnPropertyChanged(nameof(AddressInsightText)); } }
     public bool IsOwnWalletAddress { get; set { field = value; OnPropertyChanged(); OnPropertyChanged(nameof(HasAddressInsight)); OnPropertyChanged(nameof(AddressInsightTitle)); OnPropertyChanged(nameof(AddressInsightText)); } }
     public bool IsUnknownValidAddress { get; set { field = value; OnPropertyChanged(); OnPropertyChanged(nameof(HasAddressInsight)); OnPropertyChanged(nameof(AddressInsightTitle)); OnPropertyChanged(nameof(AddressInsightText)); } }
@@ -90,11 +93,11 @@ public partial class SendPage : ContentPage, IQueryAttributable
         }
         if (query.TryGetValue("amount", out var obj_amount))
         {
-            if (Amount == 0) Amount = obj_amount switch
+            if (string.IsNullOrEmpty(AmountText) || AmountText == "0") AmountText = obj_amount switch
             {
-                string s => decimal.Parse(s),
-                decimal d => d,
-                _ => 0
+                string s => s.Replace(".", CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator),
+                decimal d => d.ToString(CultureInfo.CurrentCulture),
+                _ => "0"
             };
         }
         if (Assets is null && query.TryGetValue("assets", out var obj_assets))
@@ -227,13 +230,14 @@ public partial class SendPage : ContentPage, IQueryAttributable
 
     void OnSelectAllBalance(object sender, EventArgs e)
     {
-        Amount = decimal.Parse(SelectedAsset.DecimalBalance.ToString());
+        AmountText = TokenAmount.Format(SelectedAsset.Balance, SelectedAsset.Token.Decimals);
     }
 
     void OnValidateAmount(object sender, CustomValidationEventArgs e)
     {
-        string text = (string)e.Value!;
-        e.IsValid = BigDecimal.TryParse(text, SelectedAsset.Token.Decimals, out _);
+        e.IsValid = SelectedAsset is not null
+            && TokenAmount.TryParse(e.Value as string, SelectedAsset.Token.Decimals, out var amount)
+            && amount > 0 && amount <= SelectedAsset.Balance;
     }
 
     async void OnSubmitted(object sender, EventArgs e)
@@ -245,7 +249,8 @@ public partial class SendPage : ContentPage, IQueryAttributable
             UInt160 from = account.ScriptHash;
             if (!TryReadAddress(ToAddress, out string toAddress)) return;
             UInt160 to = toAddress.ToScriptHash(protocolSettings.AddressVersion);
-            BigInteger amount = BigDecimal.Parse(entryAmount.Text, SelectedAsset.Token.Decimals).Value;
+            if (!TokenAmount.TryParse(entryAmount.Text, SelectedAsset.Token.Decimals, out BigInteger amount)
+                || amount <= 0 || amount > SelectedAsset.Balance) return;
             TransactionIntent[] intents = [new TransferIntent
             {
                 Asset = SelectedAsset.Token,
@@ -265,7 +270,7 @@ public partial class SendPage : ContentPage, IQueryAttributable
             }
             if (SelectedAsset.Token.Hash == NativeContract.GAS.Hash && tx.NetworkFee + tx.SystemFee + amount > SelectedAsset.Balance)
             {
-                BigDecimal max = new(SelectedAsset.Balance - tx.NetworkFee - tx.SystemFee, SelectedAsset.Token.Decimals);
+                string max = TokenAmount.Format(SelectedAsset.Balance - tx.NetworkFee - tx.SystemFee, SelectedAsset.Token.Decimals);
                 validationAmount.SetError(string.Format(Strings.InsufficientBalanceForAmountAndFees, max));
                 return;
             }

--- a/OneGateApp/Services/TokenAmount.cs
+++ b/OneGateApp/Services/TokenAmount.cs
@@ -1,0 +1,36 @@
+using System.Globalization;
+using System.Numerics;
+
+namespace NeoOrder.OneGate.Services;
+
+static class TokenAmount
+{
+    public static string Format(BigInteger units, byte decimals, CultureInfo? culture = null)
+    {
+        culture ??= CultureInfo.CurrentCulture;
+        string digits = BigInteger.Abs(units).ToString(CultureInfo.InvariantCulture).PadLeft(decimals + 1, '0');
+        string whole = decimals == 0 ? digits : digits[..^decimals];
+        string fraction = decimals == 0 ? "" : digits[^decimals..].TrimEnd('0');
+        string sign = units.Sign < 0 ? culture.NumberFormat.NegativeSign : "";
+        return sign + whole + (fraction.Length == 0 ? "" : culture.NumberFormat.NumberDecimalSeparator + fraction);
+    }
+
+    public static bool TryParse(string? text, byte decimals, out BigInteger units, CultureInfo? culture = null)
+    {
+        units = BigInteger.Zero;
+        if (string.IsNullOrWhiteSpace(text)) return false;
+        culture ??= CultureInfo.CurrentCulture;
+        string[] parts = text.Trim().Split(culture.NumberFormat.NumberDecimalSeparator, StringSplitOptions.None);
+        if (parts.Length > 2) return false;
+        string whole = parts[0];
+        string fraction = parts.Length == 2 ? parts[1] : "";
+        if (whole.Length + fraction.Length == 0) return false;
+        // Amount fields accept ungrouped decimal digits only. In particular,
+        // a locale's grouping separator must never change the transfer amount.
+        if (!whole.All(char.IsAsciiDigit) || !fraction.All(char.IsAsciiDigit)) return false;
+        fraction = fraction.TrimEnd('0');
+        if (fraction.Length > decimals) return false;
+        string digits = (whole.Length == 0 ? "0" : whole) + fraction.PadRight(decimals, '0');
+        return BigInteger.TryParse(digits, NumberStyles.None, CultureInfo.InvariantCulture, out units);
+    }
+}

--- a/OneGateApp/Services/TokenAmount.cs
+++ b/OneGateApp/Services/TokenAmount.cs
@@ -5,6 +5,10 @@ namespace NeoOrder.OneGate.Services;
 
 static class TokenAmount
 {
+    // Generous enough for token precision, but bounds work on untrusted QR/link
+    // amounts before trimming, splitting, padding or parsing a BigInteger.
+    const int MaxInputLength = 1024;
+
     public static string Format(BigInteger units, byte decimals, CultureInfo? culture = null)
     {
         culture ??= CultureInfo.CurrentCulture;
@@ -18,7 +22,7 @@ static class TokenAmount
     public static bool TryParse(string? text, byte decimals, out BigInteger units, CultureInfo? culture = null)
     {
         units = BigInteger.Zero;
-        if (string.IsNullOrWhiteSpace(text)) return false;
+        if (text is null || text.Length > MaxInputLength || string.IsNullOrWhiteSpace(text)) return false;
         culture ??= CultureInfo.CurrentCulture;
         string[] parts = text.Trim().Split(culture.NumberFormat.NumberDecimalSeparator, StringSplitOptions.None);
         if (parts.Length > 2) return false;

--- a/tests/P2-02/PaymentActionTests.cs
+++ b/tests/P2-02/PaymentActionTests.cs
@@ -1,0 +1,51 @@
+using System.Globalization;
+using NeoOrder.OneGate.Models.AppLinks;
+using NeoOrder.OneGate.Services;
+using Xunit;
+
+public class PaymentActionTests
+{
+    [Theory]
+    [InlineData("en-US", "1.5")]
+    [InlineData("de-DE", "1.5")]
+    [InlineData("fr-FR", "1.5")]
+    [InlineData("de-DE", "123456789012345678901234567890.12345678")]
+    [InlineData("fr-FR", "0.000000000000000000000000000000000000000000000000000000000001")]
+    public async Task Payment_uri_preserves_protocol_digits_until_send_page(string locale, string amount)
+    {
+        var original = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new(locale);
+            var action = Assert.IsType<PaymentAction>(AppLinkAction.TryCreate("neo:synthetic-recipient?asset=gas&amount=" + amount));
+            var shell = new Shell();
+            await action.GotoRoute(shell);
+            string protocolAmount = Assert.IsType<string>(shell.Query!["amount"]);
+            Assert.Equal(amount, protocolAmount);
+            string localized = protocolAmount.Replace(".", CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator);
+            Assert.True(TokenAmount.TryParse(protocolAmount, 60, out var expected, CultureInfo.InvariantCulture));
+            Assert.True(TokenAmount.TryParse(localized, 60, out var actual));
+            Assert.Equal(expected, actual);
+        }
+        finally { CultureInfo.CurrentCulture = original; }
+    }
+
+    [Theory]
+    [InlineData("1,5")]
+    [InlineData("1,000.5")]
+    [InlineData("1e3")]
+    [InlineData("-1")]
+    [InlineData("+")]
+    [InlineData(" ")]
+    public void Protocol_amount_rejects_localized_grouping_and_ambiguous_input(string amount)
+        => Assert.Null(PaymentAction.TryCreate("neo:synthetic-recipient?amount=" + Uri.EscapeDataString(amount)));
+
+    [Fact]
+    public async Task Payment_without_amount_does_not_invent_one()
+    {
+        var action = Assert.IsType<PaymentAction>(PaymentAction.TryCreate("neo:synthetic-recipient?asset=neo"));
+        var shell = new Shell();
+        await action.GotoRoute(shell);
+        Assert.False(shell.Query!.ContainsKey("amount"));
+    }
+}

--- a/tests/P2-02/PaymentActionTests.cs
+++ b/tests/P2-02/PaymentActionTests.cs
@@ -5,6 +5,24 @@ using Xunit;
 
 public class PaymentActionTests
 {
+    [Fact]
+    public void Protocol_amount_at_character_limit_is_preserved()
+    {
+        string amount = new string('0', 1023) + "1";
+        var action = Assert.IsType<PaymentAction>(PaymentAction.TryCreate("neo:synthetic-recipient?amount=" + amount));
+        Assert.Equal(amount, action.Amount);
+    }
+
+    [Theory]
+    [InlineData(1025)]
+    [InlineData(16384)]
+    public void Overlong_protocol_amount_is_rejected(int length)
+    {
+        string amount = new string('0', length - 1) + "1";
+        Assert.Null(PaymentAction.TryCreate("neo:synthetic-recipient?amount=" + amount));
+        Assert.Null(AppLinkAction.TryCreate("neo:synthetic-recipient?amount=" + amount));
+    }
+
     [Theory]
     [InlineData("en-US", "1.5")]
     [InlineData("de-DE", "1.5")]

--- a/tests/P2-02/PaymentPlatformStubs.cs
+++ b/tests/P2-02/PaymentPlatformStubs.cs
@@ -1,0 +1,22 @@
+// Navigation-only doubles. PaymentAction, AppLinkAction and TokenAmount are linked production source.
+public class Page { }
+public class NavigationPage(Page page) : Page { public Page CurrentPage => page; }
+public interface IQueryAttributable { void ApplyQueryAttributes(IDictionary<string, object> query); }
+public class Shell
+{
+    public IDictionary<string, object>? Query { get; private set; }
+    public Task GoToAsync(string route, IDictionary<string, object> query) { Query = query; return Task.CompletedTask; }
+    public Task GoToAsync(string route) => Task.CompletedTask;
+}
+namespace NeoOrder.OneGate.Pages { public class SendPage : Page { } }
+namespace NeoOrder.OneGate.Services
+{
+    public static class SharedOptions { public const string OneGateDomain = "example.invalid"; }
+    public static class ServiceExtensions { public static T GetServiceOrCreateInstance<T>(this IServiceProvider _) where T : new() => new(); }
+}
+namespace NeoOrder.OneGate.Models.AppLinks
+{
+    static class AuthenticationAction { public static AppLinkAction? TryCreate(Uri _) => null; }
+    static class LaunchDAppAction { public static AppLinkAction? TryCreate(Uri _) => null; }
+    static class ViewNewsAction { public static AppLinkAction? TryCreate(Uri _) => null; }
+}

--- a/tests/P2-02/README.md
+++ b/tests/P2-02/README.md
@@ -1,0 +1,28 @@
+# P2-02 precise localized token amounts
+
+Run `dotnet test tests/P2-02/TokenAmount.Tests.csproj`.
+
+The tests link the production parser/formatter. Transfer units use BigInteger
+throughout; decimal is only an optional fiat approximation in SendPage. Local
+input accepts the current language's decimal separator, with no grouping or
+scientific notation. Protocol-supplied amounts are localized at the input
+boundary. PaymentAction and AppLinkAction are also linked: real protocol parsing
+and route-query creation must retain invariant decimal strings, including values
+outside System.Decimal's precision/range. Navigation alone is doubled. QR scan
+routing preserves that same string. There are no wallet, RPC or network operations
+in these tests.
+
+Before the fix, a temporary characterization adapter using the audited
+`decimal.Parse(BigDecimal.ToString())` and `BigDecimal.TryParse` expressions
+reproduced the German `1.5 -> 15` error, French parsing failure, local minimum
+unit rejection and large-balance overflow. The adapter was removed afterwards.
+The separate production PaymentAction regression initially failed 8 of its 12
+cases before removing the current-culture `decimal.Parse` conversion.
+
+Device checks: open a send form with a synthetic 1.5 token balance, select
+English/German/French and tap All. Expect 1.5/1,5/1,5 and the same integer
+150000000 at 8 decimals. Check the smallest unit, overprecision, zero and values
+above balance. Entering an amount does not authorize or broadcast a transfer.
+Also pass a real `PaymentAction` query into SendPage under each locale, including
+a large amount and a fraction smaller than System.Decimal can retain, to confirm
+the URI/QR boundary never scales or rounds the amount before token validation.

--- a/tests/P2-02/README.md
+++ b/tests/P2-02/README.md
@@ -12,6 +12,12 @@ outside System.Decimal's precision/range. Navigation alone is doubled. QR scan
 routing preserves that same string. There are no wallet, RPC or network operations
 in these tests.
 
+Raw amount input is limited to 1024 characters before trimming or numeric
+parsing, including URI/QR amounts. Tests accept the exact boundary, reject 1025
+and 16384 characters (including otherwise valid leading-zero amounts), and keep
+60-decimal-place values exact. The follow-up regression failed five cases before
+adding the early length guard.
+
 Before the fix, a temporary characterization adapter using the audited
 `decimal.Parse(BigDecimal.ToString())` and `BigDecimal.TryParse` expressions
 reproduced the German `1.5 -> 15` error, French parsing failure, local minimum

--- a/tests/P2-02/TokenAmount.Tests.csproj
+++ b/tests/P2-02/TokenAmount.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../OneGateApp/OneGateApp.csproj" ReferenceOutputAssembly="false" BuildReference="false" SkipGetTargetFrameworkProperties="true" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="Neo" Version="3.10.0" />
+    <Compile Include="../../OneGateApp/Models/AppLinks/PaymentAction.cs" Link="PaymentAction.cs" />
+    <Compile Include="../../OneGateApp/Models/AppLinks/AppLinkAction.cs" Link="AppLinkAction.cs" />
+    <Compile Include="../../OneGateApp/Services/TokenAmount.cs" Link="TokenAmount.cs" Condition="Exists('../../OneGateApp/Services/TokenAmount.cs')" />
+  </ItemGroup>
+</Project>

--- a/tests/P2-02/TokenAmountTests.cs
+++ b/tests/P2-02/TokenAmountTests.cs
@@ -6,6 +6,51 @@ using Xunit;
 public class TokenAmountTests
 {
     [Theory]
+    [InlineData("en-US", ".")]
+    [InlineData("de-DE", ",")]
+    [InlineData("fr-FR", ",")]
+    public void Input_at_character_limit_still_preserves_exact_units(string locale, string separator)
+    {
+        string text = new string('0', 1021) + "1" + separator + "5";
+        Assert.Equal(1024, text.Length);
+        Assert.True(TokenAmount.TryParse(text, 8, out var units, new CultureInfo(locale)));
+        Assert.Equal(new BigInteger(150_000_000), units);
+    }
+
+    [Theory]
+    [InlineData(1025)]
+    [InlineData(16384)]
+    public void Overlong_input_is_rejected_before_leading_zeroes_are_parsed(int length)
+    {
+        Assert.False(TokenAmount.TryParse(new string('0', length - 1) + "1", 8, out var units, CultureInfo.InvariantCulture));
+        Assert.Equal(BigInteger.Zero, units);
+    }
+
+    [Fact]
+    public void Raw_character_limit_applies_before_trimming()
+    {
+        Assert.False(TokenAmount.TryParse(new string(' ', 1024) + "1", 8, out var units, CultureInfo.InvariantCulture));
+        Assert.Equal(BigInteger.Zero, units);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" \t\r\n")]
+    public void Null_empty_and_whitespace_input_remain_invalid(string? text)
+    {
+        Assert.False(TokenAmount.TryParse(text, 8, out var units, CultureInfo.InvariantCulture));
+        Assert.Equal(BigInteger.Zero, units);
+    }
+
+    [Fact]
+    public void Sixty_decimal_places_remain_exact()
+    {
+        Assert.True(TokenAmount.TryParse("0." + new string('0', 59) + "1", 60, out var units, CultureInfo.InvariantCulture));
+        Assert.Equal(BigInteger.One, units);
+    }
+
+    [Theory]
     [InlineData("en-US", "1.5")]
     [InlineData("de-DE", "1,5")]
     [InlineData("fr-FR", "1,5")]

--- a/tests/P2-02/TokenAmountTests.cs
+++ b/tests/P2-02/TokenAmountTests.cs
@@ -1,0 +1,64 @@
+using System.Globalization;
+using System.Numerics;
+using NeoOrder.OneGate.Services;
+using Xunit;
+
+public class TokenAmountTests
+{
+    [Theory]
+    [InlineData("en-US", "1.5")]
+    [InlineData("de-DE", "1,5")]
+    [InlineData("fr-FR", "1,5")]
+    public void All_balance_formats_and_parses_without_changing_chain_units(string locale, string expected)
+    {
+        CultureInfo culture = new(locale);
+        BigInteger units = 150_000_000;
+        string formatted = TokenAmount.Format(units, 8, culture);
+        Assert.Equal(expected, formatted);
+        Assert.True(TokenAmount.TryParse(formatted, 8, out var parsed, culture));
+        Assert.Equal(units, parsed);
+    }
+
+    [Theory]
+    [InlineData("en-US", "0.00000001")]
+    [InlineData("de-DE", "0,00000001")]
+    [InlineData("fr-FR", "0,00000001")]
+    public void Minimum_unit_is_preserved(string locale, string text)
+    {
+        Assert.True(TokenAmount.TryParse(text, 8, out var units, new CultureInfo(locale)));
+        Assert.Equal(BigInteger.One, units);
+    }
+
+    [Theory]
+    [InlineData("en-US", "0.000000001")]
+    [InlineData("de-DE", "0,000000001")]
+    [InlineData("fr-FR", "1 000,5")]
+    [InlineData("en-US", "1,000.5")]
+    [InlineData("en-US", "-1")]
+    [InlineData("en-US", "1e3")]
+    [InlineData("de-DE", "1.234")]
+    public void Ambiguous_grouped_negative_and_overprecision_amounts_are_rejected(string locale, string text)
+    {
+        Assert.False(TokenAmount.TryParse(text, 8, out _, new CultureInfo(locale)));
+    }
+
+    [Fact]
+    public void Large_balance_does_not_round_or_overflow_decimal()
+    {
+        var units = BigInteger.Parse("12345678901234567890123456789012345678");
+        string text = TokenAmount.Format(units, 8, CultureInfo.InvariantCulture);
+        Assert.Equal("123456789012345678901234567890.12345678", text);
+        Assert.True(TokenAmount.TryParse(text, 8, out var parsed, CultureInfo.InvariantCulture));
+        Assert.Equal(units, parsed);
+    }
+
+    [Theory]
+    [InlineData("0", 8, "0")]
+    [InlineData("1.000", 0, "1")]
+    [InlineData(".5", 8, "50000000")]
+    public void Zero_trailing_zeroes_and_fraction_input_have_exact_values(string text, byte decimals, string expected)
+    {
+        Assert.True(TokenAmount.TryParse(text, decimals, out var units, CultureInfo.InvariantCulture));
+        Assert.Equal(BigInteger.Parse(expected), units);
+    }
+}


### PR DESCRIPTION
## Problem

Payment amounts were parsed through culture-sensitive `decimal` values in app links and through inconsistent parsers in the send form. A dot-decimal payment link could change value in a comma-decimal locale, and large/high-precision token amounts could be rounded or rejected prematurely.

## Change

- Preserve payment-link amounts as invariant, ungrouped strings through link parsing and QR navigation.
- Localize only at the send form's display boundary; validate and convert directly to exact `BigInteger` token units.
- Use the same parsing path for submission, bounds checks, and the full-balance action. Fiat estimation remains optional.
- Reject raw amount strings longer than 1024 characters before whitespace scanning, trimming, splitting, padding, or `BigInteger` parsing. This also covers payment-link/QR amounts routed through `PaymentAction`, while preserving valid values at the boundary and exact 60-decimal-place amounts.

This independent PR addresses audit P2-02 only, based on master `623603d`.

## Validation

- `dotnet test tests/P2-02/TokenAmount.Tests.csproj --no-restore --nologo`: **42 regression tests passed**, including real PaymentAction/AppLinkAction parsing. The original link-entry regressions failed with the culture-dependent implementation; five follow-up cases failed before the early length guard was added.
- iOS 26.5 iPhone 17 simulator and Android API 36 arm64 emulator: **90 native-app boolean checks passed on each platform** through the actual payment-link model and SendPage/Entry/validation handlers.
- Covered en-US, de-DE and fr-FR; invariant `1.5` links, amounts beyond decimal precision, exact 60-decimal-place values, minimum units, excessive precision, zero/over-balance input, and the full-balance action. On both platforms, the actual Entry binds a valid 1024-character amount, rejects 1025/16384-character values, and the production PaymentAction/AppLinkAction path rejects overlong amounts.
- Synthetic balances and a hidden Submit control were used in the external fixture. No live RPC request, transaction signature, or broadcast was performed.
- After removing the fixture, both platforms passed a full product rebuild (0 warnings, 0 errors) and normal Home/four-tab launch smoke verification. No OneGate app crash was observed. This product smoke check is separate from the native amount assertions.
- Both follow-up native runs used the staged patch SHA-256 `0fa066d30f9fd58875501db9a4ce72ad85a41b98aaf715fce41624678a00c121` relative to the original PR head `fbcfd07df28ae55acaeadcb0f6dab3ae07c87bcb`.

Screenshots, native result JSON and simulator-only fixture code remain outside the repository.

## Limits

The early guard bounds the amount parser's numeric work and intermediate allocations; it does not bound parsing of an entire incoming URI, which occurs before amount validation. Native checks used synthetic balances and direct production controls/models, not a camera scan or an on-chain transfer. No uploaded screenshots, hosted CI success, or combined validation with other audit branches is claimed.
