### PR TITLE
Keep cached Apps and Games visible when refresh fails

### DIFF
--- a/OneGateApp.slnx
+++ b/OneGateApp.slnx
@@ -6,4 +6,5 @@
   <Project Path="OneGate.DebugProtocol/OneGate.DebugProtocol.csproj" />
   <Project Path="OneGate.DebugProtocol.Tests/OneGate.DebugProtocol.Tests.csproj" />
   <Project Path="OneGate.Tools/OneGate.Tools.csproj" />
+  <Project Path="tests/p2-07/OfflineCatalog.Tests.csproj" />
 </Solution>

--- a/OneGateApp/Pages/DAppsPage.xaml
+++ b/OneGateApp/Pages/DAppsPage.xaml
@@ -81,9 +81,15 @@
                 </CollectionView.ItemTemplate>
             </CollectionView>
             <og:TabBar x:Name="tabbarCategory" Tabs="{Binding DAppCategories}" Spacing="4" SelectedTabChanged="OnCategoryChanged" />
+            <Border StyleClass="Card" IsVisible="{Binding LoadingService.HasError}">
+                <VerticalStackLayout Spacing="8">
+                    <Label StyleClass="Secondary" Text="{x:Static og:Strings.ConnectionIssue}" />
+                    <Button Text="{x:Static og:Strings.Retry}" Command="{Binding LoadingService}" />
+                </VerticalStackLayout>
+            </Border>
             <CollectionView ItemsSource="{Binding DAppsFiltered}" MinimumHeightRequest="20">
                 <CollectionView.EmptyView>
-                    <Border StyleClass="Card">
+                    <Border StyleClass="Card" IsVisible="{Binding LoadingService.HasError, Converter={StaticResource InvertedBoolConverter}}">
                         <Grid>
                             <Label IsVisible="{Binding LoadingService.IsLoading}" HorizontalOptions="Center">
                                 <Label.FormattedText>

--- a/OneGateApp/Pages/DAppsPage.xaml.cs
+++ b/OneGateApp/Pages/DAppsPage.xaml.cs
@@ -27,7 +27,7 @@ public partial class DAppsPage : ContentPage
 
     public DAppsPage(IServiceProvider serviceProvider, ApplicationDbContext dbContext)
     {
-        this.LoadingService = new(LoadSettingsAsync, LoadDAppsAsync);
+        this.LoadingService = new(LoadCatalogAsync);
         this.dbContext = dbContext;
         this.DApps = serviceProvider.GetServiceOrCreateInstance<CachedCollection<DApp>>();
         InitializeComponent();
@@ -37,6 +37,7 @@ public partial class DAppsPage : ContentPage
         Shell.SetSearchHandler(this, null);
 #endif
         LoadingService.Loaded += OnDataLoaded;
+        DApps.CollectionLoaded += OnDataLoaded;
         LoadingService.BeginLoad();
     }
 
@@ -89,12 +90,33 @@ public partial class DAppsPage : ContentPage
         });
     }
 
