### PR TITLE
Update cached entities by stable ID

### DIFF
--- a/OneGateApp.slnx
+++ b/OneGateApp.slnx
@@ -6,4 +6,5 @@
   <Project Path="OneGate.DebugProtocol/OneGate.DebugProtocol.csproj" />
   <Project Path="OneGate.DebugProtocol.Tests/OneGate.DebugProtocol.Tests.csproj" />
   <Project Path="OneGate.Tools/OneGate.Tools.csproj" />
+  <Project Path="tests/p2-09/CacheIdentity.Tests.csproj" />
 </Solution>

--- a/OneGateApp/Data/Banner.cs
+++ b/OneGateApp/Data/Banner.cs
@@ -1,9 +1,10 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using NeoOrder.OneGate.Models;
+using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
 namespace NeoOrder.OneGate.Data;
 
-public class Banner : IComparable<Banner>
+public class Banner : IComparable<Banner>, ICachedEntity
 {
     [DatabaseGenerated(DatabaseGeneratedOption.None)]
     public int Id { get; set; }

--- a/OneGateApp/Data/DApp.cs
+++ b/OneGateApp/Data/DApp.cs
@@ -7,7 +7,7 @@ using System.Text.Json;
 
 namespace NeoOrder.OneGate.Data;
 
-public class DApp : IComparable<DApp>, IShareable, IVersioned
+public class DApp : IComparable<DApp>, IShareable, IVersioned, ICachedEntity
 {
     [DatabaseGenerated(DatabaseGeneratedOption.None)]
     public int Id { get; set; }

--- a/OneGateApp/Data/News.cs
+++ b/OneGateApp/Data/News.cs
@@ -6,7 +6,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace NeoOrder.OneGate.Data;
 
-public class News : IComparable<News>, IShareable
+public class News : IComparable<News>, IShareable, ICachedEntity
 {
     [DatabaseGenerated(DatabaseGeneratedOption.None)]
     public int Id { get; set; }
@@ -51,6 +51,7 @@ public class News : IComparable<News>, IShareable
     int IComparable<News>.CompareTo(News? other)
     {
         if (other is null) return 1;
-        return -PublishDate.CompareTo(other.PublishDate);
+        int comparison = -PublishDate.CompareTo(other.PublishDate);
+        return comparison != 0 ? comparison : Id.CompareTo(other.Id);
     }
 }

--- a/OneGateApp/Models/CachedCollection.cs
+++ b/OneGateApp/Models/CachedCollection.cs
@@ -5,7 +5,7 @@ using System.Net.Http.Json;
 
 namespace NeoOrder.OneGate.Models;
 
-public class CachedCollection<T>(IDbContextFactory<CacheDbContext> dbContextFactory, HttpClient httpClient) : ObservableCollection<T> where T : class, IComparable<T>
+public class CachedCollection<T>(IDbContextFactory<CacheDbContext> dbContextFactory, HttpClient httpClient) : ObservableCollection<T> where T : class, IComparable<T>, ICachedEntity
 {
     public event EventHandler? CollectionLoaded;
 
@@ -15,11 +15,19 @@ public class CachedCollection<T>(IDbContextFactory<CacheDbContext> dbContextFact
 
     public new void Add(T item)
     {
+        for (int i = 0; i < Count; i++)
+        {
+            if (base[i].Id != item.Id) continue;
+            if (base[i].CompareTo(item) == 0)
+            {
+                base.SetItem(i, item);
+                return;
+            }
+            base.RemoveItem(i);
+            break;
+        }
         int index = BinarySearch(item);
-        if (index < 0)
-            base.InsertItem(~index, item);
-        else
-            base.SetItem(index, item);
+        base.InsertItem(index < 0 ? ~index : index, item);
     }
 
     public void AddRange(IEnumerable<T> items)
@@ -67,28 +75,29 @@ public class CachedCollection<T>(IDbContextFactory<CacheDbContext> dbContextFact
                 var last_update = await dbContext.Settings.GetAsync<DateTimeOffset>(settings_key);
                 if (last_update > DateTimeOffset.UtcNow - duration) return;
                 var items_new = (await httpClient.GetFromJsonAsync<T[]>(url))!;
+                var incomingById = items_new.ToDictionary(p => p.Id);
+                var currentById = this.ToDictionary(p => p.Id);
                 for (int i = Count - 1; i >= 0; i--)
                 {
                     T item = base[i];
-                    if (items_new.Any(p => p.CompareTo(item) == 0)) continue;
+                    if (incomingById.ContainsKey(item.Id)) continue;
                     base.RemoveItem(i);
                     if (!cacheNeedsSeeding)
                         dbContext.Entry(item).State = EntityState.Deleted;
                 }
                 foreach (T item in items_new)
                 {
-                    int index = BinarySearch(item);
-                    if (index >= 0)
+                    if (currentById.TryGetValue(item.Id, out T? current))
                     {
-                        if (cacheNeedsSeeding || ShouldReplace(base[index], item))
+                        if (cacheNeedsSeeding || ShouldReplace(current, item))
                         {
-                            base.SetItem(index, item);
+                            Add(item);
                             dbContext.Entry(item).State = cacheNeedsSeeding ? EntityState.Added : EntityState.Modified;
                         }
                     }
                     else
                     {
-                        base.InsertItem(~index, item);
+                        Add(item);
                         dbContext.Entry(item).State = EntityState.Added;
                     }
                 }
@@ -106,8 +115,8 @@ public class CachedCollection<T>(IDbContextFactory<CacheDbContext> dbContextFact
 
     static bool ShouldReplace(T current, T incoming)
     {
-        return current is IVersioned currentVersioned
-            && incoming is IVersioned incomingVersioned
-            && currentVersioned.Version != incomingVersioned.Version;
+        return current is not IVersioned currentVersioned
+            || incoming is not IVersioned incomingVersioned
+            || currentVersioned.Version != incomingVersioned.Version;
     }
 }

--- a/OneGateApp/Models/ICachedEntity.cs
+++ b/OneGateApp/Models/ICachedEntity.cs
@@ -1,0 +1,6 @@
+namespace NeoOrder.OneGate.Models;
+
+public interface ICachedEntity
+{
+    int Id { get; }
+}

--- a/tests/p2-09/CacheBoundary.cs
+++ b/tests/p2-09/CacheBoundary.cs
@@ -1,0 +1,67 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using NeoOrder.OneGate.Data;
+using System.Net;
+using System.Text.Json;
+
+// Actual cache, entities, SQL settings helpers and SQLite are used. Only the
+// production on-disk database location and remote HTTP responses are replaced.
+public sealed class CacheFixture : IDbContextFactory<CacheDbContext>, IDisposable
+{
+    readonly SqliteConnection connection = new("Data Source=:memory:");
+    public ResponseHandler Handler { get; } = new();
+    public HttpClient Client { get; }
+    public CacheFixture()
+    {
+        connection.Open();
+        using var db = CreateDbContext();
+        db.Database.EnsureCreated();
+        Client = new(Handler) { BaseAddress = new("https://example.com") };
+    }
+    public CacheDbContext CreateDbContext() => new(new DbContextOptionsBuilder<CacheDbContext>()
+        .UseSqlite(connection).UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking).Options);
+    public Task<CacheDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) => Task.FromResult(CreateDbContext());
+    public void Respond<T>(params T[] values) => Handler.Json = JsonSerializer.Serialize(values, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+    public void Dispose() { Client.Dispose(); connection.Dispose(); }
+}
+public sealed class ResponseHandler : HttpMessageHandler
+{
+    public string Json { get; set; } = "[]";
+    public int Requests { get; private set; }
+    public Exception? Error { get; set; }
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        Requests++;
+        if (Error is not null) throw Error;
+        return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(Json) });
+    }
+}
+namespace NeoOrder.OneGate.Data
+{
+    public class CacheDbContext(DbContextOptions<CacheDbContext> options) : DbContext(options)
+    {
+        public DbSet<Setting> Settings => Set<Setting>();
+        public DbSet<Banner> Banners => Set<Banner>();
+        public DbSet<News> News => Set<News>();
+        public DbSet<VersionedItem> VersionedItems => Set<VersionedItem>();
+    }
+    public static class CacheDbContextFactoryExtensions
+    {
+        public static Task<CacheDbContext> CreateInitializedDbContextAsync(this IDbContextFactory<CacheDbContext> factory) => factory.CreateDbContextAsync();
+    }
+}
+public class VersionedItem : NeoOrder.OneGate.Models.ICachedEntity, NeoOrder.OneGate.Models.IVersioned, IComparable<VersionedItem>
+{
+    public int Id { get; set; }
+    public int Version { get; set; }
+    public string Name { get; set; } = "";
+    public int CompareTo(VersionedItem? other) => other is null ? 1 : Id.CompareTo(other.Id);
+}
+namespace NeoOrder.OneGate.Services
+{
+    public static class SharedOptions
+    {
+        public const string OneGateDomain = "example.com";
+        public static JsonSerializerOptions JsonSerializerOptions { get; } = new(JsonSerializerDefaults.Web);
+    }
+}

--- a/tests/p2-09/CacheIdentity.Tests.csproj
+++ b/tests/p2-09/CacheIdentity.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework><ImplicitUsings>enable</ImplicitUsings><Nullable>enable</Nullable>
+    <IsTestProject>true</IsTestProject><IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
+    <Compile Include="../../OneGateApp/Models/CachedCollection.cs" Link="CachedCollection.cs" />
+    <Compile Include="../../OneGateApp/Models/ICachedEntity.cs" Link="ICachedEntity.cs" />
+    <Compile Include="../../OneGateApp/Models/IVersioned.cs" Link="IVersioned.cs" />
+    <Compile Include="../../OneGateApp/Models/IShareable.cs" Link="IShareable.cs" />
+    <Compile Include="../../OneGateApp/Data/News.cs" Link="News.cs" />
+    <Compile Include="../../OneGateApp/Data/Banner.cs" Link="Banner.cs" />
+    <Compile Include="../../OneGateApp/Data/Setting.cs" Link="Setting.cs" />
+    <Compile Include="../../OneGateApp/Data/SettingsExtensions.cs" Link="SettingsExtensions.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- App relationship only; linked-source tests run without MAUI workloads. -->
+    <ProjectReference Include="../../OneGateApp/OneGateApp.csproj"
+                      ReferenceOutputAssembly="false" BuildReference="false"
+                      SkipGetTargetFrameworkProperties="true" />
+  </ItemGroup>
+</Project>

--- a/tests/p2-09/CacheIdentityTests.cs
+++ b/tests/p2-09/CacheIdentityTests.cs
@@ -1,0 +1,148 @@
+using Microsoft.EntityFrameworkCore;
+using NeoOrder.OneGate.Data;
+using NeoOrder.OneGate.Models;
+using Xunit;
+
+public class CacheIdentityTests
+{
+    static News Article(int id, DateTimeOffset published, string title) => new()
+    {
+        Id = id, PublishDate = published, Title = title, Category = "Test", Language = "en",
+        Guid = id.ToString(), Url = "https://example.com/" + id, Authors = "Author", Keywords = [], Summary = title, Content = title
+    };
+
+    [Fact]
+    public async Task DifferentNewsIdsWithIdenticalPublicationTimeSurviveRefreshAndRestart()
+    {
+        using var fixture = new CacheFixture();
+        var published = DateTimeOffset.UtcNow;
+        fixture.Respond(Article(1, published, "First"), Article(2, published, "Second"));
+        var news = new CachedCollection<News>(fixture, fixture.Client);
+
+        await news.LoadAsync("/news", TimeSpan.Zero);
+
+        Assert.Equal(2, news.Count);
+        using (var db = fixture.CreateDbContext()) Assert.Equal(2, await db.News.CountAsync());
+        var restarted = new CachedCollection<News>(fixture, fixture.Client);
+        await restarted.LoadAsync("/news", TimeSpan.FromDays(1));
+        Assert.Equal([1, 2], restarted.Select(item => item.Id).Order().ToArray());
+    }
+
+    [Fact]
+    public async Task SameIdNewsEditsReplaceContentAndRepositionWhenPublicationTimeChanges()
+    {
+        using var fixture = new CacheFixture();
+        var earlier = DateTimeOffset.UtcNow.AddHours(-1);
+        var news = new CachedCollection<News>(fixture, fixture.Client);
+        fixture.Respond(Article(1, earlier, "Old"), Article(2, earlier.AddMinutes(30), "Second"));
+        await news.LoadAsync("/news", TimeSpan.Zero);
+        fixture.Respond(Article(1, earlier.AddHours(1), "Corrected"), Article(2, earlier.AddMinutes(30), "Second"));
+
+        await news.LoadAsync("/news", TimeSpan.Zero);
+
+        Assert.Equal(2, news.Count);
+        Assert.Equal(1, news[0].Id);
+        Assert.Equal("Corrected", news[0].Content);
+        using var db = fixture.CreateDbContext();
+        Assert.Equal("Corrected", (await db.News.SingleAsync(item => item.Id == 1)).Title);
+    }
+
+    [Fact]
+    public async Task SameTimeNewsCorrectionsAndBannerLinkEditsArePersisted()
+    {
+        using var fixture = new CacheFixture();
+        var published = DateTimeOffset.UtcNow;
+        var news = new CachedCollection<News>(fixture, fixture.Client);
+        fixture.Respond(Article(1, published, "Old"));
+        await news.LoadAsync("/news", TimeSpan.Zero);
+        fixture.Respond(Article(1, published, "Corrected"));
+        await news.LoadAsync("/news", TimeSpan.Zero);
+        Assert.Equal("Corrected", news.Single().Title);
+
+        var banners = new CachedCollection<Banner>(fixture, fixture.Client);
+        fixture.Respond(new Banner { Id = 1, ImageUrl = "https://example.com/old.png", TargetUrl = "https://example.com/old" });
+        await banners.LoadAsync("/banners", TimeSpan.Zero);
+        fixture.Respond(new Banner { Id = 1, ImageUrl = "https://example.com/new.png", TargetUrl = "https://example.com/new" });
+        await banners.LoadAsync("/banners", TimeSpan.Zero);
+        Assert.EndsWith("/new", banners.Single().TargetUrl);
+        using var db = fixture.CreateDbContext();
+        Assert.Equal("Corrected", (await db.News.SingleAsync()).Title);
+        Assert.EndsWith("/new.png", (await db.Banners.SingleAsync()).ImageUrl);
+    }
+
+    [Fact]
+    public async Task RemovingOneOfTwoSameTimeArticlesDoesNotRemoveTheOther()
+    {
+        using var fixture = new CacheFixture();
+        var published = DateTimeOffset.UtcNow;
+        using (var db = fixture.CreateDbContext())
+        {
+            db.News.AddRange(Article(1, published, "First"), Article(2, published, "Second"));
+            await db.SaveChangesAsync();
+        }
+        fixture.Respond(Article(2, published, "Second updated"), Article(3, published, "Third"));
+        var news = new CachedCollection<News>(fixture, fixture.Client);
+
+        await news.LoadAsync("/news", TimeSpan.Zero);
+
+        Assert.Equal([2, 3], news.Select(item => item.Id).Order().ToArray());
+        using var verify = fixture.CreateDbContext();
+        int[] persistedIds = await verify.News.OrderBy(item => item.Id).Select(item => item.Id).ToArrayAsync();
+        Assert.Equal([2, 3], persistedIds);
+    }
+
+    [Fact]
+    public async Task VersionedEntitiesRetainSameVersionAndReplaceNewVersion()
+    {
+        using var fixture = new CacheFixture();
+        var cache = new CachedCollection<VersionedItem>(fixture, fixture.Client);
+        fixture.Respond(new VersionedItem { Id = 1, Version = 1, Name = "First" });
+        await cache.LoadAsync("/versioned", TimeSpan.Zero);
+        var original = cache.Single();
+        fixture.Respond(new VersionedItem { Id = 1, Version = 1, Name = "Same version" });
+        await cache.LoadAsync("/versioned", TimeSpan.Zero);
+        Assert.Same(original, cache.Single());
+        fixture.Respond(new VersionedItem { Id = 1, Version = 2, Name = "New version" });
+        await cache.LoadAsync("/versioned", TimeSpan.Zero);
+        Assert.Equal("New version", cache.Single().Name);
+        using var db = fixture.CreateDbContext();
+        Assert.Equal(2, (await db.VersionedItems.SingleAsync()).Version);
+    }
+
+    [Fact]
+    public async Task DuplicateRemoteIdsDoNotPartiallyMutateCache()
+    {
+        using var fixture = new CacheFixture();
+        var published = DateTimeOffset.UtcNow;
+        var news = new CachedCollection<News>(fixture, fixture.Client);
+        fixture.Respond(Article(1, published, "Original"));
+        await news.LoadAsync("/news", TimeSpan.Zero);
+        fixture.Respond(Article(2, published, "Two"), Article(2, published.AddHours(1), "Duplicate"));
+
+        await Assert.ThrowsAsync<ArgumentException>(() => news.LoadAsync("/news", TimeSpan.Zero));
+
+        Assert.Equal("Original", news.Single().Title);
+        using var db = fixture.CreateDbContext();
+        Assert.Equal("Original", (await db.News.SingleAsync()).Title);
+    }
+
+    [Fact]
+    public async Task CacheDatabaseRecreationIsSeededFromRefreshedEntities()
+    {
+        using var fixture = new CacheFixture();
+        var cache = new CachedCollection<Banner>(fixture, fixture.Client);
+        fixture.Respond(new Banner { Id = 1, ImageUrl = "https://example.com/1", TargetUrl = "https://example.com/1" });
+        await cache.LoadAsync("/banners", TimeSpan.Zero);
+        using (var db = fixture.CreateDbContext())
+        {
+            await db.Database.EnsureDeletedAsync();
+            await db.Database.EnsureCreatedAsync();
+        }
+
+        await cache.LoadAsync("/banners", TimeSpan.Zero);
+
+        using var verify = fixture.CreateDbContext();
+        Assert.Single(cache);
+        Assert.Equal(1, await verify.Banners.CountAsync());
+    }
+}


### PR DESCRIPTION
## Summary

Fix audit P2-09: cache identity must use the entity ID, not its sort position or publication timestamp.

- Introduce a shared cached-entity ID contract for DApps, News and Banners.
- Replace/reposition entries by ID and persist edits to non-versioned news/banner data while preserving the existing version contract for DApps.
- Keep different news IDs with identical publication times, add deterministic ordering, and reject duplicate remote IDs before mutating the collection.
- Preserve cache seeding after its SQLite database is recreated.

## Validation

- `dotnet test tests/p2-09/CacheIdentity.Tests.csproj --no-restore --nologo`: 7/7 passed using production cache/entity source and SQLite.
- iOS 26.5 simulator and Android API 36 arm64 emulator: four native checks passed on each platform with actual CachedCollection/News/Banner and a disposable SQLite store. Different same-time IDs survived; edited items were reordered; a newly created collection reloaded the persisted edits; banner target updates were retained. A native CollectionView displayed the corrected content.
- After removing the external fixture, separate product rebuilds were installed and launched on both platforms. Normal Home/four tabs rendered, with no OneGate app crash observed.
- Final tested source patch SHA-256: `4cdb404a92eca99d7f9c5d49bbdeff136ce58342585f5a64d9a01ec73cf3228b`; matched to iOS and Android evidence before committing.

## Limitations and integration

Native refresh responses were controlled fixtures, not proof of a production backend change. No wallet signing or chain submissions were performed; screenshots and QA fixtures remain outside the repository and are not attached here, and no hosted CI pass is claimed.

Independently based and validated on `master@623603d`; preserve the union of solution project entries and revalidate after integrating other audit changes, which have not been jointly validated. When combining audit P2-08/P2-07, retain forced-refresh and offline/preference behavior alongside ID-based updates, and add this `ICachedEntity` dependency to the P2-08-cache linked sources and VersionedItem test boundary.
