### PR TITLE
Honor explicit Home and Gaming refreshes

### DIFF
--- a/OneGateApp.slnx
+++ b/OneGateApp.slnx
@@ -6,4 +6,6 @@
   <Project Path="OneGate.DebugProtocol/OneGate.DebugProtocol.csproj" />
   <Project Path="OneGate.DebugProtocol.Tests/OneGate.DebugProtocol.Tests.csproj" />
   <Project Path="OneGate.Tools/OneGate.Tools.csproj" />
+  <Project Path="tests/p2-08/RefreshIntent.Tests.csproj" />
+  <Project Path="tests/p2-08-cache/ForcedRefresh.Tests.csproj" />
 </Solution>

--- a/OneGateApp/Models/CachedCollection.cs
+++ b/OneGateApp/Models/CachedCollection.cs
@@ -46,7 +46,7 @@ public class CachedCollection<T>(IDbContextFactory<CacheDbContext> dbContextFact
         return ~low;
     }
 
-    public async Task LoadAsync(string url, TimeSpan duration)
+    public async Task LoadAsync(string url, TimeSpan duration, bool forceRefresh = false)
     {
         await sync_lock.WaitAsync();
         try
@@ -65,7 +65,7 @@ public class CachedCollection<T>(IDbContextFactory<CacheDbContext> dbContextFact
                     && Count > 0
                     && !await dbContext.Set<T>().AnyAsync();
                 var last_update = await dbContext.Settings.GetAsync<DateTimeOffset>(settings_key);
-                if (last_update > DateTimeOffset.UtcNow - duration) return;
+                if (!forceRefresh && last_update > DateTimeOffset.UtcNow - duration) return;
                 var items_new = (await httpClient.GetFromJsonAsync<T[]>(url))!;
                 for (int i = Count - 1; i >= 0; i--)
                 {

--- a/OneGateApp/Pages/GamingPage.xaml.cs
+++ b/OneGateApp/Pages/GamingPage.xaml.cs
@@ -65,7 +65,7 @@ public partial class GamingPage : ContentPage
 
     async Task LoadDAppsAsync()
     {
-        await DApps.LoadAsync("/api/dapps", TimeSpan.FromDays(1));
+        await DApps.LoadAsync("/api/dapps", TimeSpan.FromDays(1), forceRefresh: LoadingService.IsReloading);
     }
 
     void OnGameTypeChanged(object sender, EventArgs e)

--- a/OneGateApp/Pages/HomePage.xaml.cs
+++ b/OneGateApp/Pages/HomePage.xaml.cs
@@ -79,7 +79,7 @@ public partial class HomePage : ContentPage
 
     async Task LoadBannersAsync()
     {
-        await Banners.LoadAsync("/api/banners", TimeSpan.FromDays(1));
+        await Banners.LoadAsync("/api/banners", TimeSpan.FromDays(1), forceRefresh: LoadingService.IsReloading);
     }
 
     async Task LoadNewsAsync()
@@ -88,6 +88,6 @@ public partial class HomePage : ContentPage
         string[]? excluded = await dbContext.Settings.GetAsync<string[]>("news/categories/excluded");
         if (excluded?.Length > 0)
             url += "?" + string.Join('&', excluded.Select(p => "x=" + WebUtility.UrlEncode(p)));
-        await News.LoadAsync(url, TimeSpan.FromMinutes(15));
+        await News.LoadAsync(url, TimeSpan.FromMinutes(15), forceRefresh: LoadingService.IsReloading);
     }
 }

--- a/tests/p2-08-cache/CacheBoundary.cs
+++ b/tests/p2-08-cache/CacheBoundary.cs
@@ -1,0 +1,67 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using NeoOrder.OneGate.Data;
+using System.Net;
+using System.Text.Json;
+
+// Actual cache, entities, SQL settings helpers and SQLite are used. Only the
+// production on-disk database location and remote HTTP responses are replaced.
+public sealed class CacheFixture : IDbContextFactory<CacheDbContext>, IDisposable
+{
+    readonly SqliteConnection connection = new("Data Source=:memory:");
+    public ResponseHandler Handler { get; } = new();
+    public HttpClient Client { get; }
+    public CacheFixture()
+    {
+        connection.Open();
+        using var db = CreateDbContext();
+        db.Database.EnsureCreated();
+        Client = new(Handler) { BaseAddress = new("https://example.com") };
+    }
+    public CacheDbContext CreateDbContext() => new(new DbContextOptionsBuilder<CacheDbContext>()
+        .UseSqlite(connection).UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking).Options);
+    public Task<CacheDbContext> CreateDbContextAsync(CancellationToken cancellationToken = default) => Task.FromResult(CreateDbContext());
+    public void Respond<T>(params T[] values) => Handler.Json = JsonSerializer.Serialize(values, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+    public void Dispose() { Client.Dispose(); connection.Dispose(); }
+}
+public sealed class ResponseHandler : HttpMessageHandler
+{
+    public string Json { get; set; } = "[]";
+    public int Requests { get; private set; }
+    public Exception? Error { get; set; }
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        Requests++;
+        if (Error is not null) throw Error;
+        return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(Json) });
+    }
+}
+namespace NeoOrder.OneGate.Data
+{
+    public class CacheDbContext(DbContextOptions<CacheDbContext> options) : DbContext(options)
+    {
+        public DbSet<Setting> Settings => Set<Setting>();
+        public DbSet<Banner> Banners => Set<Banner>();
+        public DbSet<News> News => Set<News>();
+        public DbSet<VersionedItem> VersionedItems => Set<VersionedItem>();
+    }
+    public static class CacheDbContextFactoryExtensions
+    {
+        public static Task<CacheDbContext> CreateInitializedDbContextAsync(this IDbContextFactory<CacheDbContext> factory) => factory.CreateDbContextAsync();
+    }
+}
+public class VersionedItem : NeoOrder.OneGate.Models.IVersioned, IComparable<VersionedItem>
+{
+    public int Id { get; set; }
+    public int Version { get; set; }
+    public string Name { get; set; } = "";
+    public int CompareTo(VersionedItem? other) => other is null ? 1 : Id.CompareTo(other.Id);
+}
+namespace NeoOrder.OneGate.Services
+{
+    public static class SharedOptions
+    {
+        public const string OneGateDomain = "example.com";
+        public static JsonSerializerOptions JsonSerializerOptions { get; } = new(JsonSerializerDefaults.Web);
+    }
+}