+    async Task LoadCatalogAsync()
+    {
+        // Do not leave a previous permissive policy visible while settings are
+        // loading. A failed read remains restricted rather than reusing old flags.
+        allowRestrictedContent = false;
+        developerModeEnabled = false;
+        OnDataLoaded(this, EventArgs.Empty);
+        try { await LoadSettingsAsync(); }
+        finally
+        {
+            // An already loaded/shared collection will not send another disk-load
+            // event, and an offline refresh will not send a success event either.
+            OnDataLoaded(this, EventArgs.Empty);
+        }
+        await LoadDAppsAsync();
+    }
+
     async Task LoadSettingsAsync()
     {
-        allowRestrictedContent = await DAppCatalogPolicy.GetAllowRestrictedContentAsync(dbContext);
-        developerModeEnabled = await DAppCatalogPolicy.GetDeveloperModeEnabledAsync(dbContext);
-        DAppsIdFavorite = await dbContext.Settings.GetAsync<List<int>>("dapps/favorite") ?? [];
-        DAppsIdRecent = await dbContext.Settings.GetAsync<List<int>>("dapps/recent") ?? [];
+        bool allowRestrictedContent = await DAppCatalogPolicy.GetAllowRestrictedContentAsync(dbContext);
+        bool developerModeEnabled = await DAppCatalogPolicy.GetDeveloperModeEnabledAsync(dbContext);
+        List<int> favorite = await dbContext.Settings.GetAsync<List<int>>("dapps/favorite") ?? [];
+        List<int> recent = await dbContext.Settings.GetAsync<List<int>>("dapps/recent") ?? [];
+        this.allowRestrictedContent = allowRestrictedContent;
+        this.developerModeEnabled = developerModeEnabled;
+        DAppsIdFavorite = favorite;
+        DAppsIdRecent = recent;
     }
 
     async Task LoadDAppsAsync()

--- a/OneGateApp/Pages/DAppsPage.xaml.cs
+++ b/OneGateApp/Pages/DAppsPage.xaml.cs
@@ -3,6 +3,7 @@ using NeoOrder.OneGate.Models;
 using NeoOrder.OneGate.Properties;
 using NeoOrder.OneGate.Services;
 using System.Collections.ObjectModel;
+using System.Runtime.ExceptionServices;
 using TabBar = NeoOrder.OneGate.Controls.Views.TabBar;
 
 namespace NeoOrder.OneGate.Pages;
@@ -97,7 +98,9 @@ public partial class DAppsPage : ContentPage
         allowRestrictedContent = false;
         developerModeEnabled = false;
         OnDataLoaded(this, EventArgs.Empty);
+        Exception? settingsFailure = null;
         try { await LoadSettingsAsync(); }
+        catch (Exception ex) { settingsFailure = ex; }
         finally
         {
             // An already loaded/shared collection will not send another disk-load
@@ -105,6 +108,8 @@ public partial class DAppsPage : ContentPage
             OnDataLoaded(this, EventArgs.Empty);
         }
         await LoadDAppsAsync();
+        if (settingsFailure is not null)
+            ExceptionDispatchInfo.Capture(settingsFailure).Throw();
     }
 
     async Task LoadSettingsAsync()

--- a/OneGateApp/Pages/GamingPage.xaml
+++ b/OneGateApp/Pages/GamingPage.xaml
@@ -33,6 +33,12 @@
         <CollectionView ItemsSource="{Binding GamesFiltered}" MinimumHeightRequest="20">
             <CollectionView.Header>
                 <VerticalStackLayout Spacing="16">
+                    <Border StyleClass="Card" IsVisible="{Binding LoadingService.HasError}">
+                        <VerticalStackLayout Spacing="8">
+                            <Label StyleClass="Secondary" Text="{x:Static og:Strings.ConnectionIssue}" />
+                            <Button Text="{x:Static og:Strings.Retry}" Command="{Binding LoadingService}" />
+                        </VerticalStackLayout>
+                    </Border>
                     <Border StrokeShape="RoundRectangle 10" StrokeThickness="0" HeightRequest="132">
                         <Image Source="gaming_banner.webp" Aspect="AspectFill" />
                     </Border>
@@ -65,7 +71,7 @@
                 </VerticalStackLayout>
             </CollectionView.Header>
             <CollectionView.EmptyView>
-                <Border StyleClass="Card" HeightRequest="120">
+                <Border StyleClass="Card" HeightRequest="120" IsVisible="{Binding LoadingService.HasError, Converter={StaticResource InvertedBoolConverter}}">
                     <Grid>
                         <Label IsVisible="{Binding LoadingService.IsLoading}" HorizontalOptions="Center" VerticalOptions="Center">
                             <Label.FormattedText>

