### PR TITLE
Use the current query when confirming search

### DIFF
--- a/OneGateApp.slnx
+++ b/OneGateApp.slnx
@@ -6,4 +6,5 @@
   <Project Path="OneGate.DebugProtocol/OneGate.DebugProtocol.csproj" />
   <Project Path="OneGate.DebugProtocol.Tests/OneGate.DebugProtocol.Tests.csproj" />
   <Project Path="OneGate.Tools/OneGate.Tools.csproj" />
+  <Project Path="tests/p2-11/SearchConfirmation.Tests.csproj" />
 </Solution>

--- a/OneGateApp/Pages/GlobalSearchPage.xaml.cs
+++ b/OneGateApp/Pages/GlobalSearchPage.xaml.cs
@@ -112,6 +112,8 @@ public partial class GlobalSearchPage : ContentPage
 
     async void OnSearchButtonPressed(object sender, EventArgs e)
     {
+        searchVersion++;
+        UpdateResults();
         if (Results.Length == 1)
             await OpenResultAsync(Results[0]);
     }

--- a/tests/p2-11/SearchConfirmation.Tests.csproj
+++ b/tests/p2-11/SearchConfirmation.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsTestProject>true</IsTestProject>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" PrivateAssets="all" />
+    <Compile Include="../../OneGateApp/Pages/GlobalSearchPage.xaml.cs" Link="GlobalSearchPage.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- App relationship only; linked-source tests run without MAUI workloads. -->
+    <ProjectReference Include="../../OneGateApp/OneGateApp.csproj"
+                      ReferenceOutputAssembly="false" BuildReference="false"
+                      SkipGetTargetFrameworkProperties="true" />
+  </ItemGroup>
+</Project>

--- a/tests/p2-11/SearchConfirmationTests.cs
+++ b/tests/p2-11/SearchConfirmationTests.cs
@@ -1,0 +1,32 @@
+using NeoOrder.OneGate.Data;
+using NeoOrder.OneGate.Models;
+using NeoOrder.OneGate.Pages;
+using NeoOrder.OneGate.Services;
+using Xunit;
+
+public class SearchConfirmationTests
+{
+    [Theory]
+    [InlineData("Beta", "Beta", 1)]
+    [InlineData("Missing", null, 0)]
+    [InlineData("", null, 0)]
+    [InlineData("a", null, 2)]
+    public async Task ConfirmationUsesCurrentTextBeforePendingDebounce(string query, string? expected, int resultCount)
+    {
+        Commands.LaunchDApp.Last = null;
+        var catalog = new CachedCollection<DApp> { new() { Name = "Alpha" }, new() { Name = "Beta" } };
+        var page = new GlobalSearchPage(new TestServices(catalog), new(), new());
+        await page.LoadForTestAsync();
+        page.ChangeQueryForTest("Alpha");
+        page.Dispatcher.Flush();
+        Assert.Single(page.Results);
+
+        page.ChangeQueryForTest(query);
+        page.ConfirmForTest();
+
+        Assert.Equal(expected, Commands.LaunchDApp.Last?.Name);
+        Assert.Equal(resultCount, page.Results.Length);
+        page.Dispatcher.Flush();
+        Assert.Equal(expected, Commands.LaunchDApp.Last?.Name);
+    }
+}