--- a/tests/p2-08-cache/ForcedRefresh.Tests.csproj
+++ b/tests/p2-08-cache/ForcedRefresh.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework><ImplicitUsings>enable</ImplicitUsings><Nullable>enable</Nullable>
+    <IsTestProject>true</IsTestProject><IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
+    <Compile Include="../../OneGateApp/Models/CachedCollection.cs" Link="CachedCollection.cs" />
+    <Compile Include="../../OneGateApp/Models/IVersioned.cs" Link="IVersioned.cs" />
+    <Compile Include="../../OneGateApp/Models/IShareable.cs" Link="IShareable.cs" />
+    <Compile Include="../../OneGateApp/Data/News.cs" Link="News.cs" />
+    <Compile Include="../../OneGateApp/Data/Banner.cs" Link="Banner.cs" />
+    <Compile Include="../../OneGateApp/Data/Setting.cs" Link="Setting.cs" />
+    <Compile Include="../../OneGateApp/Data/SettingsExtensions.cs" Link="SettingsExtensions.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- App relationship only; linked-source tests run without MAUI workloads. -->
+    <ProjectReference Include="../../OneGateApp/OneGateApp.csproj"
+                      ReferenceOutputAssembly="false" BuildReference="false"
+                      SkipGetTargetFrameworkProperties="true" />
+  </ItemGroup>
+</Project>

