### PR TITLE
Cancel revoked remote debugger handshakes

### DIFF
--- a/OneGateApp.slnx
+++ b/OneGateApp.slnx
@@ -6,4 +6,5 @@
   <Project Path="OneGate.DebugProtocol/OneGate.DebugProtocol.csproj" />
   <Project Path="OneGate.DebugProtocol.Tests/OneGate.DebugProtocol.Tests.csproj" />
   <Project Path="OneGate.Tools/OneGate.Tools.csproj" />
+  <Project Path="tests/p1-04/RevocationTests.csproj" />
 </Solution>

--- a/OneGateApp/Services/RemoteDebug/RemoteDebugConnectionGeneration.cs
+++ b/OneGateApp/Services/RemoteDebug/RemoteDebugConnectionGeneration.cs
@@ -1,0 +1,34 @@
+namespace NeoOrder.OneGate.Services.RemoteDebug;
+
+// Access is serialized by RemoteDebugService.stateLock. A revoked attempt cannot
+// publish either persistent trust or a live connection after a later toggle.
+sealed class RemoteDebugConnectionGeneration : IDisposable
+{
+    CancellationTokenSource cancellation = new();
+    long version;
+
+    public readonly record struct Attempt(long Version, CancellationToken Token);
+
+    public Attempt Capture() => new(version, cancellation.Token);
+
+    public void Invalidate()
+    {
+        var previous = cancellation;
+        cancellation = new();
+        version++;
+        previous.Cancel();
+        previous.Dispose();
+    }
+
+    public void ThrowIfStale(Attempt attempt)
+    {
+        if (attempt.Version != version || attempt.Token.IsCancellationRequested)
+            throw new OperationCanceledException("The remote-debug connection was revoked.", attempt.Token);
+    }
+
+    public void Dispose()
+    {
+        cancellation.Cancel();
+        cancellation.Dispose();
+    }
+}

--- a/OneGateApp/Services/RemoteDebug/RemoteDebugService.cs
+++ b/OneGateApp/Services/RemoteDebug/RemoteDebugService.cs
@@ -16,6 +16,8 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
     static readonly TimeSpan ApprovalTimeout = TimeSpan.FromMinutes(2);
     readonly SemaphoreSlim stateLock = new(1, 1);
     readonly SemaphoreSlim connectLock = new(1, 1);
+    readonly object disposeLock = new();
+    readonly RemoteDebugConnectionGeneration connectionGeneration = new();
     readonly ConcurrentDictionary<string, RemoteDebugSession> sessions = new(StringComparer.Ordinal);
     readonly ConcurrentDictionary<string, Task<JsonNode?>> operations = new(StringComparer.Ordinal);
     DebugIdentity? debugTargetIdentity;
@@ -24,6 +26,8 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
     RemoteDebugConnection? connection;
     bool initialized;
     bool developerModeEnabled;
+    bool closing;
+    Task? disposeTask;
 
     public event EventHandler? StateChanged;
     public bool IsDeveloperModeEnabled => developerModeEnabled;
@@ -33,16 +37,19 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
     public async Task SetDeveloperModeAsync(bool enabled)
     {
         await EnsureInitializedAsync();
-        developerModeEnabled = enabled;
-        if (enabled)
+        await stateLock.WaitAsync();
+        try
         {
-            await StartDiscoveryAsync();
+            ThrowIfClosing();
+            if (developerModeEnabled != enabled)
+                connectionGeneration.Invalidate();
+            developerModeEnabled = enabled;
+            if (enabled) await StartDiscoveryAsync();
+            else await StopDiscoveryAsync();
         }
-        else
-        {
+        finally { stateLock.Release(); }
+        if (!enabled)
             await StopConnectionAndSessionsAsync();
-            await StopDiscoveryAsync();
-        }
         StateChanged?.Invoke(this, EventArgs.Empty);
     }
 
@@ -52,6 +59,7 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
         await stateLock.WaitAsync();
         try
         {
+            ThrowIfClosing();
             return debuggers.Select(p => p with { }).ToArray();
         }
         finally
@@ -80,11 +88,11 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
     public async Task ForgetDebuggerAsync(string debuggerId)
     {
         await EnsureInitializedAsync();
-        if (connection?.Debugger.Id == debuggerId)
-            await StopConnectionAndSessionsAsync();
         await stateLock.WaitAsync();
         try
         {
+            ThrowIfClosing();
+            connectionGeneration.Invalidate();
             debuggers.RemoveAll(p => p.Id == debuggerId);
             await SaveStateAsync();
         }
@@ -92,6 +100,8 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
         {
             stateLock.Release();
         }
+        if (connection?.Debugger.Id == debuggerId)
+            await StopConnectionAndSessionsAsync();
         StateChanged?.Invoke(this, EventArgs.Empty);
     }
 
