### PR TITLE
fix: scope native DApp bridge requests to their document

### DIFF
--- a/OneGateApp.slnx
+++ b/OneGateApp.slnx
@@ -6,4 +6,5 @@
   <Project Path="OneGate.DebugProtocol/OneGate.DebugProtocol.csproj" />
   <Project Path="OneGate.DebugProtocol.Tests/OneGate.DebugProtocol.Tests.csproj" />
   <Project Path="OneGate.Tools/OneGate.Tools.csproj" />
+  <Project Path="tests/p1-03/P1-03.Tests.csproj" />
 </Solution>

--- a/OneGateApp/Controls/Handlers/BridgeWebViewHandler.Android.cs
+++ b/OneGateApp/Controls/Handlers/BridgeWebViewHandler.Android.cs
@@ -4,7 +4,6 @@ using Android.Webkit;
 using Android.Widget;
 using AndroidX.Core.View;
 using AndroidX.WebKit;
-using Java.Interop;
 using Microsoft.Maui;
 using Microsoft.Maui.ApplicationModel;
 using Microsoft.Maui.Handlers;
@@ -14,20 +13,18 @@ namespace NeoOrder.OneGate.Controls.Handlers;
 
 partial class BridgeWebViewHandler
 {
-    class ScriptHandler(Action<string> onMessage, Func<string, string> onSyncMessage) : Java.Lang.Object
-    {
-        [JavascriptInterface]
-        [Export("invoke")]
-        public void Invoke(string payload)
-        {
-            onMessage(payload);
-        }
+    const string NativeBridgeName = "__OneGateNativeBridge";
+    const string SyncPrompt = "__OneGateBridgeSync";
+    readonly string syncToken = Convert.ToHexString(System.Security.Cryptography.RandomNumberGenerator.GetBytes(32));
+    ScriptHandler? scriptHandler;
 
-        [JavascriptInterface]
-        [Export("invokeSync")]
-        public string InvokeSync(string payload)
+    class ScriptHandler(BridgeWebViewHandler handler) : Java.Lang.Object, WebViewCompat.IWebMessageListener
+    {
+        public void OnPostMessage(Android.Webkit.WebView? view, WebMessageCompat? message, Android.Net.Uri? sourceOrigin, bool isMainFrame, JavaScriptReplyProxy? replyProxy)
         {
-            return onSyncMessage(payload);
+            if (!isMainFrame || message?.Type != WebMessageCompat.TypeString) return;
+            if (message?.Data is string payload)
+                handler.BridgeWebView.OnMessage(payload, sourceOrigin?.ToString(), view?.Url, isMainFrame);
         }
     }
 
@@ -38,6 +35,22 @@ partial class BridgeWebViewHandler
         ICustomViewCallback? fullscreenCallback;
         WindowInsetsControllerCompat? fullscreenInsetsController;
         bool wereSystemBarsVisible;
+
+        public override bool OnJsPrompt(Android.Webkit.WebView? view, string? url, string? message, string? defaultValue, JsPromptResult? result)
+        {
+            if (message?.StartsWith(SyncPrompt, StringComparison.Ordinal) != true)
+                return base.OnJsPrompt(view, url, message, defaultValue, result);
+            // Android prompts do not expose isMainFrame. Only the main-frame injection
+            // receives this private capability; the raw prompt remains origin-checked.
+            string? token = message.StartsWith(SyncPrompt + ":", StringComparison.Ordinal) ? message[(SyncPrompt.Length + 1)..] : null;
+            if (!handler.BridgeWebView.IsAuthorizedSyncSource(token, handler.syncToken, url, view?.Url))
+            {
+                result?.Cancel();
+                return true;
+            }
+            result?.Confirm(handler.BridgeWebView.OnSyncMessage(defaultValue ?? string.Empty, url, view?.Url, true));
+            return true;
+        }
 
         public override void OnShowCustomView(Android.Views.View? view, ICustomViewCallback? callback)
         {
@@ -195,14 +208,37 @@ partial class BridgeWebViewHandler
         platformView.Settings.DomStorageEnabled = true;
         platformView.Settings.JavaScriptEnabled = true;
         platformView.Settings.MediaPlaybackRequiresUserGesture = false;
-        platformView.AddJavascriptInterface(new ScriptHandler(BridgeWebView.OnMessage, BridgeWebView.OnSyncMessage), "__OneGateBridge");
-        if (WebViewFeature.IsFeatureSupported(WebViewFeature.DocumentStartScript))
+        if (WebViewFeature.IsFeatureSupported(WebViewFeature.DocumentStartScript)
+            && WebViewFeature.IsFeatureSupported(WebViewFeature.WebMessageListener))
         {
-            string script = Views.BridgeWebView.CreateRpcScript();
+            scriptHandler = new ScriptHandler(this);
+            // Messages include sourceOrigin and isMainFrame, verified before dispatch.
+            WebViewCompat.AddWebMessageListener(platformView, NativeBridgeName, ["*"], scriptHandler);
+            string script = $$"""
+                (function () {
+                    if (window.top !== window) return;
+                    const token = '{{syncToken}}';
+                    window.__OneGateBridge = {
+                        invoke: function(payload) { window.{{NativeBridgeName}}.postMessage(payload); },
+                        invokeSync: function(payload) { return window.prompt('{{SyncPrompt}}:' + token, payload); }
+                    };
+                })();
+                """ + Views.BridgeWebView.CreateRpcScript();
             if (!string.IsNullOrWhiteSpace(BridgeWebView.DocumentStartScript))
                 script += BridgeWebView.DocumentStartScript;
             WebViewCompat.AddDocumentStartJavaScript(platformView, script, ["*"]);
         }
+    }
+
+    protected override void DisconnectHandler(Android.Webkit.WebView platformView)
+    {
+        if (scriptHandler is not null)
+        {
+            WebViewCompat.RemoveWebMessageListener(platformView, NativeBridgeName);
+            scriptHandler.Dispose();
+            scriptHandler = null;
+        }
+        base.DisconnectHandler(platformView);
     }
 }
 #endif

--- a/OneGateApp/Controls/Handlers/BridgeWebViewHandler.Windows.cs
+++ b/OneGateApp/Controls/Handlers/BridgeWebViewHandler.Windows.cs
@@ -8,6 +8,7 @@ namespace NeoOrder.OneGate.Controls.Handlers;
 partial class BridgeWebViewHandler
 {
     const string SyncPrompt = "__OneGateBridgeSync";
+    readonly string syncToken = Convert.ToHexString(System.Security.Cryptography.RandomNumberGenerator.GetBytes(32));
 
     protected override void ConnectHandler(WebView2 platformView)
     {
@@ -30,15 +31,19 @@ partial class BridgeWebViewHandler
         sender.CoreWebView2.WebMessageReceived += CoreWebView2_WebMessageReceived;
         sender.CoreWebView2.ScriptDialogOpening += CoreWebView2_ScriptDialogOpening;
         sender.CoreWebView2.PermissionRequested += CoreWebView2_PermissionRequested;
-        string shim = """
+        string shim = $$"""
+            (function() {
+            if (window.top !== window) return;
+            const token = '{{syncToken}}';
             window.__OneGateBridge = {
                 invoke: function(payload) {
                     window.chrome.webview.postMessage(payload);
                 },
                 invokeSync: function(payload) {
-                    return window.prompt("__OneGateBridgeSync", payload);
+                    return window.prompt("__OneGateBridgeSync:" + token, payload);
                 }
             };
+            })();
             """;
         string script = shim + Views.BridgeWebView.CreateRpcScript();
         if (!string.IsNullOrWhiteSpace(BridgeWebView.DocumentStartScript))
@@ -72,15 +77,22 @@ partial class BridgeWebViewHandler
 
     void CoreWebView2_WebMessageReceived(CoreWebView2 sender, CoreWebView2WebMessageReceivedEventArgs args)
     {
-        BridgeWebView.OnMessage(args.TryGetWebMessageAsString());
+        BridgeWebView.OnMessage(args.TryGetWebMessageAsString(), args.Source, sender.Source, true);
     }
 
     void CoreWebView2_ScriptDialogOpening(CoreWebView2 sender, CoreWebView2ScriptDialogOpeningEventArgs args)
     {
-        if (args.Kind != CoreWebView2ScriptDialogKind.Prompt || args.Message != SyncPrompt)
+        if (args.Kind != CoreWebView2ScriptDialogKind.Prompt || !args.Message.StartsWith(SyncPrompt, StringComparison.Ordinal))
             return;
 
-        args.ResultText = BridgeWebView.OnSyncMessage(args.DefaultText ?? string.Empty);
+        string? token = args.Message.StartsWith(SyncPrompt + ":", StringComparison.Ordinal) ? args.Message[(SyncPrompt.Length + 1)..] : null;
+        if (!BridgeWebView.IsAuthorizedSyncSource(token, syncToken, args.Uri, sender.Source))
+        {
+            args.ResultText = string.Empty;
+            args.Accept();
+            return;
+        }
+        args.ResultText = BridgeWebView.OnSyncMessage(args.DefaultText ?? string.Empty, args.Uri, sender.Source, true);
         args.Accept();
     }
 }

--- a/OneGateApp/Controls/Handlers/BridgeWebViewHandler.iOS.cs
+++ b/OneGateApp/Controls/Handlers/BridgeWebViewHandler.iOS.cs
@@ -13,11 +13,12 @@ partial class BridgeWebViewHandler
 {
     const string SyncPrompt = "__OneGateBridgeSync";
 
-    class ScriptHandler(Action<string> onMessage) : NSObject, IWKScriptMessageHandler
+    class ScriptHandler(BridgeWebViewHandler handler) : NSObject, IWKScriptMessageHandler
     {
         public void DidReceiveScriptMessage(WKUserContentController userContentController, WKScriptMessage message)
         {
-            onMessage(message.Body?.ToString()!);
+            handler.BridgeWebView.OnMessage(message.Body?.ToString() ?? string.Empty,
+                GetFrameOrigin(message.FrameInfo), handler.PlatformView.Url?.AbsoluteString, message.FrameInfo.MainFrame);
         }
     }
 
@@ -59,9 +60,10 @@ partial class BridgeWebViewHandler
             WKFrameInfo frame,
             Action<string> completionHandler)
         {
-            if (frame.MainFrame && prompt == SyncPrompt && handler.VirtualView is Views.BridgeWebView bridgeWebView)
+            if (prompt == SyncPrompt && handler.VirtualView is Views.BridgeWebView bridgeWebView)
             {
-                completionHandler(bridgeWebView.OnSyncMessage(defaultText ?? string.Empty));
+                completionHandler(bridgeWebView.OnSyncMessage(defaultText ?? string.Empty,
+                    GetFrameOrigin(frame), webView.Url?.AbsoluteString, frame.MainFrame));
                 return;
             }
 
@@ -104,7 +106,7 @@ partial class BridgeWebViewHandler
         controller.AddUserScript(CreateDocumentStartScript(shim + Views.BridgeWebView.CreateRpcScript()));
         if (!string.IsNullOrWhiteSpace(BridgeWebView.DocumentStartScript))
             controller.AddUserScript(CreateDocumentStartScript(BridgeWebView.DocumentStartScript));
-        controller.AddScriptMessageHandler(new ScriptHandler(BridgeWebView.OnMessage), "__OneGateBridge");
+        controller.AddScriptMessageHandler(new ScriptHandler(this), "__OneGateBridge");
 #if MACCATALYST
         config.Preferences.ElementFullscreenEnabled = true;
 #endif
@@ -115,6 +117,14 @@ partial class BridgeWebViewHandler
     static WKUserScript CreateDocumentStartScript(string script)
     {
         return new WKUserScript(new NSString(script), WKUserScriptInjectionTime.AtDocumentStart, true);
+    }
+
+    static string? GetFrameOrigin(WKFrameInfo frame)
+    {
+        WKSecurityOrigin origin = frame.SecurityOrigin;
+        if (origin.Protocol is not ("http" or "https") || string.IsNullOrEmpty(origin.Host)) return null;
+        return new UriBuilder(origin.Protocol, origin.Host, origin.Port > 0 ? (int)origin.Port : -1)
+            .Uri.GetLeftPart(UriPartial.Authority);
     }
 }
 #endif

--- a/OneGateApp/Controls/Popups/SendTransactionPopup.xaml
+++ b/OneGateApp/Controls/Popups/SendTransactionPopup.xaml
@@ -16,6 +16,7 @@
         <ScrollView MaximumHeightRequest="400">
             <VerticalStackLayout Spacing="15">
                 <Label Text="{Binding Message}" />
+                <Label Text="{Binding RequestOrigin}" IsVisible="{Binding RequestOrigin, Converter={StaticResource IsNotNullConverter}}" FontAttributes="Bold" LineBreakMode="WordWrap" />
                 <og:IntentsView Intents="{Binding Intents}" />
                 <Border StrokeShape="RoundRectangle 10" BackgroundColor="{toolkit:AppThemeResource Panel}">
                     <VerticalStackLayout Padding="10,0">

--- a/OneGateApp/Controls/Popups/SendTransactionPopup.xaml.cs
+++ b/OneGateApp/Controls/Popups/SendTransactionPopup.xaml.cs
@@ -13,6 +13,7 @@ namespace NeoOrder.OneGate.Controls.Popups;
 public partial class SendTransactionPopup : MyPopup<bool>
 {
     readonly WalletAuthorizationService walletAuthorizationService;
+    public string? RequestOrigin { get; set { field = value; OnPropertyChanged(); } }
 
     public string Title { get; set { field = value; OnPropertyChanged(); } } = Strings.SendTransaction;
     public string Message { get; set { field = value; OnPropertyChanged(); } } = Strings.SendTransactionText;

--- a/OneGateApp/Controls/Popups/SignMessagePopup.xaml
+++ b/OneGateApp/Controls/Popups/SignMessagePopup.xaml
@@ -16,6 +16,7 @@
             <Button Grid.Column="1" StyleClass="Icon" Text="&#xe6b5;" FontSize="24" Margin="-10" Padding="10" Clicked="OnCancel" />
         </Grid>
         <Label Text="{x:Static og:Strings.SignMessageText}" />
+        <Label Text="{Binding RequestOrigin}" IsVisible="{Binding RequestOrigin, Converter={StaticResource IsNotNullConverter}}" FontAttributes="Bold" LineBreakMode="WordWrap" />
         <Border StrokeShape="RoundRectangle 8" BackgroundColor="#fdf0d5" Padding="10">
             <Grid ColumnDefinitions="auto,*" ColumnSpacing="10">
                 <Label StyleClass="Icon" Text="&#xe744;" FontSize="18" TextColor="#b8860b" VerticalOptions="Start" />

--- a/OneGateApp/Controls/Popups/SignMessagePopup.xaml.cs
+++ b/OneGateApp/Controls/Popups/SignMessagePopup.xaml.cs
@@ -10,6 +10,7 @@ public partial class SignMessagePopup : MyPopup<string?>
     const int MaxReadableMessageInputLength = 16 * 1024;
 
     readonly WalletAuthorizationService walletAuthorizationService;
+    public string? RequestOrigin { get; set { field = value; OnPropertyChanged(); } }
 
     public string? Account { get; set { field = value; OnPropertyChanged(); } }
     public string[] Addresses { get; set { field = value; OnPropertyChanged(); } }

--- a/OneGateApp/Controls/Views/BridgeInvocation.cs
+++ b/OneGateApp/Controls/Views/BridgeInvocation.cs
@@ -1,0 +1,5 @@
+using System.Text.Json.Nodes;
+
+namespace NeoOrder.OneGate.Controls.Views;
+
+public sealed record BridgeInvocation(JsonObject Request, BridgeRequestContext Context);

--- a/OneGateApp/Controls/Views/BridgeRequestPolicy.cs
+++ b/OneGateApp/Controls/Views/BridgeRequestPolicy.cs
@@ -1,0 +1,70 @@
+namespace NeoOrder.OneGate.Controls.Views;
+
+public readonly record struct BridgeRequestContext(long NavigationId, string Origin, string DocumentToken = "");
+
+/// <summary>Validates native-supplied frame provenance and expires requests on navigation.</summary>
+internal sealed class BridgeRequestPolicy
+{
+    readonly object gate = new();
+    long navigationId;
+    string documentToken = string.Empty;
+
+    // Called only through the native-protected synchronous document-start handshake.
+    public string BeginDocument()
+    {
+        lock (gate)
+        {
+            navigationId++;
+            return documentToken = Convert.ToHexString(System.Security.Cryptography.RandomNumberGenerator.GetBytes(32));
+        }
+    }
+
+    public void Invalidate()
+    {
+        lock (gate) { navigationId++; documentToken = string.Empty; }
+    }
+
+    public bool IsCurrent(BridgeRequestContext context)
+    {
+        lock (gate)
+            return !string.IsNullOrEmpty(context.Origin) && !string.IsNullOrEmpty(documentToken)
+                && context.NavigationId == navigationId && StringComparer.Ordinal.Equals(context.DocumentToken, documentToken);
+    }
+
+    public bool TryAuthorize(string? sourceUrl, string? pageUrl, bool isMainFrame, out BridgeRequestContext context)
+    {
+        context = default;
+        if (!isMainFrame || !TryGetWebOrigin(sourceUrl, out Uri? source) || !TryGetWebOrigin(pageUrl, out Uri? page))
+            return false;
+        if (!StringComparer.OrdinalIgnoreCase.Equals(source.Scheme, page.Scheme)
+            || !StringComparer.OrdinalIgnoreCase.Equals(source.IdnHost, page.IdnHost)
+            || source.Port != page.Port)
+            return false;
+        lock (gate) context = new(navigationId, source.GetLeftPart(UriPartial.Authority), documentToken);
+        return true;
+    }
+
+    public bool TryAuthorizeSync(string? suppliedToken, string expectedToken, string? sourceUrl, string? pageUrl, out BridgeRequestContext context)
+    {
+        context = default;
+        return !string.IsNullOrEmpty(expectedToken)
+            && StringComparer.Ordinal.Equals(suppliedToken, expectedToken)
+            && TryAuthorize(sourceUrl, pageUrl, true, out context);
+    }
+
+    public bool TryBindDocument(BridgeRequestContext context, string? token, out BridgeRequestContext bound)
+    {
+        bound = default;
+        lock (gate)
+        {
+            if (!IsCurrent(context) || !StringComparer.Ordinal.Equals(token, documentToken)) return false;
+            bound = context;
+            return true;
+        }
+    }
+
+    static bool TryGetWebOrigin(string? value, [System.Diagnostics.CodeAnalysis.NotNullWhen(true)] out Uri? uri)
+    {
+        return Uri.TryCreate(value, UriKind.Absolute, out uri) && uri.Scheme is "http" or "https";
+    }
+}

--- a/OneGateApp/Controls/Views/BridgeWebView.cs
+++ b/OneGateApp/Controls/Views/BridgeWebView.cs
@@ -13,12 +13,14 @@ public partial class BridgeWebView : WebView
     const string SystemCallMethodPrefix = "onegate.system.";
     const string SystemCallInvokeFunctionName = "__OneGateSystemInvoke";
     const string SystemCallInvokeSyncFunctionName = "__OneGateSystemInvokeSync";
+    const string InitializeDocumentMethod = "__onegate_document";
 
     public static readonly BindableProperty DocumentStartScriptProperty = BindableProperty.Create(nameof(DocumentStartScript), typeof(string), typeof(BridgeWebView));
     readonly ConcurrentDictionary<string, Func<JsonArray?, Task<JsonNode?>>> asyncSystemCallHandlers = new(StringComparer.Ordinal);
     readonly ConcurrentDictionary<string, Func<JsonArray?, JsonNode?>> syncSystemCallHandlers = new(StringComparer.Ordinal);
+    readonly BridgeRequestPolicy requestPolicy = new();
 
-    public event EventHandler<BridgeWebView, JsonObject>? InvokedFromJavaScript;
+    public event EventHandler<BridgeWebView, BridgeInvocation>? InvokedFromJavaScript;
     public event EventHandler<JsonObject>? RemoteConsoleMessageReceived;
 
     public string? DocumentStartScript { get => (string?)GetValue(DocumentStartScriptProperty); set => SetValue(DocumentStartScriptProperty, value); }
@@ -32,11 +34,14 @@ public partial class BridgeWebView : WebView
         RegisterSystemCallHandler("fullscreen.enter", EnterFullscreenSystemAsync);
         RegisterSystemCallHandler("fullscreen.exit", ExitFullscreenSystemAsync);
 #endif
-        Unloaded += (_, _) => RestoreHostState();
+        Unloaded += (_, _) => { requestPolicy.Invalidate(); RestoreHostState(); };
         HandlerChanging += (_, e) =>
         {
             if (e.OldHandler is not null)
+            {
+                requestPolicy.Invalidate();
                 RestoreHostState();
+            }
         };
     }
 
@@ -58,6 +63,7 @@ public partial class BridgeWebView : WebView
     {
         return $$"""
             (function () {
+                if (window.top !== window) return;
                 if (window.__OneGateRpcInjected) return;
                 window.__OneGateRpcInjected = true;
 
@@ -67,6 +73,23 @@ public partial class BridgeWebView : WebView
                     return 'onegate_' + Date.now() + '_' + Math.random().toString(16).slice(2);
                 }
 
+                /* The protected synchronous transport establishes the actual
+                   document identity, including same-URL reloads. Generic navigation
+                   events also cover canceled/iframe loads and cannot do this. */
+                const bootstrap = {
+                    jsonrpc: "2.0",
+                    id: createId(),
+                    method: "{{InitializeDocumentMethod}}",
+                    params: []
+                };
+                let initialized = window.__OneGateBridge.invokeSync(JSON.stringify(bootstrap));
+                if (typeof initialized === 'string') initialized = JSON.parse(initialized);
+                if (!initialized || initialized.jsonrpc !== "2.0" || initialized.id !== bootstrap.id
+                    || initialized.error || typeof initialized.result !== 'string' || !initialized.result)
+                    throw new Error('Native document initialization failed.');
+                const documentToken = initialized.result;
+                Object.defineProperty(window, '__OneGateDocumentToken', { value: documentToken });
+
                 function invoke(method, params) {
                     return new Promise(function(resolve, reject) {
                         const id = createId();
@@ -75,6 +98,7 @@ public partial class BridgeWebView : WebView
                         const request = {
                             jsonrpc: "2.0",
                             id: id,
+                            onegateDocument: documentToken,
                             method: method,
                             params: params
                         };
@@ -96,6 +120,7 @@ public partial class BridgeWebView : WebView
                     const request = {
                         jsonrpc: "2.0",
                         id: createId(),
+                        onegateDocument: documentToken,
                         method: method,
                         params: params
                     };
@@ -141,6 +166,7 @@ public partial class BridgeWebView : WebView
                 };
             })();
             (function () {
+                if (window.top !== window) return;
                 if (window.__OneGateScreenOrientationInjected) return;
                 window.__OneGateScreenOrientationInjected = true;
                 if (!window.screen) return;
@@ -191,6 +217,7 @@ public partial class BridgeWebView : WebView
                 install(orientationPrototype);
             })();
             (function () {
+                if (window.top !== window) return;
                 if (window.__OneGateFullscreenInjected) return;
                 window.__OneGateFullscreenInjected = true;
 
@@ -443,10 +470,18 @@ public partial class BridgeWebView : WebView
             """.ReplaceLineEndings("");
     }
 
-    public Task SendRpcRepsonseAsync(JsonObject response)
+    public bool IsCurrentRequest(BridgeInvocation invocation) => requestPolicy.IsCurrent(invocation.Context);
+
+    internal bool IsAuthorizedSyncSource(string? token, string expectedToken, string? sourceUrl, string? pageUrl)
+        => requestPolicy.TryAuthorizeSync(token, expectedToken, sourceUrl, pageUrl, out _);
+
+    public Task SendRpcRepsonseAsync(JsonObject response, BridgeRequestContext context)
     {
         ArgumentNullException.ThrowIfNull(response);
-        return EvaluateJavaScriptAsync($"window.{BridgeCallbackName}({response.ToJsonString()})");
+        if (!requestPolicy.IsCurrent(context)) return Task.CompletedTask;
+        // The native generation check precedes queued JS evaluation. Check again
+        // inside the document so navigation in between cannot receive an old reply.
+        return EvaluateJavaScriptAsync($"if (window.__OneGateDocumentToken === {JsonSerializer.Serialize(context.DocumentToken)}) window.{BridgeCallbackName}({response.ToJsonString()})");
     }
 
     protected void RegisterSystemCallHandler(string method, Func<JsonArray?, JsonNode?> handler)
@@ -516,8 +551,9 @@ public partial class BridgeWebView : WebView
         }
     }
 
-    internal void OnMessage(string payload)
+    internal void OnMessage(string payload, string? sourceUrl, string? pageUrl, bool isMainFrame)
     {
+        if (!requestPolicy.TryAuthorize(sourceUrl, pageUrl, isMainFrame, out var context)) return;
         JsonObject? request;
         try
         {
@@ -527,36 +563,47 @@ public partial class BridgeWebView : WebView
         {
             return;
         }
+        string? documentToken = request["onegateDocument"] is JsonValue token && token.TryGetValue<string>(out var value) ? value : null;
+        if (!requestPolicy.TryBindDocument(context, documentToken, out context)) return;
         string method = request["method"]!.GetValue<string>();
         if (TryGetSystemCallMethod(method, out string? systemMethod))
-            DispatchSystemCall(request, systemMethod);
+            DispatchSystemCall(request, systemMethod, context);
         else
-            DispatchJavaScriptInvocation(request);
+            DispatchJavaScriptInvocation(new(request, context));
     }
 
-    void DispatchJavaScriptInvocation(JsonObject request)
+    void DispatchJavaScriptInvocation(BridgeInvocation invocation)
     {
         if (MainThread.IsMainThread)
-            InvokedFromJavaScript?.Invoke(this, request);
+        {
+            if (IsCurrentRequest(invocation)) InvokedFromJavaScript?.Invoke(this, invocation);
+        }
         else
-            MainThread.BeginInvokeOnMainThread(() => InvokedFromJavaScript?.Invoke(this, request));
+            MainThread.BeginInvokeOnMainThread(() => { if (IsCurrentRequest(invocation)) InvokedFromJavaScript?.Invoke(this, invocation); });
     }
 
-    internal string OnSyncMessage(string payload)
+    internal string OnSyncMessage(string payload, string? sourceUrl, string? pageUrl, bool isMainFrame)
     {
+        if (!requestPolicy.TryAuthorize(sourceUrl, pageUrl, isMainFrame, out var context))
+            return CreateRpcErrorResponse(null, 10001, "Bridge source is not authorized").ToJsonString();
         if (MainThread.IsMainThread)
-            return HandleSyncMessage(payload);
+            return HandleSyncMessage(payload, context);
 
-        return MainThread.InvokeOnMainThreadAsync(() => HandleSyncMessage(payload)).GetAwaiter().GetResult();
+        return MainThread.InvokeOnMainThreadAsync(() => HandleSyncMessage(payload, context)).GetAwaiter().GetResult();
     }
 
-    string HandleSyncMessage(string payload)
+    string HandleSyncMessage(string payload, BridgeRequestContext context)
     {
         JsonObject? request = null;
         try
         {
             request = ParseRpcRequest(payload);
             string method = request["method"]!.GetValue<string>();
+            if (method == InitializeDocumentMethod)
+                return new JsonObject { ["jsonrpc"] = "2.0", ["id"] = request["id"]!.DeepClone(), ["result"] = requestPolicy.BeginDocument() }.ToJsonString();
+            string? documentToken = request["onegateDocument"] is JsonValue token && token.TryGetValue<string>(out var value) ? value : null;
+            if (!requestPolicy.TryBindDocument(context, documentToken, out _))
+                return CreateRpcErrorResponse(request, 10001, "Bridge document is no longer active").ToJsonString();
             if (TryGetSystemCallMethod(method, out string? systemMethod))
                 return HandleSyncSystemCall(request, systemMethod).ToJsonString();
             return InvokeSynchronouslyFromJavaScript(request).ToJsonString();
@@ -661,16 +708,17 @@ public partial class BridgeWebView : WebView
         };
     }
 
-    void DispatchSystemCall(JsonObject request, string method)
+    void DispatchSystemCall(JsonObject request, string method, BridgeRequestContext context)
     {
         if (MainThread.IsMainThread)
-            _ = HandleSystemCallAsync(request, method);
+            _ = HandleSystemCallAsync(request, method, context);
         else
-            MainThread.BeginInvokeOnMainThread(() => _ = HandleSystemCallAsync(request, method));
+            MainThread.BeginInvokeOnMainThread(() => _ = HandleSystemCallAsync(request, method, context));
     }
 
-    async Task HandleSystemCallAsync(JsonObject request, string method)
+    async Task HandleSystemCallAsync(JsonObject request, string method, BridgeRequestContext context)
     {
+        if (!requestPolicy.IsCurrent(context)) return;
         JsonObject response = CreateRpcResponse(request);
         try
         {
@@ -694,7 +742,7 @@ public partial class BridgeWebView : WebView
             response["error"] = CreateSystemCallError(10000, ex.Message);
         }
 
-        await SendRpcRepsonseAsync(response);
+        await SendRpcRepsonseAsync(response, context);
     }
 
     static JsonObject CreateSystemCallError(int code, string message)

--- a/OneGateApp/Pages/LaunchDAppPage.xaml.cs
+++ b/OneGateApp/Pages/LaunchDAppPage.xaml.cs
@@ -30,6 +30,7 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable, IRemoteDe
     readonly RpcClient rpcClient;
     RemoteDebugService? remoteDebugService;
     string? remoteDebugSessionId;
+    readonly AsyncLocal<BridgeInvocation?> currentBridgeInvocation = new();
 
     public required DApp DApp { get; set { field = value; OnPropertyChanged(); } }
     public required string Url { get; set { field = value; OnPropertyChanged(); } }
@@ -281,6 +282,7 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable, IRemoteDe
     {
         return $$"""
             (function () {
+                if (window.top !== window) return;
                 if (window.__OneGateDapiInjected) return;
                 window.__OneGateDapiInjected = true;
 
@@ -935,8 +937,11 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable, IRemoteDe
             ToolbarItems.Remove(reportButton);
     }
 
-    async void OnInvokedFromJavaScript(BridgeWebView webView, JsonObject request)
+    async void OnInvokedFromJavaScript(BridgeWebView webView, BridgeInvocation invocation)
     {
+        if (!webView.IsCurrentRequest(invocation)) return;
+        currentBridgeInvocation.Value = invocation;
+        JsonObject request = invocation.Request;
         string method = request["method"] is JsonValue methodValue && methodValue.TryGetValue(out string? methodName)
             ? methodName
             : "unknown";
@@ -945,8 +950,16 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable, IRemoteDe
         JsonObject response = await rpcServer.HandleRequestAsync(request);
         if (remoteDebugSessionId is not null && remoteDebugService is not null)
             remoteDebugService.RecordDapiResponse(remoteDebugSessionId, method, response);
-        await webView.SendRpcRepsonseAsync(response);
+        await webView.SendRpcRepsonseAsync(response, invocation.Context);
     }
+
+    void EnsureCurrentBridgeRequest()
+    {
+        if (currentBridgeInvocation.Value is { } invocation && !webView.IsCurrentRequest(invocation))
+            throw new OperationCanceledException("The requesting document is no longer active.");
+    }
+
+    string RequestOrigin => currentBridgeInvocation.Value?.Context.Origin ?? new Uri(DApp.Url).GetLeftPart(UriPartial.Authority);
 
     async Task EmitEventAsync(string eventName, JsonObject? detial)
     {

--- a/OneGateApp/Pages/LaunchDAppPage.xaml.dAPI.cs
+++ b/OneGateApp/Pages/LaunchDAppPage.xaml.dAPI.cs
@@ -41,11 +41,14 @@ partial class LaunchDAppPage
         }
         if (!payload.Domain.Equals(new Uri(DApp.Url).Host, StringComparison.OrdinalIgnoreCase))
             throw new DapiException(10002, "Domain mismatch");
+        EnsureCurrentBridgeRequest();
         if (IsRemoteDebugSession)
             await RequestRemoteApprovalAsync("authenticate", payload);
-        else if (!await walletAuthorizationService.RequestAuthorizationAsync(this, Strings.LoginRequest, Strings.LoginRequestText))
+        else if (!await walletAuthorizationService.RequestAuthorizationAsync(this, Strings.LoginRequest, $"{Strings.LoginRequestText}\n{RequestOrigin}"))
             throw new DapiException(10006, "Operation cancelled");
+        EnsureCurrentBridgeRequest();
         await activityLogService.RecordWalletAuthorizationAsync(DApp);
+        EnsureCurrentBridgeRequest();
         WalletAccount account = walletProvider.GetWallet()!.GetDefaultAccount()!;
         return payload.CreateResponse(account, protocolSettings);
     }
@@ -59,6 +62,7 @@ partial class LaunchDAppPage
     [RpcMethod]
     async Task<string> PickAddress(string? prompt)
     {
+        EnsureCurrentBridgeRequest();
         if (IsRemoteDebugSession)
         {
             RemoteDebugApprovalResult approval = await RequestRemoteApprovalAsync("pickAddress", prompt);
@@ -182,6 +186,7 @@ partial class LaunchDAppPage
             if (specific is not null) intent = specific;
             intents.Add(intent);
         }
+        EnsureCurrentBridgeRequest();
         if (IsRemoteDebugSession)
         {
             await RequestRemoteApprovalAsync("sign", context);
@@ -190,6 +195,7 @@ partial class LaunchDAppPage
         {
             var popup = serviceProvider.GetServiceOrCreateInstance<SendTransactionPopup>();
             popup.Title = Strings.SignTransaction;
+            popup.RequestOrigin = RequestOrigin;
             popup.Message = Strings.SignTransactionText;
             popup.Transaction = tx;
             popup.Intents = intents.ToArray();
@@ -197,6 +203,7 @@ partial class LaunchDAppPage
             var popup_result = await this.ShowPopupAsync<bool>(popup);
             if (!popup_result.Result) throw new OperationCanceledException();
         }
+        EnsureCurrentBridgeRequest();
         if (!walletProvider.GetWallet()!.Sign(context))
             throw new DapiException(10000, "Failed to sign transaction");
         await activityLogService.RecordSignatureAsync(DApp);
@@ -206,6 +213,7 @@ partial class LaunchDAppPage
     [RpcMethod]
     async Task<SignedMessage> SignMessage(string message, UInt160? account, SignOptions? options)
     {
+        EnsureCurrentBridgeRequest();
         if (options?.IsTypedData == true)
             throw new DapiException(10001, "Typed data signing is not supported");
         if (options?.IsLedgerCompatible == true)
@@ -218,6 +226,7 @@ partial class LaunchDAppPage
         else
         {
             var popup = serviceProvider.GetServiceOrCreateInstance<SignMessagePopup>();
+            popup.RequestOrigin = RequestOrigin;
             popup.Account = account?.ToAddress(protocolSettings.AddressVersion);
             popup.IsBase64Encoded = options?.IsBase64Encoded == true;
             popup.Message = message;
@@ -225,6 +234,7 @@ partial class LaunchDAppPage
             if (result.Result is null) throw new OperationCanceledException();
             account ??= result.Result.ToScriptHash(protocolSettings.AddressVersion);
         }
+        EnsureCurrentBridgeRequest();
         byte[] payload = options?.IsBase64Encoded == true
             ? Convert.FromBase64String(message)
             : Utility.StrictUTF8.GetBytes(message);
@@ -249,6 +259,7 @@ partial class LaunchDAppPage
             throw new DapiException(10001, "Only transaction relaying is supported");
         if (IsRemoteDebugSession)
             await RequestRemoteApprovalAsync("relay", context);
+        EnsureCurrentBridgeRequest();
         tx.Witnesses = context.GetWitnesses();
         UInt256 transactionHash = await rpcClient.SendRawTransaction(tx);
         await activityLogService.RecordTransactionAsync(DApp, transactionHash);
@@ -293,6 +304,7 @@ partial class LaunchDAppPage
 
     async Task<RemoteDebugApprovalResult> RequestRemoteApprovalAsync(string method, params object?[] parameters)
     {
+        EnsureCurrentBridgeRequest();
         if (remoteDebugSessionId is null || remoteDebugService is null)
             throw new InvalidOperationException("A remote debug session is required for remote approval.");
         JsonArray serializedParameters = new(parameters.Select(parameter => parameter is null
@@ -308,6 +320,7 @@ partial class LaunchDAppPage
             throw new OperationCanceledException();
         }
         if (!approval.Approved) throw new OperationCanceledException();
+        EnsureCurrentBridgeRequest();
         return approval;
     }
 
@@ -321,14 +334,17 @@ partial class LaunchDAppPage
                 if (specific != null) intents[i] = specific;
             }
         }
+        EnsureCurrentBridgeRequest();
         if (!IsRemoteDebugSession)
         {
             var popup = serviceProvider.GetServiceOrCreateInstance<SendTransactionPopup>();
+            popup.RequestOrigin = RequestOrigin;
             popup.Transaction = tx;
             popup.Intents = intents;
             var result = await this.ShowPopupAsync<bool>(popup);
             if (!result.Result) throw new OperationCanceledException();
         }
+        EnsureCurrentBridgeRequest();
         var context = new ContractParametersContext(null!, tx, protocolSettings.Network);
         if (!walletProvider.GetWallet()!.Sign(context))
             throw new DapiException(10000, "Failed to sign transaction");

--- a/tests/p1-03/P1-03.Tests.csproj
+++ b/tests/p1-03/P1-03.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="../../OneGateApp/Controls/Views/BridgeRequestPolicy.cs" Link="BridgeRequestPolicy.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../OneGateApp/OneGateApp.csproj"
+                      ReferenceOutputAssembly="false" BuildReference="false"
+                      SkipGetTargetFrameworkProperties="true" />
+  </ItemGroup>
+</Project>

--- a/tests/p1-03/Program.cs
+++ b/tests/p1-03/Program.cs
@@ -1,0 +1,41 @@
+using NeoOrder.OneGate.Controls.Views;
+
+int failures = 0;
+void Check(bool condition, string name)
+{
+    Console.WriteLine($"{(condition ? "PASS" : "FAIL")} {name}");
+    if (!condition) failures++;
+}
+
+var policy = new BridgeRequestPolicy();
+string firstToken = policy.BeginDocument();
+Check(policy.TryAuthorize("https://game.example", "https://game.example/play", true, out var request), "current main frame accepted");
+Check(!policy.TryAuthorize("https://game.example", "https://game.example/play", false, out _), "same-origin iframe rejected");
+Check(!policy.TryAuthorize("https://ads.example", "https://game.example/play", false, out _), "cross-origin iframe rejected");
+Check(!policy.TryAuthorize("https://ads.example", "https://game.example/play", true, out _), "forged source origin rejected");
+Check(!policy.TryAuthorize("http://game.example", "https://game.example/play", true, out _), "scheme mismatch rejected");
+Check(!policy.TryAuthorize("https://game.example:8443", "https://game.example/play", true, out _), "port mismatch rejected");
+Check(!policy.TryAuthorize("file:///tmp/a.html", "file:///tmp/a.html", true, out _), "opaque and file origins rejected");
+Check(!policy.TryAuthorize("null", "https://game.example", true, out _), "null origin rejected");
+Check(policy.TryAuthorize("https://GAME.EXAMPLE:443", "https://game.example/play", true, out _), "canonical origin accepted");
+Check(policy.TryAuthorize("http://localhost:8080", "http://localhost:8080/demo", true, out _), "local developer web origin preserved");
+Check(policy.IsCurrent(request), "current request can reply");
+string secondToken = policy.BeginDocument();
+Check(firstToken != secondToken, "native issues a fresh token for each actual document");
+Check(!policy.IsCurrent(request), "new document invalidates old response and signing permission");
+Check(policy.TryAuthorize("https://game.example", "https://game.example/next", true, out var next) && policy.IsCurrent(next), "new document request accepted");
+Check(!policy.TryAuthorizeSync("wrong", "expected", "https://game.example", "https://game.example", out _), "sync prompt without main-frame token rejected");
+Check(policy.TryAuthorizeSync("expected", "expected", "https://game.example", "https://game.example/play", out _), "sync main-frame capability preserved");
+Check(!policy.TryAuthorizeSync("expected", "expected", "https://ads.example", "https://game.example", out _), "sync token alone cannot bypass origin");
+Check(policy.TryBindDocument(next, secondToken, out var bound) && bound.DocumentToken == secondToken, "native context binds to its issued document token");
+Check(!policy.TryBindDocument(next, "attacker-selected", out _), "ordinary payload cannot replace native-issued document identity");
+Check(!policy.TryBindDocument(request, firstToken, out _), "old document request cannot bind a new response");
+Check(!policy.TryBindDocument(next, firstToken, out _), "late old-document message cannot acquire a new navigation generation");
+Check(!policy.IsCurrent(next with { DocumentToken = firstToken }), "current generation with stale token cannot authorize signing or reply");
+Check(!policy.TryBindDocument(next, null, out _), "missing document token rejected");
+Check(!policy.TryBindDocument(next, new string('x', 129), out _), "oversized document token rejected");
+policy.Invalidate();
+Check(!policy.IsCurrent(next), "handler disconnect and unload revoke the active document");
+Check(policy.TryAuthorize("https://game.example", "https://game.example/next", true, out var unloaded)
+    && !policy.TryBindDocument(unloaded, secondToken, out _), "an unloaded document cannot revive itself with its previous token");
+Environment.ExitCode = failures == 0 ? 0 : 1;

--- a/tests/p1-03/README.md
+++ b/tests/p1-03/README.md
@@ -1,0 +1,74 @@
+# P1-03: native DApp bridge provenance
+
+Run the linked production policy tests:
+
+```sh
+dotnet run --project tests/p1-03/P1-03.Tests.csproj
+node tests/p1-03/dapi-script.test.mjs
+```
+
+The tests were added first (RED: policy source missing); lifecycle regressions
+were added before the native bootstrap implementation (RED), then pass 26/26. They
+exercise main-frame/origin checks, scheme/port/file-origin rejection, navigation
+expiration, and the Android main-frame private capability used for synchronous
+system calls. Native-issued document tokens reject old same-origin messages even
+when delivered after a new document becomes active. Ordinary payloads cannot
+replace the native identity. The Node test executes the actual injected RPC script and native
+callback template, checking old replies are rejected after a new document loads.
+Source-bound assertions also check authentication after its activity-log await,
+post-await remote approval guards, no asynchronous signing-to-broadcast gap, and
+reserved iOS child-frame sync prompt rejection. These assertions inspect guard
+placement; they do not execute wallet signing or platform prompt delegates.
+Native integration still requires the checks below; these tests are not simulator
+validation. The test project is registered in the solution and declares a
+non-building, non-output reference to the app; its build compiles only linked
+production policy source, not mobile target frameworks.
+
+## Native QA before committing
+
+Run on both real Android and iOS simulators. Serve `fixtures/` on two local HTTP
+ports, e.g. 8765 and 8766. Open `index.html?iframePort=8766` in OneGate's DApp
+debug launcher, using a hostname reachable from the simulator (typically
+`10.0.2.2` on Android or `127.0.0.1` on iOS). The page embeds one same-origin
+iframe and one different-port iframe. All probes use read-only RPC or cancelable
+address selection; do not authorize transactions or publish wallet data.
+
+1. Main-frame `getBlockCount` succeeds. Main-frame address picker opens and can
+   be canceled normally; normal error/cancel callbacks still resolve.
+2. In **both** iframe probes, raw native `pickAddress` messages do not open any
+   wallet popup or appear as accepted dAPI requests. No provider or orientation
+   shims are installed in iframe globals.
+3. Raw Android sync prompt without the private main-frame token is rejected;
+   normal main-frame `screen.orientation.lock('landscape')` followed by the
+   synchronous `screen.orientation.unlock()` continues to work. On iOS test
+   orientation and fullscreen enter/exit as well.
+4. Begin a slow read-only main-frame request, navigate/reload before it resolves,
+   and verify its callback does not reach the new document. A transaction/message
+   confirmation left pending while its document navigates must not sign after
+   approval; use an instrumented local authorization fixture, not a real transfer.
+   Also keep a main-frame request pending during iframe navigation and a canceled
+   cross-origin top navigation; both must survive because the top document stays.
+   Hold a same-origin navigation response, send a late request from the still-live
+   old document, finish navigation, then verify that request and old-token replay
+   are rejected. Do not substitute navigation-start generation checks for this.
+5. Main-frame signing confirmations show the native-verified requesting origin.
+   Open, cancel, close, and reopen the DApp; verify the bridge remains usable.
+
+Android's prompt callback does not expose a frame flag, so synchronous calls use
+a random capability held only in the top-frame injection's closure, together
+with the native prompt source URL. Same-origin JavaScript can intentionally call
+the parent page's public methods under normal browser same-origin permissions;
+this change prevents direct untrusted frame-to-native calls, not cooperation by
+the trusted parent page. Windows uses the same protected prompt capability since
+its dialog callback also lacks a main-frame flag. A private synchronous native
+bootstrap runs only at top-document start and establishes the active identity;
+generic MAUI `Navigating` events include iframe/canceled navigations and do not
+replace that identity. Handler removal and unload revoke it. No insecure
+`AddJavascriptInterface` fallback remains.
+
+## Integration
+
+This branch requires both Android `DOCUMENT_START_SCRIPT` and
+`WEB_MESSAGE_LISTENER`. Independent P2-16 adds the native missing-capability UX;
+when integrating both, its preflight must include the latter capability too.
+No simulator validation, app build, commit, or push was performed by the worker.

--- a/tests/p1-03/dapi-script.test.mjs
+++ b/tests/p1-03/dapi-script.test.mjs
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+
+const source = readFileSync(new URL('../../OneGateApp/Controls/Views/BridgeWebView.cs', import.meta.url), 'utf8');
+const constants = Object.fromEntries([...source.matchAll(/const string (\w+) = "([^"]+)";/g)].map(match => [match[1], match[2]]));
+const script = source.match(/return \$\$"""([\s\S]*?)"""\.ReplaceLineEndings/)[1]
+  .replace(/\{\{(\w+)\}\}/g, (_, name) => constants[name])
+  .replace(/\r\n|\r|\n/g, ''); // Match the real C# ReplaceLineEndings("") result.
+let nextNativeToken = 1;
+function document(isMainFrame = true) {
+  const messages = [];
+  const nativeToken = 'native-issued-' + nextNativeToken++;
+  const window = { __OneGateBridge: {
+    invoke: value => messages.push(JSON.parse(value)),
+    invokeSync: value => {
+      const request = JSON.parse(value);
+      assert.equal(request.method, '__onegate_document');
+      return JSON.stringify({ jsonrpc: '2.0', id: request.id, result: nativeToken });
+    }
+  } };
+  window.top = isMainFrame ? window : {};
+  const context = vm.createContext({ window, navigator: { platform: 'QA' } });
+  vm.runInContext(script, context);
+  return { window, context, messages, nativeToken };
+}
+const first = document();
+const pending = first.window.__OneGateInvoke('getBlockCount', []);
+const request = first.messages[0];
+assert.equal(request.onegateDocument, first.window.__OneGateDocumentToken);
+assert.ok(request.onegateDocument);
+assert.equal(request.onegateDocument, first.nativeToken, 'request identity must be issued by native bootstrap, not supplied by arbitrary JS');
+const response = { jsonrpc: '2.0', id: request.id, result: 123 };
+const callback = source.match(/return EvaluateJavaScriptAsync\(\$"(if \(window\.__OneGateDocumentToken.+)"\);/)[1]
+  .replace('{JsonSerializer.Serialize(context.DocumentToken)}', JSON.stringify(request.onegateDocument))
+  .replace('{BridgeCallbackName}', constants.BridgeCallbackName)
+  .replace('{response.ToJsonString()}', JSON.stringify(response));
+vm.runInContext(callback, first.context);
+assert.equal(await pending, 123);
+const next = document();
+let staleReplies = 0;
+next.window.__OneGateBridgeCallback = () => staleReplies++;
+vm.runInContext(callback, next.context);
+assert.equal(staleReplies, 0, 'queued response must not reach a new document');
+assert.equal(document(false).window.__OneGateInvoke, undefined, 'iframe has no RPC shim');
+assert.equal(Object.getOwnPropertyDescriptor(first.window, '__OneGateDocumentToken').writable, false);
+assert.doesNotMatch(source, /Navigating \+=/,
+  'generic navigation events include iframe and canceled navigations and must not replace top-document identity');
+console.log('PASS document-scoped payload and callback, navigation race, iframe shim and immutable token');
+
+// Source-bound guard placement checks complement the policy execution tests.
+// They do not claim to execute wallet authentication or platform delegates.
+const dapi = readFileSync(new URL('../../OneGateApp/Pages/LaunchDAppPage.xaml.dAPI.cs', import.meta.url), 'utf8');
+assert.match(dapi, /await activityLogService\.RecordWalletAuthorizationAsync\(DApp\);\s*EnsureCurrentBridgeRequest\(\);\s*WalletAccount/,
+  'navigation during the authorization activity-log await must be rejected before authentication signing');
+const remoteApproval = dapi.slice(dapi.indexOf('async Task<RemoteDebugApprovalResult> RequestRemoteApprovalAsync'), dapi.indexOf('async Task<UInt256> SignAndSendAsync'));
+assert.match(remoteApproval, /if \(!approval\.Approved\) throw new OperationCanceledException\(\);\s*EnsureCurrentBridgeRequest\(\);\s*return approval;/,
+  'remote approval results must be revalidated after their await');
+const send = dapi.slice(dapi.indexOf('async Task<UInt256> SignAndSendAsync'));
+assert.match(send, /EnsureCurrentBridgeRequest\(\);\s*var context/);
+assert.doesNotMatch(send.slice(send.indexOf('var context'), send.indexOf('await rpcClient.SendRawTransaction')), /\bawait\b/,
+  'no asynchronous gap is allowed between the final request guard and starting broadcast');
+const ios = readFileSync(new URL('../../OneGateApp/Controls/Handlers/BridgeWebViewHandler.iOS.cs', import.meta.url), 'utf8');
+assert.match(ios, /if \(prompt == SyncPrompt && handler.VirtualView is Views.BridgeWebView bridgeWebView\)/,
+  'reserved sync prompts from child frames must be rejected by bridge policy instead of falling back to a native dialog');
+console.log('PASS source-bound authentication, approval and broadcast guard placement, reserved iOS prompt routing');

--- a/tests/p1-03/fixtures/frame.html
+++ b/tests/p1-03/fixtures/frame.html
@@ -1,0 +1,13 @@
+<!doctype html><meta name="viewport" content="width=device-width,initial-scale=1">
+<p id="status"></p><button id="probe">Raw frame request (must not open picker)</button>
+<button id="sync">Raw sync prompt (must be rejected)</button>
+<script>
+document.querySelector('#status').textContent = 'Provider injected: ' + Boolean(window.OneGateDapiProvider) + '; origin: ' + location.origin;
+document.querySelector('#probe').onclick = () => {
+ const payload = JSON.stringify({jsonrpc:'2.0', id:'frame-qa-'+Date.now(), onegateDocument:new URL(location.href).searchParams.get('documentToken'), method:'pickAddress', params:['FAIL: iframe opened this picker']});
+ if (window.__OneGateNativeBridge) window.__OneGateNativeBridge.postMessage(payload);
+ else if (window.webkit?.messageHandlers?.__OneGateBridge) window.webkit.messageHandlers.__OneGateBridge.postMessage(payload);
+ else document.querySelector('#status').textContent += '; native interface absent';
+};
+document.querySelector('#sync').onclick = () => prompt('__OneGateBridgeSync', JSON.stringify({jsonrpc:'2.0',id:'sync-frame',method:'onegate.system.screen.orientation.unlock',params:[]}));
+</script>

--- a/tests/p1-03/fixtures/index.html
+++ b/tests/p1-03/fixtures/index.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>OneGate bridge provenance QA</title>
+<h1>Native bridge provenance</h1>
+<button id="read">Main: block count</button>
+<button id="pick">Main: pick address (cancel)</button>
+<button id="lock">Main: lock landscape</button>
+<button id="unlock">Main: synchronous unlock</button>
+<pre id="result"></pre>
+<h2>Same-origin iframe</h2><iframe id="same"></iframe>
+<h2>Cross-origin iframe</h2><iframe id="cross"></iframe>
+<script>
+const output = document.querySelector('#result');
+const show = value => output.textContent = JSON.stringify(value);
+document.querySelector('#read').onclick = () => OneGateDapiProvider.getBlockCount().then(show, show);
+document.querySelector('#pick').onclick = () => OneGateDapiProvider.pickAddress('Main-frame QA: cancel this picker').then(() => show('Picker completed'), show);
+document.querySelector('#lock').onclick = () => screen.orientation.lock('landscape').then(() => show('Locked'), show);
+document.querySelector('#unlock').onclick = () => { try { screen.orientation.unlock(); show('Unlocked'); } catch (e) { show(e.message); } };
+const cross = new URL('frame.html', location.href);
+// Give both fixtures the active identity so native frame checks, not token
+// mismatch, are the only reason their direct asynchronous calls are rejected.
+cross.searchParams.set('documentToken', window.__OneGateDocumentToken);
+document.querySelector('#same').src = cross.href;
+cross.port = new URL(location.href).searchParams.get('iframePort') || '8766';
+document.querySelector('#cross').src = cross.href;
+</script>


### PR DESCRIPTION
## Summary

Fix audit P1-03: bind DApp bridge requests to native frame/origin provenance and the active document before dispatch, wallet authorization, and response delivery.

- Replace Android's all-frame JavaScript interface with a source-aware WebMessageListener; reject child-frame/raw untrusted messages. Preserve synchronous system calls through a private top-frame capability.
- Establish a native-issued document token at document start. Reject stale same-origin requests and responses after a new document commits, without invalidating the top page for iframe or cancelled navigation.
- Carry the verified origin into authorization/signing prompts and recheck document validity after approval awaits. Revoke context on unload/handler removal.

## Validation performed before commit

- Linked production-policy regression tests: 26/26; Node tests execute the actual transformed, single-line injected script and delayed native callback template.
- iOS 26.5 simulator and Android API 36 ARM64 emulator: **30/30 native assertions on each platform**, using production BridgeWebView/handlers and two controlled loopback HTTP origins. Tested normal main-frame sync/async calls, same/cross-origin raw iframe rejection, cancelled/iframe navigation preserving pending calls, slow same-origin navigation, old-token replay, and stale callbacks.
- After fixture removal, full product Rebuild, isolated-app installation, and native startup smoke passed on both platforms. Source patch SHA-256: `8da3555c2c1f502510ba032c345b188f292dbdf00aacd69798c874be312a053d`.
- No real signing, wallet approval, funds, or chain broadcast. Approval guard placement has source-bound regression checks; the native navigation fixture uses safe counters, not wallet signing. The delayed callback test deliberately holds the real MAUI evaluation delegate, rather than claiming a naturally occurring scheduler race.
- Windows adapter updated consistently but not built or runtime-tested on this macOS host. Same-origin script deliberately calling its trusted parent's public API is outside the direct frame-to-native boundary.
- Simulator screenshots/logs are retained outside the repository; no screenshot files or QA app fixture are committed. No GitHub screenshot upload is claimed.

## Integration notes

Independent fix based on master `623603d634f07eaead14745da87920a356159be0`, not a stacked or combined validation of all audit fixes. Preserve the solution test-project union and rerun tests/native validation after resolving overlaps.

Android now requires both `DOCUMENT_START_SCRIPT` and `WEB_MESSAGE_LISTENER`. When integrating P2-16's separate missing-capability UI, its preflight must require both; never restore an insecure bridge fallback. Preserve the context checks when integrating P2-13 response mapping, P2-15 error classification, and P2-18 page lifecycle changes.