--- a/OneGateApp/Pages/GamingPage.xaml.cs
+++ b/OneGateApp/Pages/GamingPage.xaml.cs
@@ -29,7 +29,7 @@ public partial class GamingPage : ContentPage
 
     public GamingPage(IServiceProvider serviceProvider, ApplicationDbContext dbContext)
     {
-        this.LoadingService = new(LoadSettingsAsync, LoadDAppsAsync);
+        this.LoadingService = new(LoadCatalogAsync);
         this.dbContext = dbContext;
         this.DApps = serviceProvider.GetServiceOrCreateInstance<CachedCollection<DApp>>();
         InitializeComponent();
@@ -38,6 +38,7 @@ public partial class GamingPage : ContentPage
         Shell.SetSearchHandler(this, null);
 #endif
         LoadingService.Loaded += OnDataLoaded;
+        DApps.CollectionLoaded += OnDataLoaded;
         LoadingService.BeginLoad();
     }
 
@@ -56,11 +57,31 @@ public partial class GamingPage : ContentPage
         UpdateGamesItemsLayout(width);
     }
 
+    async Task LoadCatalogAsync()
+    {
+        // Do not leave a previous permissive policy visible while settings are
+        // loading. A failed read remains restricted rather than reusing old flags.
+        allowRestrictedContent = false;
+        developerModeEnabled = false;
+        OnDataLoaded(this, EventArgs.Empty);
+        try { await LoadSettingsAsync(); }
+        finally
+        {
+            // An already loaded/shared collection will not send another disk-load
+            // event, and an offline refresh will not send a success event either.
+            OnDataLoaded(this, EventArgs.Empty);
+        }
+        await LoadDAppsAsync();
+    }
+
     async Task LoadSettingsAsync()
     {
-        allowRestrictedContent = await DAppCatalogPolicy.GetAllowRestrictedContentAsync(dbContext);
-        developerModeEnabled = await DAppCatalogPolicy.GetDeveloperModeEnabledAsync(dbContext);
-        GamesIdRecent = await dbContext.Settings.GetAsync<List<int>>("dapps/recent") ?? [];
+        bool allowRestrictedContent = await DAppCatalogPolicy.GetAllowRestrictedContentAsync(dbContext);
+        bool developerModeEnabled = await DAppCatalogPolicy.GetDeveloperModeEnabledAsync(dbContext);
+        List<int> recent = await dbContext.Settings.GetAsync<List<int>>("dapps/recent") ?? [];
+        this.allowRestrictedContent = allowRestrictedContent;
+        this.developerModeEnabled = developerModeEnabled;
+        GamesIdRecent = recent;
     }
 
     async Task LoadDAppsAsync()

--- a/OneGateApp/Pages/GamingPage.xaml.cs
+++ b/OneGateApp/Pages/GamingPage.xaml.cs
@@ -3,6 +3,7 @@ using NeoOrder.OneGate.Models;
 using NeoOrder.OneGate.Properties;
 using NeoOrder.OneGate.Services;
 using System.Collections.ObjectModel;
+using System.Runtime.ExceptionServices;
 using TabBar = NeoOrder.OneGate.Controls.Views.TabBar;
 
 namespace NeoOrder.OneGate.Pages;
@@ -64,7 +65,9 @@ public partial class GamingPage : ContentPage
         allowRestrictedContent = false;
         developerModeEnabled = false;
         OnDataLoaded(this, EventArgs.Empty);
+        Exception? settingsFailure = null;
         try { await LoadSettingsAsync(); }
+        catch (Exception ex) { settingsFailure = ex; }
         finally
         {
             // An already loaded/shared collection will not send another disk-load
@@ -72,6 +75,8 @@ public partial class GamingPage : ContentPage
             OnDataLoaded(this, EventArgs.Empty);
         }
         await LoadDAppsAsync();
+        if (settingsFailure is not null)
+            ExceptionDispatchInfo.Capture(settingsFailure).Throw();
     }
 
     async Task LoadSettingsAsync()