--- a/tests/p2-08-cache/ForcedRefreshTests.cs
+++ b/tests/p2-08-cache/ForcedRefreshTests.cs
@@ -1,0 +1,40 @@
+using NeoOrder.OneGate.Data;
+using NeoOrder.OneGate.Models;
+using Xunit;
+
+public class ForcedRefreshTests
+{
+    [Fact]
+    public async Task AutomaticLoadHonorsTtlAndForceFetchesFreshResponse()
+    {
+        using var fixture = new CacheFixture();
+        var cache = new CachedCollection<Banner>(fixture, fixture.Client);
+        fixture.Respond(new Banner { Id = 1, ImageUrl = "https://example.com/1", TargetUrl = "https://example.com/1" });
+        await cache.LoadAsync("/banners", TimeSpan.FromDays(1));
+        fixture.Respond(new Banner { Id = 2, ImageUrl = "https://example.com/2", TargetUrl = "https://example.com/2" });
+        await cache.LoadAsync("/banners", TimeSpan.FromDays(1));
+        Assert.Equal(1, fixture.Handler.Requests);
+        Assert.Equal(1, cache.Single().Id);
+
+        await cache.LoadAsync("/banners", TimeSpan.FromDays(1), forceRefresh: true);
+
+        Assert.Equal(2, fixture.Handler.Requests);
+        Assert.Equal(2, cache.Single().Id);
+    }
+
+    [Fact]
+    public async Task ForceBypassesFutureTimestampAndFailureDoesNotMarkFresh()
+    {
+        using var fixture = new CacheFixture();
+        var future = DateTimeOffset.UtcNow.AddDays(3);
+        using (var db = fixture.CreateDbContext()) await db.Settings.PutAsync("caching/last_update/banner", future);
+        var cache = new CachedCollection<Banner>(fixture, fixture.Client);
+        fixture.Handler.Error = new HttpRequestException("Offline");
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => cache.LoadAsync("/banners", TimeSpan.FromDays(1), forceRefresh: true));
+
+        Assert.Equal(1, fixture.Handler.Requests);
+        using var verify = fixture.CreateDbContext();
+        Assert.Equal(future, await verify.Settings.GetAsync<DateTimeOffset>("caching/last_update/banner"));
+    }
+}

--- a/tests/p2-08/RefreshIntent.Tests.csproj
+++ b/tests/p2-08/RefreshIntent.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework><ImplicitUsings>enable</ImplicitUsings><Nullable>enable</Nullable>
+    <IsTestProject>true</IsTestProject><IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" PrivateAssets="all" />
+    <Compile Include="../../OneGateApp/Services/LoadingService.cs" Link="LoadingService.cs" />
+    <Compile Include="../../OneGateApp/Pages/GamingPage.xaml.cs" Link="GamingPage.cs" />
+    <Compile Include="../../OneGateApp/Pages/HomePage.xaml.cs" Link="HomePage.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- App relationship only; linked-source tests run without MAUI workloads. -->
+    <ProjectReference Include="../../OneGateApp/OneGateApp.csproj"
+                      ReferenceOutputAssembly="false" BuildReference="false"
+                      SkipGetTargetFrameworkProperties="true" />
+  </ItemGroup>
+</Project>

--- a/tests/p2-08/RefreshIntentTests.cs
+++ b/tests/p2-08/RefreshIntentTests.cs
@@ -1,0 +1,37 @@
+using NeoOrder.OneGate.Data;
+using NeoOrder.OneGate.Models;
+using NeoOrder.OneGate.Pages;
+using System.Windows.Input;
+using Xunit;
+
+public class RefreshIntentTests
+{
+    [Fact]
+    public void GamesManualRefreshBypassesCacheWhileAutomaticLoadKeepsIt()
+    {
+        var games = new CachedCollection<DApp>();
+        var page = new GamingPage(new TestServices(games), new());
+        Assert.Equal([false], games.ForcedRequests);
+
+        ((ICommand)page.LoadingService).Execute(null);
+
+        Assert.Equal([false, true], games.ForcedRequests);
+        Assert.False(page.LoadingService.IsReloading);
+    }
+
+    [Fact]
+    public void HomeRefreshBypassesBothBannerAndNewsCache()
+    {
+        var banners = new CachedCollection<Banner>();
+        var news = new CachedCollection<News>();
+        var page = new HomePage(new TestServices(banners, news), new());
+        page.LoadingService.BeginLoad();
+        Assert.Equal([false], banners.ForcedRequests);
+        Assert.Equal([false], news.ForcedRequests);
+
+        ((ICommand)page.LoadingService).Execute(null);
+
+        Assert.Equal([false, true], banners.ForcedRequests);
+        Assert.Equal([false, true], news.ForcedRequests);
+    }
+}