--- a/tests/p2-11/TestBoundary.cs
+++ b/tests/p2-11/TestBoundary.cs
@@ -1,0 +1,119 @@
+// Only native UI, persistence, and network boundaries are substituted. The page
+// source linked by this project contains the production search/event logic.
+using NeoOrder.OneGate.Data;
+using NeoOrder.OneGate.Models;
+
+public class ContentPage
+{
+    public TestDispatcher Dispatcher { get; } = new();
+    protected virtual void OnAppearing() { }
+    protected void OnPropertyChanged(string? property = null) { }
+}
+public class TestDispatcher
+{
+    readonly List<Action> actions = [];
+    public void DispatchDelayed(TimeSpan delay, Action action) => actions.Add(action);
+    public void Flush() { Action[] pending = [.. actions]; actions.Clear(); foreach (Action action in pending) action(); }
+}
+public class TextChangedEventArgs(string? text) : EventArgs { public string? NewTextValue => text; }
+public class TappedEventArgs : EventArgs { public object? Parameter { get; set; } }
+public class TestSearchBar { public bool Focus() => true; public void Unfocus() { } }
+public class Shell
+{
+    public static Shell Current { get; } = new();
+    public Task GoToAsync(string route, Dictionary<string, object> args) => Task.CompletedTask;
+}
+public class TestServices(CachedCollection<DApp> catalog) : IServiceProvider
+{
+    public object? GetService(Type type) => type == typeof(CachedCollection<DApp>) ? catalog : null;
+}
+namespace Microsoft.EntityFrameworkCore
+{
+    public static class QueryExtensions
+    {
+        public static IEnumerable<T> AsNoTracking<T>(this IEnumerable<T> source) => source;
+        public static Task<T[]> ToArrayAsync<T>(this IEnumerable<T> source) => Task.FromResult(source.ToArray());
+    }
+}
+namespace NeoOrder.OneGate.Data
+{
+    public class ApplicationDbContext
+    {
+        public TestSettings Settings { get; } = new();
+        public List<Contact> Contacts { get; } = [];
+    }
+    public class TestSettings
+    {
+        public Task<T?> GetAsync<T>(string key) where T : notnull => Task.FromResult(default(T));
+    }
+    public class Contact { public string Label { get; set; } = ""; public string Address { get; set; } = ""; }
+    public class DApp
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+        public bool IsRegularApp { get; set; } = true;
+        public string Url { get; set; } = "https://example.com";
+        public string? IconUrl { get; set; }
+        public string[]? Tags { get; set; }
+        public Dictionary<string, string> NameLocalizer => new() { ["en"] = Name };
+        public Dictionary<string, string>? DescriptionLocalizer => null;
+        public static string LocalizeTag(string tag) => tag;
+    }
+}
+namespace NeoOrder.OneGate.Models
+{
+    public class CachedCollection<T> : List<T>
+    {
+        public Task LoadAsync(string url, TimeSpan ttl) => Task.CompletedTask;
+    }
+    public class AssetInfo { public Token Token { get; } = new(); public string DisplayBalance => "0"; }
+    public class Token { public string Symbol => "NEO"; public string Name => "Neo"; public string Hash => "hash"; public string? Icon => null; }
+}
+namespace NeoOrder.OneGate.Services
+{
+    public class TokenManager { public Task<IReadOnlyList<AssetInfo>> LoadAssetsAsync() => Task.FromResult<IReadOnlyList<AssetInfo>>([]); }
+    public class LoadingService(Func<Task> action)
+    {
+        public event EventHandler? Loaded;
+        public event System.ComponentModel.PropertyChangedEventHandler? PropertyChanged;
+        public bool IsLoading => false;
+        public async void BeginLoad() { await action(); Loaded?.Invoke(this, EventArgs.Empty); PropertyChanged?.Invoke(this, new(nameof(IsLoading))); }
+    }
+    public static class DAppCatalogPolicy
+    {
+        public static Task<bool> GetDeveloperModeEnabledAsync(ApplicationDbContext context) => Task.FromResult(false);
+        public static bool IsDiscoverable(DApp app, bool developerMode) => true;
+    }
+    public static class Extensions
+    {
+        public static T GetServiceOrCreateInstance<T>(this IServiceProvider services) => (T)services.GetService(typeof(T))!;
+        public static bool ShouldRefresh(this ContentPage page) => false;
+        public static string? Localize(this Dictionary<string, string> value) => value.Values.FirstOrDefault();
+    }
+}
+namespace NeoOrder.OneGate.Properties
+{
+    public static class Strings
+    {
+        public static string Asset => "Asset";
+        public static string AddressBook => "Address book";
+        public static string Apps => "Apps";
+    }
+}
+namespace NeoOrder.OneGate.Pages
+{
+    public static class Commands { public static TestCommand LaunchDApp { get; } = new(); }
+    public class TestCommand
+    {
+        public DApp? Last { get; set; }
+        public Task ExecuteAsync(DApp app) { Last = app; return Task.CompletedTask; }
+    }
+    public partial class GlobalSearchPage
+    {
+        readonly TestSearchBar searchBar = new();
+        void InitializeComponent() { }
+        public async Task LoadForTestAsync() { await LoadSearchDataAsync(); OnLoaded(this, EventArgs.Empty); }
+        public void ChangeQueryForTest(string text) => OnSearchTextChanged(this, new(text));
+        public void ConfirmForTest() => OnSearchButtonPressed(this, EventArgs.Empty);
+    }
+}


### PR DESCRIPTION
## Problem

Pressing Search before the debounce completed could open the previous query's sole result instead of searching the text currently in the field.

## Change

Invalidate the pending debounce and synchronously recompute the results before applying the existing single-result navigation behavior.

This independent PR addresses audit P2-11 only, based on master `623603d`.

## Validation

- 4 regression tests passed; three failed with the original implementation.
- iOS 26.5 iPhone 17 simulator and Android API 36 arm64 emulator: each exercised the actual GlobalSearchPage/SearchBar handlers and passed four native checks. Immediately confirming after changing an old sole match to zero or multiple matches did not launch the stale result; the delayed callback preserved the new results.
- Search data was a controlled in-memory index to isolate the UI race. No wallet operation or external navigation was performed.
- Removed the fixture, fully rebuilt, installed and smoke-launched the normal product on both platforms with zero build warnings/errors.

Screenshots and simulator-only fixtures remain outside the repository.