--- a/OneGateApp/Services/LoadingService.cs
+++ b/OneGateApp/Services/LoadingService.cs
@@ -14,6 +14,7 @@ public partial class LoadingService(params Func<Task>[] loadActions) : ICommand,
 
     public bool IsLoading { get; private set { field = value; OnPropertyChanged(); } }
     public bool IsReloading { get; private set { field = value; OnPropertyChanged(); } }
+    public bool HasError { get; private set { field = value; OnPropertyChanged(); } }
 
     void OnPropertyChanged([CallerMemberName] string? propertyName = null)
     {
@@ -23,6 +24,7 @@ public partial class LoadingService(params Func<Task>[] loadActions) : ICommand,
     public async void BeginLoad(bool reload = false)
     {
         if (IsLoading) return;
+        HasError = false;
         IsLoading = true;
         if (reload) IsReloading = true;
         CanExecuteChanged?.Invoke(this, EventArgs.Empty);
@@ -33,6 +35,7 @@ public partial class LoadingService(params Func<Task>[] loadActions) : ICommand,
         }
         catch (Exception ex)
         {
+            HasError = true;
             await Toast.Show(ex.Message);
         }
         IsLoading = false;

--- a/tests/p2-07/OfflineCatalog.Tests.csproj
+++ b/tests/p2-07/OfflineCatalog.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework><ImplicitUsings>enable</ImplicitUsings><Nullable>enable</Nullable>
+    <IsTestProject>true</IsTestProject><IsPackable>false</IsPackable>
+    <DefineConstants>$(DefineConstants);IOS</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" PrivateAssets="all" />
+    <Compile Include="../../OneGateApp/Services/LoadingService.cs" Link="LoadingService.cs" />
+    <Compile Include="../../OneGateApp/Pages/GamingPage.xaml.cs" Link="GamingPage.cs" />
+    <Compile Include="../../OneGateApp/Pages/DAppsPage.xaml.cs" Link="DAppsPage.cs" />
+    <Compile Include="../../OneGateApp/Services/DAppCatalogPolicy.cs" Link="DAppCatalogPolicy.cs" />
+    <Compile Include="../../OneGateApp/Data/ContentWarnings.cs" Link="ContentWarnings.cs" />
+    <Compile Include="../../OneGateApp/Data/DAppPlatforms.cs" Link="DAppPlatforms.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- App relationship only; linked-source tests run without MAUI workloads. -->
+    <ProjectReference Include="../../OneGateApp/OneGateApp.csproj"
+                      ReferenceOutputAssembly="false" BuildReference="false"
+                      SkipGetTargetFrameworkProperties="true" />
+  </ItemGroup>
+</Project>

--- a/tests/p2-07/OfflineCatalogTests.cs
+++ b/tests/p2-07/OfflineCatalogTests.cs
@@ -78,6 +78,28 @@ public class OfflineCatalogTests
         Assert.Equal(1, Assert.Single(Recent(page)).Id);
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task SettingsFailureStillLoadsDiskCatalogWithRestrictedDefaults(bool games)
+    {
+        var catalog = new CachedCollection<DApp>();
+        catalog.Load = () =>
+        {
+            catalog.Add(new DApp { Id = 7, IsGamingApp = games });
+            catalog.Add(new DApp { Id = 8, IsGamingApp = games, Warnings = (ContentWarnings)1 });
+            return Task.CompletedTask;
+        };
+        var database = new ApplicationDbContext();
+        database.Settings.FailureKey = DAppCatalogPolicy.AllowRestrictedContentKey;
+        object page = games ? new GamingPage(new TestServices(catalog), database) : new DAppsPage(new TestServices(catalog), database);
+
+        await Idle(Loading(page));
+
+        Assert.True(Loading(page).HasError);
+        Assert.Equal(7, Assert.Single(Items(page)).Id);
+    }
+
     static async Task<(CachedCollection<DApp>, ApplicationDbContext)> PermissiveCatalog(bool games)
     {
         var catalog = new CachedCollection<DApp>

--- a/tests/p2-07/OfflineCatalogTests.cs
+++ b/tests/p2-07/OfflineCatalogTests.cs
@@ -1,0 +1,155 @@
+using NeoOrder.OneGate.Data;
+using NeoOrder.OneGate.Models;
+using NeoOrder.OneGate.Pages;
+using NeoOrder.OneGate.Services;
+using Xunit;
+
+public class OfflineCatalogTests
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void BothPagesPresentASharedAlreadyLoadedCacheWhenOffline(bool gamesFirst)
+    {
+        var catalog = new CachedCollection<DApp>
+        {
+            new() { Id = 1, IsGamingApp = true }, new() { Id = 2, IsGamingApp = false }
+        };
+        catalog.Load = () => throw new HttpRequestException("Offline");
+        int notifications = 0;
+        catalog.CollectionLoaded += (_, _) => notifications++;
+        var services = new TestServices(catalog);
+        GamingPage gaming;
+        DAppsPage apps;
+        if (gamesFirst) { gaming = new(services, new()); apps = new(services, new()); }
+        else { apps = new(services, new()); gaming = new(services, new()); }
+
+        Assert.Equal(1, notifications);
+        Assert.Equal(1, Assert.Single(gaming.GamesFiltered).Id);
+        Assert.Equal(2, Assert.Single(apps.DAppsFiltered).Id);
+        Assert.True(gaming.LoadingService.HasError && apps.LoadingService.HasError);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task TighteningPreferencesImmediatelyFiltersAnOfflineLoadedPage(bool games)
+    {
+        var (catalog, database) = await PermissiveCatalog(games);
+        object page = games ? new GamingPage(new TestServices(catalog), database) : new DAppsPage(new TestServices(catalog), database);
+        Assert.Equal(3, Items(page).Length);
+        await database.Settings.PutAsync(DAppCatalogPolicy.AllowRestrictedContentKey, false);
+        await database.Settings.PutAsync(DAppCatalogPolicy.DeveloperModeKey, false);
+        var response = new TaskCompletionSource();
+        catalog.Load = () => response.Task;
+
+        Loading(page).BeginLoad();
+
+        Assert.Equal(1, Assert.Single(Items(page)).Id);
+        Assert.Equal(1, Assert.Single(Recent(page)).Id);
+        response.SetException(new HttpRequestException("Offline"));
+        await Idle(Loading(page));
+        Assert.True(Loading(page).HasError);
+        Assert.Equal(1, Assert.Single(Items(page)).Id);
+    }
+
+    [Theory]
+    [InlineData(true, DAppCatalogPolicy.AllowRestrictedContentKey)]
+    [InlineData(false, DAppCatalogPolicy.AllowRestrictedContentKey)]
+    [InlineData(true, DAppCatalogPolicy.DeveloperModeKey)]
+    [InlineData(false, DAppCatalogPolicy.DeveloperModeKey)]
+    public async Task SettingsFailureDoesNotReusePreviouslyPermissiveFlags(bool games, string failureKey)
+    {
+        var (catalog, database) = await PermissiveCatalog(games);
+        object page = games ? new GamingPage(new TestServices(catalog), database) : new DAppsPage(new TestServices(catalog), database);
+        Assert.Equal(3, Items(page).Length);
+        var settings = new TaskCompletionSource();
+        database.Settings.ReadGate = settings.Task;
+        database.Settings.FailureKey = failureKey;
+
+        Loading(page).BeginLoad();
+
+        // A slow/failing preference read must not leave old forbidden cards tappable.
+        Assert.Equal(1, Assert.Single(Items(page)).Id);
+        settings.SetResult();
+        await Idle(Loading(page));
+        Assert.True(Loading(page).HasError);
+        Assert.Equal(1, Assert.Single(Items(page)).Id);
+        Assert.Equal(1, Assert.Single(Recent(page)).Id);
+    }
+
+    static async Task<(CachedCollection<DApp>, ApplicationDbContext)> PermissiveCatalog(bool games)
+    {
+        var catalog = new CachedCollection<DApp>
+        {
+            new() { Id = 1, IsGamingApp = games },
+            new() { Id = 2, IsGamingApp = games, Warnings = (ContentWarnings)1 },
+            new() { Id = 3, IsGamingApp = games, IsInDevelopment = true }
+        };
+        var database = new ApplicationDbContext();
+        await database.Settings.PutAsync(DAppCatalogPolicy.AllowRestrictedContentKey, true);
+        await database.Settings.PutAsync(DAppCatalogPolicy.DeveloperModeKey, true);
+        await database.Settings.PutAsync("dapps/recent", new List<int> { 1, 2, 3 });
+        return (catalog, database);
+    }
+    static DApp[] Items(object page) => page is GamingPage gaming ? gaming.GamesFiltered : ((DAppsPage)page).DAppsFiltered;
+    static IEnumerable<DApp> Recent(object page) => page is GamingPage gaming ? gaming.GamesRecent : ((DAppsPage)page).DAppsRecent;
+    static LoadingService Loading(object page) => page is GamingPage gaming ? gaming.LoadingService : ((DAppsPage)page).LoadingService;
+    static async Task Idle(LoadingService loading)
+    {
+        for (int i = 0; loading.IsLoading && i < 100; i++) await Task.Delay(5);
+        Assert.False(loading.IsLoading);
+    }
+
+    [Fact]
+    public void GamesShowExpiredCachedItemsWhenNetworkRefreshFails()
+    {
+        var catalog = new CachedCollection<DApp> { new() { Id = 1, IsGamingApp = true } };
+        catalog.Load = () => throw new HttpRequestException("Offline");
+
+        var page = new GamingPage(new TestServices(catalog), new());
+
+        Assert.Equal(1, Assert.Single(page.GamesFiltered).Id);
+        Assert.False(page.LoadingService.IsLoading);
+        Assert.True(page.LoadingService.HasError);
+    }
+
+    [Fact]
+    public void AppsShowExpiredCachedItemsWhenNetworkRefreshFails()
+    {
+        var catalog = new CachedCollection<DApp> { new() { Id = 2, IsGamingApp = false } };
+        catalog.Load = () => throw new HttpRequestException("Offline");
+
+        var page = new DAppsPage(new TestServices(catalog), new());
+
+        Assert.Equal(2, Assert.Single(page.DAppsFiltered).Id);
+        Assert.False(page.LoadingService.IsLoading);
+        Assert.True(page.LoadingService.HasError);
+    }
+
+    [Fact]
+    public async Task CacheAppearsBeforeSlowNetworkRequestCompletes()
+    {
+        var request = new TaskCompletionSource();
+        var catalog = new CachedCollection<DApp> { new() { Id = 3, IsGamingApp = true } };
+        catalog.Load = () => request.Task;
+        var page = new GamingPage(new TestServices(catalog), new());
+        try { Assert.Single(page.GamesFiltered); }
+        finally { request.SetResult(); await Task.Delay(20); }
+    }
+
+    [Fact]
+    public void FailedEmptyCatalogAndSuccessfulEmptyCatalogHaveDifferentState()
+    {
+        var catalog = new CachedCollection<DApp> { Load = () => throw new HttpRequestException() };
+        var page = new GamingPage(new TestServices(catalog), new());
+        Assert.Empty(page.GamesFiltered);
+        Assert.True(page.LoadingService.HasError);
+
+        catalog.Load = () => Task.CompletedTask;
+        page.LoadingService.BeginLoad();
+
+        Assert.Empty(page.GamesFiltered);
+        Assert.False(page.LoadingService.HasError);
+    }
+}

--- a/tests/p2-07/TestBoundary.cs
+++ b/tests/p2-07/TestBoundary.cs
@@ -1,0 +1,147 @@
+// Native controls and network/persistence are test boundaries. Actual page and
+// LoadingService source is compiled unchanged into this project.
+using System.Collections.ObjectModel;
+using NeoOrder.OneGate.Data;
+using NeoOrder.OneGate.Models;
+
+public class ContentPage
+{
+    public TestDispatcher Dispatcher { get; } = new();
+    protected virtual void OnAppearing() { }
+    protected virtual void OnDisappearing() { }
+    protected virtual void OnSizeAllocated(double width, double height) { }
+    protected void OnPropertyChanged(string? property = null) { }
+}
+public interface IDispatcherTimer { TimeSpan Interval { get; set; } event EventHandler? Tick; void Start(); void Stop(); }
+public class TestTimer : IDispatcherTimer
+{
+    public TimeSpan Interval { get; set; }
+    public event EventHandler? Tick;
+    public void Start() { }
+    public void Stop() { }
+    public void Fire() => Tick?.Invoke(this, EventArgs.Empty);
+}
+public class TestDispatcher { public IDispatcherTimer CreateTimer() => new TestTimer(); }
+public class TestCarousel { public int Position { get; set; } }
+public class TestItemsLayout { public int Span { get; set; } = 1; }
+public class Button { public object CommandParameter { get; set; } = new(); }
+public class TappedEventArgs : EventArgs { public object? Parameter { get; set; } }
+public class Shell
+{
+    public static Shell Current { get; } = new();
+    public Task GoToAsync(string route, Dictionary<string, object> parameters) => Task.CompletedTask;
+}
+public class TestServices(params object[] services) : IServiceProvider
+{
+    public object? GetService(Type type) => services.Single(item => item.GetType() == type);
+}
+namespace CommunityToolkit.Maui.Alerts { }
+namespace NeoOrder.OneGate.Controls
+{
+    public static class Toast { public static Task Show(string text) => Task.CompletedTask; }
+}
+namespace NeoOrder.OneGate.Controls.Views
+{
+    public class TabBar { public IReadOnlyList<string>? Tabs { get; set; } = ["All"]; public string? SelectedTab { get; set; } = "All"; }
+}
+namespace NeoOrder.OneGate.Data
+{
+    public class ApplicationDbContext { public TestSettings Settings { get; } = new(); }
+    public class TestSettings
+    {
+        readonly Dictionary<string, object> values = [];
+        public string? FailureKey { get; set; }
+        public Task? ReadGate { get; set; }
+        public async Task<T?> GetAsync<T>(string key) where T : notnull
+        {
+            if (ReadGate is not null) await ReadGate;
+            if (FailureKey == key) throw new InvalidOperationException("Controlled settings failure");
+            return values.TryGetValue(key, out object? value) ? (T)value : default;
+        }
+        public Task PutAsync<T>(string key, T value) { values[key] = value!; return Task.CompletedTask; }
+    }
+    public class DApp
+    {
+        public int Id { get; set; }
+        public bool IsGamingApp { get; set; } = true;
+        public bool IsRegularApp => !IsGamingApp;
+        public bool IsHiddenFromCatalog { get; set; }
+        public bool IsInDevelopment { get; set; }
+        public ContentWarnings Warnings { get; set; }
+        public DAppPlatforms SupportedPlatforms { get; set; } = DAppPlatforms.iOS;
+        public string? GameType { get; set; } = "Action";
+        public string? GameTypeDisplayName => GameType;
+        public string[]? Tags { get; set; }
+        public static string? LocalizeGameType(string? gameType) => gameType;
+        public static string LocalizeTag(string tag) => tag;
+    }
+    public class Banner { }
+    public class News { }
+}
+namespace NeoOrder.OneGate.Models
+{
+    public class CachedCollection<T> : ObservableCollection<T>
+    {
+        bool loaded;
+        public event EventHandler? CollectionLoaded;
+        public List<bool> ForcedRequests { get; } = [];
+        public Func<Task> Load { get; set; } = () => Task.CompletedTask;
+        public async Task LoadAsync(string url, TimeSpan ttl, bool forceRefresh = false)
+        {
+            ForcedRequests.Add(forceRefresh);
+            // Match production: disk cache is only loaded/signalled once per
+            // collection instance; later failed refreshes do not signal at all.
+            if (!loaded)
+            {
+                loaded = true;
+                CollectionLoaded?.Invoke(this, EventArgs.Empty);
+            }
+            await Load();
+            CollectionLoaded?.Invoke(this, EventArgs.Empty);
+        }
+    }
+}
+namespace NeoOrder.OneGate.Models.AppLinks
+{
+    public class LaunchDAppAction
+    {
+        public Uri Uri { get; } = new("https://example.com");
+        public static LaunchDAppAction? TryCreate(string url) => null;
+    }
+}
+namespace NeoOrder.OneGate.Services
+{
+    public static class Extensions
+    {
+        public static T GetServiceOrCreateInstance<T>(this IServiceProvider services) => (T)services.GetService(typeof(T))!;
+        public static bool ShouldRefresh(this ContentPage page) => false;
+    }
+}
+namespace NeoOrder.OneGate.Properties { public static class Strings { public static string All => "All"; } }
+namespace NeoOrder.OneGate.Pages
+{
+    public static class Commands
+    {
+        public static TestCommand CheckForUpdates { get; } = new();
+        public static TestCommand LaunchDApp { get; } = new();
+        public static TestCommand OpenUrl { get; } = new();
+    }
+    public class TestCommand { public Task ExecuteAsync(object value) => Task.CompletedTask; }
+    public partial class GamingPage
+    {
+        readonly TestItemsLayout GamesItemsLayout = new();
+        readonly Controls.Views.TabBar gameTypeTabBar = new();
+        void InitializeComponent() { }
+    }
+    public partial class DAppsPage
+    {
+        readonly Controls.Views.TabBar tabbarCategory = new();
+        readonly Controls.Views.TabBar tabbarFavoriteOrRecent = new() { Tabs = ["Recent", "Favorite"], SelectedTab = "Recent" };
+        void InitializeComponent() { }
+    }
+    public partial class HomePage
+    {
+        readonly TestCarousel carouselView = new();
+        void InitializeComponent() { }
+    }
+}


### PR DESCRIPTION
## Summary

Fix audit P2-07: a settings read failure no longer prevents the Apps/Games page from loading its disk-backed catalog.

- Load the cached collection with restrictive defaults even when preferences cannot be read.
- Preserve the original settings failure for the existing error/retry state after the catalog has been presented.
- Add regression coverage for both Apps and Games pages, including filtering restricted entries while settings are unavailable.

## Validation

- `dotnet test tests/p2-07/OfflineCatalog.Tests.csproj --no-restore --nologo`: 14/14 passed.
- iOS simulator: `OneGateApp` rebuilt for `net10.0-ios`, installed and launched on the iPhone 17 simulator; normal welcome UI displayed.
- Android API 36 `onegate_api36` emulator: self-contained APK rebuilt with `EmbedAssembliesIntoApk=true`, installed and launched directly through the resolved MAUI `MainActivity`; normal welcome UI displayed.
- Screenshots and device logs are outside the repository under `/tmp`.

The controlled settings-failure regression is covered by the focused test project; simulator validation exercised the resulting production app startup on both platforms. No wallet signing, game play, or chain submission was performed.

This PR remains independently based on `master@623603d`; no historical Erik-rejected approach or STOP item was changed.