--- a/tests/p2-08/TestBoundary.cs
+++ b/tests/p2-08/TestBoundary.cs
@@ -1,0 +1,127 @@
+// Native controls and network/persistence are test boundaries. Actual page and
+// LoadingService source is compiled unchanged into this project.
+using System.Collections.ObjectModel;
+using NeoOrder.OneGate.Data;
+using NeoOrder.OneGate.Models;
+
+public class ContentPage
+{
+    public TestDispatcher Dispatcher { get; } = new();
+    protected virtual void OnAppearing() { }
+    protected virtual void OnDisappearing() { }
+    protected virtual void OnSizeAllocated(double width, double height) { }
+    protected void OnPropertyChanged(string? property = null) { }
+}
+public interface IDispatcherTimer { TimeSpan Interval { get; set; } event EventHandler? Tick; void Start(); void Stop(); }
+public class TestTimer : IDispatcherTimer
+{
+    public TimeSpan Interval { get; set; }
+    public event EventHandler? Tick;
+    public void Start() { }
+    public void Stop() { }
+    public void Fire() => Tick?.Invoke(this, EventArgs.Empty);
+}
+public class TestDispatcher { public IDispatcherTimer CreateTimer() => new TestTimer(); }
+public class TestCarousel { public int Position { get; set; } }
+public class TestItemsLayout { public int Span { get; set; } = 1; }
+public class Button { public object CommandParameter { get; set; } = new(); }
+public class TappedEventArgs : EventArgs { public object? Parameter { get; set; } }
+public class Shell
+{
+    public static Shell Current { get; } = new();
+    public Task GoToAsync(string route, Dictionary<string, object> parameters) => Task.CompletedTask;
+}
+public class TestServices(params object[] services) : IServiceProvider
+{
+    public object? GetService(Type type) => services.Single(item => item.GetType() == type);
+}
+namespace CommunityToolkit.Maui.Alerts { }
+namespace NeoOrder.OneGate.Controls
+{
+    public static class Toast { public static Task Show(string text) => Task.CompletedTask; }
+}
+namespace NeoOrder.OneGate.Controls.Views
+{
+    public class TabBar { public IReadOnlyList<string>? Tabs { get; set; } = ["All"]; public string? SelectedTab { get; set; } = "All"; }
+}
+namespace NeoOrder.OneGate.Data
+{
+    public class ApplicationDbContext { public TestSettings Settings { get; } = new(); }
+    public class TestSettings
+    {
+        public Task<T?> GetAsync<T>(string key) where T : notnull => Task.FromResult(default(T));
+        public Task PutAsync<T>(string key, T value) => Task.CompletedTask;
+    }
+    public class DApp
+    {
+        public int Id { get; set; }
+        public bool IsGamingApp { get; set; } = true;
+        public bool IsRegularApp => !IsGamingApp;
+        public string? GameType { get; set; } = "Action";
+        public string? GameTypeDisplayName => GameType;
+        public string[]? Tags { get; set; }
+        public static string? LocalizeGameType(string? gameType) => gameType;
+        public static string LocalizeTag(string tag) => tag;
+    }
+    public class Banner { }
+    public class News { }
+}
+namespace NeoOrder.OneGate.Models
+{
+    public class CachedCollection<T> : ObservableCollection<T>
+    {
+        public event EventHandler? CollectionLoaded;
+        public List<bool> ForcedRequests { get; } = [];
+        public Func<Task> Load { get; set; } = () => Task.CompletedTask;
+        public Task LoadAsync(string url, TimeSpan ttl, bool forceRefresh = false)
+        {
+            ForcedRequests.Add(forceRefresh);
+            CollectionLoaded?.Invoke(this, EventArgs.Empty);
+            return Load();
+        }
+    }
+}
+namespace NeoOrder.OneGate.Models.AppLinks
+{
+    public class LaunchDAppAction
+    {
+        public Uri Uri { get; } = new("https://example.com");
+        public static LaunchDAppAction? TryCreate(string url) => null;
+    }
+}
+namespace NeoOrder.OneGate.Services
+{
+    public static class DAppCatalogPolicy
+    {
+        public static Task<bool> GetAllowRestrictedContentAsync(ApplicationDbContext db) => Task.FromResult(false);
+        public static Task<bool> GetDeveloperModeEnabledAsync(ApplicationDbContext db) => Task.FromResult(false);
+        public static bool IsVisible(DApp app, bool restricted, bool developer) => true;
+    }
+    public static class Extensions
+    {
+        public static T GetServiceOrCreateInstance<T>(this IServiceProvider services) => (T)services.GetService(typeof(T))!;
+        public static bool ShouldRefresh(this ContentPage page) => false;
+    }
+}
+namespace NeoOrder.OneGate.Properties { public static class Strings { public static string All => "All"; } }
+namespace NeoOrder.OneGate.Pages
+{
+    public static class Commands
+    {
+        public static TestCommand CheckForUpdates { get; } = new();
+        public static TestCommand LaunchDApp { get; } = new();
+        public static TestCommand OpenUrl { get; } = new();
+    }
+    public class TestCommand { public Task ExecuteAsync(object value) => Task.CompletedTask; }
+    public partial class GamingPage
+    {
+        readonly TestItemsLayout GamesItemsLayout = new();
+        readonly Controls.Views.TabBar gameTypeTabBar = new();
+        void InitializeComponent() { }
+    }
+    public partial class HomePage
+    {
+        readonly TestCarousel carouselView = new();
+        void InitializeComponent() { }
+    }
+}