@@ -151,10 +161,10 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
 
     async Task EnsureInitializedAsync()
     {
-        if (initialized) return;
         await stateLock.WaitAsync();
         try
         {
+            ThrowIfClosing();
             if (initialized) return;
             string? value = await SecureStorage.Default.GetAsync(SecureStorageKey);
             if (string.IsNullOrEmpty(value))
@@ -239,7 +249,16 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
         await connectLock.WaitAsync();
         try
         {
-            if (!developerModeEnabled) return;
+            RemoteDebugConnectionGeneration.Attempt attempt;
+            await stateLock.WaitAsync();
+            try
+            {
+                ThrowIfClosing();
+                if (!developerModeEnabled) return;
+                if (trusted is not null && !debuggers.Any(p => p.Id == trusted.Value.Debugger.Id)) return;
+                attempt = connectionGeneration.Capture();
+            }
+            finally { stateLock.Release(); }
             if (connection is not null)
             {
                 if (trusted?.Debugger.Id == connection.Debugger.Id) return;
@@ -251,27 +270,40 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
             Exception? lastError = null;
             foreach (var endpoint in endpoints)
             {
+                TcpClient? client = null;
+                RemoteDebugConnection? candidate = null;
                 try
                 {
-                    using CancellationTokenSource timeout = new(ConnectionTimeout);
-                    TcpClient client = new();
+                    using CancellationTokenSource timeout = CancellationTokenSource.CreateLinkedTokenSource(attempt.Token);
+                    timeout.CancelAfter(ConnectionTimeout);
+                    client = new();
                     await client.ConnectAsync(endpoint.Host, endpoint.Port, timeout.Token);
-                    RemoteDebugConnection candidate = await RemoteDebugConnection.ConnectAsync(
+                    candidate = await RemoteDebugConnection.ConnectAsync(
                         client,
                         debugTargetIdentity!,
                         invitation,
                         trusted?.Debugger,
-                        PersistDebuggerAsync,
-                        HandleRequestAsync,
+                        debugger => PersistDebuggerAsync(debugger, attempt),
+                        (method, parameters) => HandleAuthorizedRequestAsync(candidate!, method, parameters),
                         timeout.Token);
-                    candidate.Disconnected += OnConnectionDisconnected;
-                    connection = candidate;
-                    candidate.Start();
+                    await stateLock.WaitAsync(attempt.Token);
+                    try
+                    {
+                        connectionGeneration.ThrowIfStale(attempt);
+                        if (!developerModeEnabled) throw new OperationCanceledException(attempt.Token);
+                        candidate.Disconnected += OnConnectionDisconnected;
+                        connection = candidate;
+                        candidate.Start();
+                    }
+                    finally { stateLock.Release(); }
                     StateChanged?.Invoke(this, EventArgs.Empty);
                     return;
                 }
                 catch (Exception ex)
                 {
+                    if (candidate is not null) await candidate.DisposeAsync();
+                    else client?.Dispose();
+                    if (attempt.Token.IsCancellationRequested) throw;
                     lastError = ex;
                 }
             }
@@ -283,11 +315,14 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
         }
     }
 
-    async Task PersistDebuggerAsync(TrustedRemoteDebugger debugger)
+    async Task PersistDebuggerAsync(TrustedRemoteDebugger debugger, RemoteDebugConnectionGeneration.Attempt attempt)
     {
         await stateLock.WaitAsync();
         try
         {
+            ThrowIfClosing();
+            connectionGeneration.ThrowIfStale(attempt);
+            if (!developerModeEnabled) throw new OperationCanceledException(attempt.Token);
             debuggers.RemoveAll(p => p.Id == debugger.Id);
             debuggers.Add(debugger);
             await SaveStateAsync();
@@ -307,11 +342,21 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
         StateChanged?.Invoke(this, EventArgs.Empty);
     }
 
-    async Task<JsonNode?> HandleRequestAsync(string method, JsonObject parameters)
+    void RequireAuthorizedConnection(RemoteDebugConnection source)
     {
+        if (closing || !developerModeEnabled || !ReferenceEquals(connection, source)
+            || !debuggers.Any(p => p.Id == source.Debugger.Id))
+            throw new RemoteDebugCommandException("CONNECTION_REVOKED", "Remote debugging is disabled or this debugger is no longer trusted.");
+    }
+
+    async Task<JsonNode?> HandleAuthorizedRequestAsync(RemoteDebugConnection source, string method, JsonObject parameters)
+    {
+        await stateLock.WaitAsync();
+        try { RequireAuthorizedConnection(source); }
+        finally { stateLock.Release(); }
         return method switch
         {
-            "session.start" => await StartSessionAsync(parameters),
+            "session.start" => await StartSessionAsync(source, parameters),
             "session.status" => await RequireHost(parameters).GetRemoteStatusAsync(),
             "session.logs" => Logs(parameters),
             "session.trace" => Trace(parameters),
@@ -327,7 +372,7 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
         };
     }
 
-    async Task<JsonNode?> StartSessionAsync(JsonObject parameters)
+    async Task<JsonNode?> StartSessionAsync(RemoteDebugConnection source, JsonObject parameters)
     {
         string value = parameters["url"]?.GetValue<string>()
             ?? throw new RemoteDebugCommandException("INVALID_ARGUMENT", "url is required.");
@@ -335,19 +380,24 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
             throw new RemoteDebugCommandException("HTTPS_REQUIRED", "OneGate remote sessions require an HTTPS DApp URL.");
         string sessionId = Guid.NewGuid().ToString("N");
         RemoteDebugSession session = new(sessionId, url);
-        if (!sessions.TryAdd(sessionId, session)) throw new InvalidOperationException();
         try
         {
             await MainThread.InvokeOnMainThreadAsync(async () =>
             {
-                LaunchDAppPage page = serviceProvider.GetServiceOrCreateInstance<LaunchDAppPage>();
-                page.ConfigureRemoteDebug(sessionId, this);
-                page.ApplyQueryAttributes(new Dictionary<string, object>
+                await stateLock.WaitAsync();
+                try
                 {
-                    ["uri"] = url
-                });
-                Application.Current!.OpenWindow(new Window(new NavigationPage(page)));
-                await Task.CompletedTask;
+                    RequireAuthorizedConnection(source);
+                    if (!sessions.TryAdd(sessionId, session)) throw new InvalidOperationException();
+                    LaunchDAppPage page = serviceProvider.GetServiceOrCreateInstance<LaunchDAppPage>();
+                    page.ConfigureRemoteDebug(sessionId, this);
+                    page.ApplyQueryAttributes(new Dictionary<string, object>
+                    {
+                        ["uri"] = url
+                    });
+                    Application.Current!.OpenWindow(new Window(new NavigationPage(page)));
+                }
+                finally { stateLock.Release(); }
             });
             return new JsonObject
             {
@@ -490,13 +540,39 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
         });
     }
 
-    public async ValueTask DisposeAsync()
+    void ThrowIfClosing() => ObjectDisposedException.ThrowIf(closing, this);
+
+    public ValueTask DisposeAsync()
     {
-        await StopConnectionAndSessionsAsync();
-        await StopDiscoveryAsync();
-        debugTargetIdentity?.Dispose();
-        stateLock.Dispose();
-        connectLock.Dispose();
+        lock (disposeLock)
+            return new(disposeTask ??= DisposeCoreAsync());
+    }
+
+    async Task DisposeCoreAsync()
+    {
+        await stateLock.WaitAsync();
+        try
+        {
+            closing = true;
+            developerModeEnabled = false;
+            connectionGeneration.Invalidate();
+            await StopDiscoveryAsync();
+        }
+        finally { stateLock.Release(); }
+
+        // Cancellation requests shutdown; it does not mean a handshake has
+        // finished unwinding or using the identity/persistence callback yet.
+        await connectLock.WaitAsync();
+        try
+        {
+            await StopConnectionAndSessionsAsync();
+            debugTargetIdentity?.Dispose();
+            connectionGeneration.Dispose();
+        }
+        finally { connectLock.Release(); }
+        // Keep the managed gates valid for callers already queued before
+        // closing. They acquire the gate, reject, and release normally. Neither
+        // gate allocates a wait handle (AvailableWaitHandle is never requested).
     }
 }
 

--- a/OneGateApp/Services/RemoteDebug/RemoteDebugService.cs
+++ b/OneGateApp/Services/RemoteDebug/RemoteDebugService.cs
@@ -37,6 +37,7 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
     public async Task SetDeveloperModeAsync(bool enabled)
     {
         await EnsureInitializedAsync();
+        ConnectionCleanup? cleanup = null;
         await stateLock.WaitAsync();
         try
         {
@@ -45,11 +46,14 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
                 connectionGeneration.Invalidate();
             developerModeEnabled = enabled;
             if (enabled) await StartDiscoveryAsync();
-            else await StopDiscoveryAsync();
+            else
+            {
+                await StopDiscoveryAsync();
+                cleanup = DetachConnectionAndSessions();
+            }
         }
         finally { stateLock.Release(); }
-        if (!enabled)
-            await StopConnectionAndSessionsAsync();
+        await StopDetachedConnectionAndSessionsAsync(cleanup);
         StateChanged?.Invoke(this, EventArgs.Empty);
     }
 
@@ -88,6 +92,7 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
     public async Task ForgetDebuggerAsync(string debuggerId)
     {
         await EnsureInitializedAsync();
+        ConnectionCleanup? cleanup = null;
         await stateLock.WaitAsync();
         try
         {
@@ -95,13 +100,14 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
             connectionGeneration.Invalidate();
             debuggers.RemoveAll(p => p.Id == debuggerId);
             await SaveStateAsync();
+            if (connection?.Debugger.Id == debuggerId)
+                cleanup = DetachConnectionAndSessions();
         }
         finally
         {
             stateLock.Release();
         }
-        if (connection?.Debugger.Id == debuggerId)
-            await StopConnectionAndSessionsAsync();
+        await StopDetachedConnectionAndSessionsAsync(cleanup);
         StateChanged?.Invoke(this, EventArgs.Empty);
     }
 
@@ -250,20 +256,22 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
         try
         {
             RemoteDebugConnectionGeneration.Attempt attempt;
+            ConnectionCleanup? cleanup = null;
             await stateLock.WaitAsync();
             try
             {
                 ThrowIfClosing();
                 if (!developerModeEnabled) return;
                 if (trusted is not null && !debuggers.Any(p => p.Id == trusted.Value.Debugger.Id)) return;
+                if (connection is not null)
+                {
+                    if (trusted?.Debugger.Id == connection.Debugger.Id) return;
+                    cleanup = DetachConnectionAndSessions();
+                }
                 attempt = connectionGeneration.Capture();
             }
             finally { stateLock.Release(); }
-            if (connection is not null)
-            {
-                if (trusted?.Debugger.Id == connection.Debugger.Id) return;
-                await StopConnectionAndSessionsAsync();
-            }
+            await StopDetachedConnectionAndSessionsAsync(cleanup);
             List<(string Host, int Port)> endpoints = invitation is not null
                 ? invitation.Endpoints.Select(p => (p.Host, p.Port)).ToList()
                 : [(trusted!.Value.Host, trusted.Value.Port)];
@@ -335,10 +343,20 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
 
     void OnConnectionDisconnected(RemoteDebugConnection sender)
     {
-        if (!ReferenceEquals(connection, sender)) return;
-        sender.Disconnected -= OnConnectionDisconnected;
-        connection = null;
-        _ = StopAllSessionsAsync();
+        _ = HandleConnectionDisconnectedAsync(sender);
+    }
+
+    async Task HandleConnectionDisconnectedAsync(RemoteDebugConnection sender)
+    {
+        ConnectionCleanup cleanup;
+        await stateLock.WaitAsync();
+        try
+        {
+            if (!ReferenceEquals(connection, sender)) return;
+            cleanup = DetachConnectionAndSessions();
+        }
+        finally { stateLock.Release(); }
+        await StopDetachedConnectionAndSessionsAsync(cleanup);
         StateChanged?.Invoke(this, EventArgs.Empty);
     }
 
@@ -516,26 +534,31 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
         return new JsonObject { ["operationId"] = operationId, ["state"] = "completed", ["value"] = await operation };
     }
 
-    async Task StopConnectionAndSessionsAsync()
+    sealed record ConnectionCleanup(RemoteDebugConnection? Connection, RemoteDebugSession[] Sessions);
+
+    // All callers hold stateLock: detach the connection and its session batch in
+    // the same transition as admission/publication. Never sweep future sessions.
+    ConnectionCleanup DetachConnectionAndSessions()
     {
         RemoteDebugConnection? current = connection;
         connection = null;
         if (current is not null)
-        {
             current.Disconnected -= OnConnectionDisconnected;
-            await current.DisposeAsync();
-        }
-        await StopAllSessionsAsync();
-    }
-
-    async Task StopAllSessionsAsync()
-    {
         RemoteDebugSession[] active = sessions.Values.ToArray();
         sessions.Clear();
         foreach (RemoteDebugSession session in active) session.RejectAll();
+        return new(current, active);
+    }
+
+    static async Task StopDetachedConnectionAndSessionsAsync(ConnectionCleanup? cleanup)
+    {
+        if (cleanup is null) return;
+        if (cleanup.Connection is not null)
+            await cleanup.Connection.DisposeAsync();
+        // Do not hold stateLock while dispatching to or awaiting the UI thread.
         await MainThread.InvokeOnMainThreadAsync(async () =>
         {
-            foreach (IRemoteDebugSessionHost host in active.Select(p => p.Host).OfType<IRemoteDebugSessionHost>())
+            foreach (IRemoteDebugSessionHost host in cleanup.Sessions.Select(p => p.Host).OfType<IRemoteDebugSessionHost>())
                 await host.StopRemoteAsync();
         });
     }
@@ -550,6 +573,7 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
 
     async Task DisposeCoreAsync()
     {
+        ConnectionCleanup cleanup;
         await stateLock.WaitAsync();
         try
         {
@@ -557,6 +581,7 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
             developerModeEnabled = false;
             connectionGeneration.Invalidate();
             await StopDiscoveryAsync();
+            cleanup = DetachConnectionAndSessions();
         }
         finally { stateLock.Release(); }
 
@@ -565,7 +590,7 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
         await connectLock.WaitAsync();
         try
         {
-            await StopConnectionAndSessionsAsync();
+            await StopDetachedConnectionAndSessionsAsync(cleanup);
             debugTargetIdentity?.Dispose();
             connectionGeneration.Dispose();
         }

--- a/tests/p1-04/DisconnectionTests.cs
+++ b/tests/p1-04/DisconnectionTests.cs
@@ -1,0 +1,133 @@
+using NeoOrder.OneGate;
+using NeoOrder.OneGate.DebugProtocol;
+using NeoOrder.OneGate.Services.RemoteDebug;
+using System.Collections.Concurrent;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Text.Json.Nodes;
+using Xunit;
+
+public class DisconnectionTests
+{
+    const BindingFlags Hidden = BindingFlags.Instance | BindingFlags.NonPublic;
+    static readonly Type ServiceType = typeof(RemoteDebugService);
+    sealed class Services : IServiceProvider { public object? GetService(Type type) => null; }
+    static T Field<T>(RemoteDebugService service, string name) => (T)ServiceType.GetField(name, Hidden)!.GetValue(service)!;
+    static void Publish(RemoteDebugService service, RemoteDebugConnection connection) => ServiceType.GetField("connection", Hidden)!.SetValue(service, connection);
+    static Task Disconnect(RemoteDebugService service, RemoteDebugConnection connection) => (Task)ServiceType.GetMethod("HandleConnectionDisconnectedAsync", Hidden)!.Invoke(service, [connection])!;
+
+    static RemoteDebugConnection Connection(TrustedRemoteDebugger debugger) => (RemoteDebugConnection)Activator.CreateInstance(typeof(RemoteDebugConnection), Hidden, null,
+        [new TcpClient(), new FramedStream(new MemoryStream()), SecureSession.Create(DebugPeerRole.DebugTarget, new byte[32], new byte[32], new byte[32]), debugger,
+            (Func<string, JsonObject, Task<JsonNode?>>)((_, _) => Task.FromResult<JsonNode?>(null))], null)!;
+
+    static async Task<(RemoteDebugService Service, TrustedRemoteDebugger Debugger)> Create()
+    {
+        var service = new RemoteDebugService(new Services());
+        await service.SetDeveloperModeAsync(true);
+        using var identity = DebugIdentity.Create();
+        var debugger = new TrustedRemoteDebugger { Id = identity.KeyId, Name = "Controlled test debugger", PublicKey = Base64Url.Encode(identity.PublicKey), ReconnectSecret = Base64Url.Encode(new byte[32]), PairedAt = DateTimeOffset.UtcNow };
+        Field<List<TrustedRemoteDebugger>>(service, "debuggers").Add(debugger);
+        return (service, debugger);
+    }
+
+    [Fact]
+    public async Task QueuedOldDisconnectCannotDetachReplacementConnection()
+    {
+        var (service, debugger) = await Create();
+        await using var old = Connection(debugger);
+        var replacement = Connection(debugger);
+        Publish(service, old);
+        var gate = Field<SemaphoreSlim>(service, "stateLock");
+        var sessions = Field<ConcurrentDictionary<string, RemoteDebugSession>>(service, "sessions");
+        await gate.WaitAsync();
+        Task pending;
+        try
+        {
+            pending = Disconnect(service, old);
+            Assert.False(pending.IsCompleted);
+            Publish(service, replacement);
+            sessions.TryAdd("replacement", new("replacement", new Uri("https://example.invalid")));
+        }
+        finally { gate.Release(); }
+        await pending.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Same(replacement, Field<RemoteDebugConnection>(service, "connection"));
+        Assert.True(sessions.ContainsKey("replacement"));
+        await service.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task DisconnectCannotRunBetweenUiAdmissionAndOpeningItsWindow()
+    {
+        var (service, debugger) = await Create();
+        var connection = Connection(debugger);
+        Publish(service, connection);
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var release = new ManualResetEventSlim();
+        bool? connectedWhenOpened = null;
+        int stoppedHosts = 0;
+        BoundaryHooks.BeforePageCreate = () => { entered.SetResult(); if (!release.Wait(TimeSpan.FromSeconds(5))) throw new TimeoutException(); };
+        BoundaryHooks.OnOpenWindow = () => connectedWhenOpened = service.IsConnected;
+        BoundaryHooks.OnHostStopped = () => stoppedHosts++;
+        try
+        {
+            Task start = Task.Run(async () => await (Task)ServiceType.GetMethod("HandleAuthorizedRequestAsync", Hidden)!.Invoke(service,
+                [connection, "session.start", new JsonObject { ["url"] = "https://example.invalid" }])!);
+            await entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Task disconnected = Disconnect(service, connection);
+            Assert.False(disconnected.IsCompleted);
+            Assert.True(service.IsConnected);
+            release.Set();
+            await start.WaitAsync(TimeSpan.FromSeconds(5));
+            await disconnected.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.True(connectedWhenOpened);
+            Assert.False(service.IsConnected);
+            Assert.Empty(Field<ConcurrentDictionary<string, RemoteDebugSession>>(service, "sessions"));
+            Assert.Equal(1, stoppedHosts);
+        }
+        finally
+        {
+            release.Set(); BoundaryHooks.BeforePageCreate = null; BoundaryHooks.OnOpenWindow = null; BoundaryHooks.OnHostStopped = null;
+            await service.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task StoppingCapturedOldHostsCannotSweepNewSessionsOrHoldStateLock()
+    {
+        var (service, debugger) = await Create();
+        var old = Connection(debugger); Publish(service, old);
+        var oldHost = new PausedHost();
+        var replacementHost = new PausedHost();
+        var sessions = Field<ConcurrentDictionary<string, RemoteDebugSession>>(service, "sessions");
+        sessions.TryAdd("old", new("old", new Uri("https://example.invalid")) { Host = oldHost });
+        Task stopping = Disconnect(service, old);
+        await oldHost.Entered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        var gate = Field<SemaphoreSlim>(service, "stateLock");
+        await gate.WaitAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        var replacement = Connection(debugger);
+        try
+        {
+            Publish(service, replacement);
+            sessions.TryAdd("new", new("new", new Uri("https://example.invalid")) { Host = replacementHost });
+        }
+        finally { gate.Release(); }
+        oldHost.Release.SetResult();
+        await stopping.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Same(replacement, Field<RemoteDebugConnection>(service, "connection"));
+        Assert.True(sessions.ContainsKey("new"));
+        Assert.False(replacementHost.Entered.Task.IsCompleted);
+        replacementHost.Release.SetResult();
+        await service.DisposeAsync();
+    }
+
+    sealed class PausedHost : IRemoteDebugSessionHost
+    {
+        public readonly TaskCompletionSource Entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public readonly TaskCompletionSource Release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public Task<JsonObject> GetRemoteStatusAsync() => throw new NotSupportedException();
+        public Task<JsonNode?> EvaluateRemoteAsync(string expression) => throw new NotSupportedException();
+        public Task<byte[]> CaptureRemoteScreenshotAsync() => throw new NotSupportedException();
+        public Task ReloadRemoteAsync(bool ignoreCache) => throw new NotSupportedException();
+        public async Task StopRemoteAsync() { Entered.TrySetResult(); await Release.Task; }
+    }
+}

--- a/tests/p1-04/DisposalTests.cs
+++ b/tests/p1-04/DisposalTests.cs
@@ -1,0 +1,66 @@
+using NeoOrder.OneGate.DebugProtocol;
+using NeoOrder.OneGate.Services.RemoteDebug;
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+using System.Text.Json.Nodes;
+using Xunit;
+
+public class DisposalTests
+{
+    const BindingFlags Hidden = BindingFlags.Instance | BindingFlags.NonPublic;
+    sealed class Services : IServiceProvider { public object? GetService(Type type) => null; }
+
+    [Fact]
+    public async Task DisposeDrainsConnectionBeforeReleasingItsDependencies()
+    {
+        var service = new RemoteDebugService(new Services());
+        await service.SetDeveloperModeAsync(true);
+        var gate = (SemaphoreSlim)typeof(RemoteDebugService).GetField("connectLock", Hidden)!.GetValue(service)!;
+        await gate.WaitAsync();
+        Task disposal = service.DisposeAsync().AsTask();
+        try
+        {
+            Assert.False(disposal.IsCompleted);
+        }
+        finally
+        {
+            gate.Release();
+        }
+        await disposal.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => service.SetDeveloperModeAsync(true));
+        await service.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task DisposeCancelsRealPausedHandshakeAndRejectsQueuedConnection()
+    {
+        var service = new RemoteDebugService(new Services());
+        await service.SetDeveloperModeAsync(true);
+        using var identity = DebugIdentity.Create();
+        var debugger = new TrustedRemoteDebugger
+        {
+            Id = identity.KeyId, Name = "Test peer", PublicKey = Base64Url.Encode(identity.PublicKey),
+            ReconnectSecret = Base64Url.Encode(new byte[32]), PairedAt = DateTimeOffset.UtcNow
+        };
+        ((List<TrustedRemoteDebugger>)typeof(RemoteDebugService).GetField("debuggers", Hidden)!.GetValue(service)!).Add(debugger);
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        Task Connect() => (Task)typeof(RemoteDebugService).GetMethod("ConnectAsync", Hidden)!
+            .Invoke(service, [null, (debugger, "127.0.0.1", port)])!;
+        Task active = Connect();
+        using TcpClient server = await listener.AcceptTcpClientAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        await using var framed = new FramedStream(server.GetStream());
+        // Observe the actual protocol hello; deliberately withhold serverHello.
+        await framed.ReadJsonAsync<JsonObject>(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
+        Task queued = Connect();
+        await service.DisposeAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(5));
+        Exception? activeError = await Record.ExceptionAsync(() => active.WaitAsync(TimeSpan.FromSeconds(5)));
+        Exception? queuedError = await Record.ExceptionAsync(() => queued.WaitAsync(TimeSpan.FromSeconds(5)));
+        Assert.IsAssignableFrom<OperationCanceledException>(activeError);
+        var disposed = Assert.IsType<ObjectDisposedException>(queuedError);
+        Assert.Equal(typeof(RemoteDebugService).FullName, disposed.ObjectName);
+        Assert.False(service.IsConnected);
+    }
+}

--- a/tests/p1-04/RevocationTests.cs
+++ b/tests/p1-04/RevocationTests.cs
@@ -1,0 +1,37 @@
+using NeoOrder.OneGate.Services.RemoteDebug;
+using Xunit;
+
+public class RevocationTests
+{
+    [Fact]
+    public async Task RevocationCancelsHandshakeAndRejectsLatePublication()
+    {
+        using var generation = new RemoteDebugConnectionGeneration();
+        var attempt = generation.Capture();
+        var released = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        bool published = false;
+        async Task FinishHandshake()
+        {
+            await released.Task;
+            generation.ThrowIfStale(attempt);
+            published = true;
+        }
+        Task pending = FinishHandshake();
+        generation.Invalidate();
+        released.SetResult();
+        await Assert.ThrowsAsync<OperationCanceledException>(() => pending);
+        Assert.True(attempt.Token.IsCancellationRequested);
+        Assert.False(published);
+    }
+
+    [Fact]
+    public void EnablingAgainCannotReactivateAnOldAttempt()
+    {
+        using var generation = new RemoteDebugConnectionGeneration();
+        var old = generation.Capture();
+        generation.Invalidate();
+        generation.Invalidate();
+        Assert.Throws<OperationCanceledException>(() => generation.ThrowIfStale(old));
+        generation.ThrowIfStale(generation.Capture());
+    }
+}

--- a/tests/p1-04/RevocationTests.csproj
+++ b/tests/p1-04/RevocationTests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup><TargetFramework>net10.0</TargetFramework><ImplicitUsings>enable</ImplicitUsings><Nullable>enable</Nullable><IsTestProject>true</IsTestProject></PropertyGroup>
+  <ItemGroup><PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/><PackageReference Include="xunit" Version="2.9.3"/><PackageReference Include="xunit.runner.visualstudio" Version="3.1.4"/></ItemGroup>
+  <ItemGroup>
+    <Compile Include="../../OneGateApp/Services/RemoteDebug/RemoteDebugConnectionGeneration.cs" Link="RemoteDebugConnectionGeneration.cs"/>
+    <Compile Include="../../OneGateApp/Services/RemoteDebug/RemoteDebugService.cs" Link="RemoteDebugService.cs"/>
+    <Compile Include="../../OneGateApp/Services/RemoteDebug/RemoteDebugModels.cs" Link="RemoteDebugModels.cs"/>
+    <ProjectReference Include="../../OneGate.DebugProtocol/OneGate.DebugProtocol.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../OneGateApp/OneGateApp.csproj" ReferenceOutputAssembly="false" BuildReference="false" SkipGetTargetFrameworkProperties="true" />
+  </ItemGroup>
+</Project>

--- a/tests/p1-04/TestBoundary.cs
+++ b/tests/p1-04/TestBoundary.cs
@@ -12,10 +12,15 @@ namespace NeoOrder.OneGate.Services.RemoteDebug
 
 namespace NeoOrder.OneGate.Pages
 {
-    public class LaunchDAppPage
+    public class LaunchDAppPage : Services.RemoteDebug.IRemoteDebugSessionHost
     {
-        public void ConfigureRemoteDebug(string id, Services.RemoteDebug.RemoteDebugService service) { }
+        public void ConfigureRemoteDebug(string id, Services.RemoteDebug.RemoteDebugService service) => service.AttachSessionHost(id, this);
         public void ApplyQueryAttributes(IDictionary<string, object> query) { }
+        public Task<System.Text.Json.Nodes.JsonObject> GetRemoteStatusAsync() => Task.FromResult(new System.Text.Json.Nodes.JsonObject());
+        public Task<System.Text.Json.Nodes.JsonNode?> EvaluateRemoteAsync(string expression) => Task.FromResult<System.Text.Json.Nodes.JsonNode?>(null);
+        public Task<byte[]> CaptureRemoteScreenshotAsync() => Task.FromResult(Array.Empty<byte>());
+        public Task ReloadRemoteAsync(bool ignoreCache) => Task.CompletedTask;
+        public Task StopRemoteAsync() { BoundaryHooks.OnHostStopped?.Invoke(); return Task.CompletedTask; }
     }
 }
 
@@ -23,7 +28,17 @@ namespace NeoOrder.OneGate
 {
     static class ServiceProviderExtensions
     {
-        public static T GetServiceOrCreateInstance<T>(this IServiceProvider services) where T : new() => new();
+        public static T GetServiceOrCreateInstance<T>(this IServiceProvider services) where T : new()
+        {
+            BoundaryHooks.BeforePageCreate?.Invoke();
+            return new();
+        }
+    }
+    static class BoundaryHooks
+    {
+        public static Action? BeforePageCreate;
+        public static Action? OnOpenWindow;
+        public static Action? OnHostStopped;
     }
     static class MainThread
     {
@@ -43,7 +58,7 @@ namespace NeoOrder.OneGate
     sealed class Application
     {
         public static Application Current { get; } = new();
-        public void OpenWindow(Window window) { }
+        public void OpenWindow(Window window) => BoundaryHooks.OnOpenWindow?.Invoke();
     }
     sealed class Window(NavigationPage page) { public NavigationPage Page { get; } = page; }
     sealed class NavigationPage(Pages.LaunchDAppPage page) { public Pages.LaunchDAppPage Page { get; } = page; }

--- a/tests/p1-04/TestBoundary.cs
+++ b/tests/p1-04/TestBoundary.cs
@@ -1,0 +1,50 @@
+// Standalone service tests retain the actual protocol and service. Only the
+// platform storage, discovery, UI dispatch and page-construction edges are fake.
+namespace NeoOrder.OneGate.Services.RemoteDebug
+{
+    sealed class MdnsRemoteDebuggerDiscovery : IAsyncDisposable
+    {
+        public event Action<string, string, int>? RemoteDebuggerDiscovered { add { } remove { } }
+        public Task StartAsync() => Task.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}
+
+namespace NeoOrder.OneGate.Pages
+{
+    public class LaunchDAppPage
+    {
+        public void ConfigureRemoteDebug(string id, Services.RemoteDebug.RemoteDebugService service) { }
+        public void ApplyQueryAttributes(IDictionary<string, object> query) { }
+    }
+}
+
+namespace NeoOrder.OneGate
+{
+    static class ServiceProviderExtensions
+    {
+        public static T GetServiceOrCreateInstance<T>(this IServiceProvider services) where T : new() => new();
+    }
+    static class MainThread
+    {
+        public static Task InvokeOnMainThreadAsync(Func<Task> action) => action();
+    }
+    sealed class SecureStorage
+    {
+        public static SecureStorage Default { get; } = new();
+        public Task<string?> GetAsync(string key) => Task.FromResult<string?>(null);
+        public Task SetAsync(string key, string value) => Task.CompletedTask;
+    }
+    static class DeviceInfo
+    {
+        public static string Name => "Regression harness";
+        public static string Platform => "Test";
+    }
+    sealed class Application
+    {
+        public static Application Current { get; } = new();
+        public void OpenWindow(Window window) { }
+    }
+    sealed class Window(NavigationPage page) { public NavigationPage Page { get; } = page; }
+    sealed class NavigationPage(Pages.LaunchDAppPage page) { public Pages.LaunchDAppPage Page { get; } = page; }
+}


### PR DESCRIPTION
## Problem

A pending debugger handshake could finish after developer mode was disabled or its debugger was forgotten, then persist trust or publish a live connection after revocation.

## Change

- Associate each connection attempt with a cancellation token and generation; recheck before persisting trust or publishing the connection.
- Reject commands from revoked/stale connections and recheck authorization when creating a session on the UI thread.
- On disposal, close admission, cancel attempts, drain active connection work, and reject already-queued callers before releasing the identity.
- Serialize disconnection identity checks and detach only that connection's sessions under the state lock; stop detached hosts outside the lock, preserving replacement connections and sessions.

This independent PR addresses audit P1-04 only, based on master `623603d`. Existing app-link/new-window session navigation is unchanged.

## Validation

- 7 targeted regressions passed, including the production remote-debug service and a real loopback TCP handshake held after clientHello, queued-connection disposal, and disconnection races.
- iOS 26.5 iPhone 17 simulator and Android API 36 arm64 emulator: each passed 17 native-app assertions covering late trust persistence after disable/forget, stale attempt/command rejection, active handshake cancellation, queued connection shutdown, actual read-loop EOF, a disconnection callback queued behind the state lock, and preservation of replacement connections/sessions while an old host cleanup is held.
- Native testing used the real service, protocol and platform secure storage, an isolated application/keychain identity, a local TCP server, and synthetic debugger records. No remote wallet operation was authorized or transaction broadcast.
- Removed the test fixture, fully rebuilt, installed and smoke-launched the normal product on both platforms; zero build warnings/errors and no observed OneGate crash. Android's device-wide crash buffer contains an unrelated system Bluetooth failure.
- Follow-up source diff SHA-256 `41be6edff6a0d6be86f6ef8ddee2ab04db4cbba3b40056e9c925ebb4410ac31b` against the first PR commit `3fe4e54`; both platforms tested this exact follow-up.

Screenshots, result JSON and simulator-only fixtures remain outside the repository. Screenshots have not been uploaded to GitHub; hosted CI is not claimed as passing.