### PR DESCRIPTION
## Summary

Fix audit P2-08: an explicit Home/Gaming refresh should fetch fresh content instead of returning immediately because the cache TTL has not expired.

- Add an optional `forceRefresh` flag to CachedCollection without changing ordinary automatic-load behavior.
- Pass manual-refresh intent from Home banners/news and Gaming catalog loading.
- Preserve cache timestamps after a failed forced request, including when the existing timestamp is in the future.

## Validation

- `dotnet test tests/p2-08/RefreshIntent.Tests.csproj --no-restore --nologo`: 2/2 passed.
- `dotnet test tests/p2-08-cache/ForcedRefresh.Tests.csproj --no-restore --nologo`: 2/2 passed, using the production cache implementation and SQLite.
- iOS 26.5 simulator and Android API 36 arm64 emulator: four native assertions passed on each platform through actual HomePage/GamingPage and production LoadingService/CachedCollection with disposable SQLite and controlled HTTP. Automatic loads retained the cache; manual refreshes fetched and displayed fresh news/banner/game data.
- The external fixture was then removed, followed by a separate product rebuild/install/launch on each platform. Normal Home/four tabs rendered, with no OneGate app crash observed.
- Final tested source patch SHA-256: `a6465f5ea0d61217456d0cb5b93750c45214aff23d6fd888d8e33f214836fa54`; matched to both native evidence sets before committing.

## Limitations and integration

Controlled native HTTP verifies refresh intent and results, not production-server availability. No signing or chain submission was performed; screenshots/fixtures remain outside the repository and are not attached here, and local passes are not hosted CI results.

Independently based and validated on `master@623603d`; retain the union of solution test entries and rerun validation after integration changes rather than treating this as combined audit validation. Integrating audit P2-09/P2-07 must retain cache identity updates and offline/preference handling as well as forced refresh; update the P2-08-cache linked sources and VersionedItem boundary for P2-09's `ICachedEntity` constraint.
