### PR TITLE
Map dAPI block and transaction queries to NEP-21 types

### DIFF
--- a/OneGateApp.slnx
+++ b/OneGateApp.slnx
@@ -6,4 +6,5 @@
   <Project Path="OneGate.DebugProtocol/OneGate.DebugProtocol.csproj" />
   <Project Path="OneGate.DebugProtocol.Tests/OneGate.DebugProtocol.Tests.csproj" />
   <Project Path="OneGate.Tools/OneGate.Tools.csproj" />
+  <Project Path="tests/p2-13/OneGate.DapiQuery.Tests.csproj" />
 </Solution>

--- a/OneGateApp/Pages/LaunchDAppPage.xaml.dAPI.cs
+++ b/OneGateApp/Pages/LaunchDAppPage.xaml.dAPI.cs
@@ -258,7 +258,8 @@ partial class LaunchDAppPage
     [RpcMethod]
     async Task<JsonObject> GetBlock(JsonValue hashOrIndex)
     {
-        return await rpcClient.RpcSendAsync<JsonObject>("getblock", hashOrIndex, true);
+        JsonObject block = await rpcClient.RpcSendAsync<JsonObject>("getblock", hashOrIndex, true);
+        return DapiQueryResponseMapper.MapBlock(block, protocolSettings.AddressVersion);
     }
 
     [RpcMethod]
@@ -270,7 +271,8 @@ partial class LaunchDAppPage
     [RpcMethod]
     async Task<JsonObject> GetTransaction(UInt256 txid)
     {
-        return await rpcClient.RpcSendAsync<JsonObject>("getrawtransaction", txid, true);
+        JsonObject transaction = await rpcClient.RpcSendAsync<JsonObject>("getrawtransaction", txid, true);
+        return DapiQueryResponseMapper.MapTransaction(transaction, protocolSettings.AddressVersion);
     }
 
     [RpcMethod]

--- a/OneGateApp/Services/RPC/DapiQueryResponseMapper.cs
+++ b/OneGateApp/Services/RPC/DapiQueryResponseMapper.cs
@@ -1,0 +1,62 @@
+using Neo.Wallets;
+using System.Text.Json.Nodes;
+
+namespace NeoOrder.OneGate.Services.RPC;
+
+/// <summary>
+/// Adapts verbose Neo node responses to the NEP-21 query types without changing
+/// the original response or the atomic units used by transaction fees.
+/// </summary>
+static class DapiQueryResponseMapper
+{
+    public static JsonObject MapBlock(JsonObject response, byte addressVersion)
+    {
+        JsonObject result = (JsonObject)response.DeepClone();
+        Rename(result, "previousblockhash", "previousBlockHash");
+        Rename(result, "merkleroot", "merkleRoot");
+        Rename(result, "nextblockhash", "nextBlockHash");
+        Rename(result, "nextconsensus", "nextConsensus");
+        result["nextConsensus"] = result["nextConsensus"]!.GetValue<string>().ToScriptHash(addressVersion).ToString();
+
+        foreach (JsonNode? node in result["tx"]!.AsArray())
+        {
+            JsonObject transaction = node!.AsObject();
+            MapTransactionInPlace(transaction, addressVersion);
+            // Verbose getblock omits this metadata from its nested transactions.
+            transaction["blockHash"] = result["hash"]!.DeepClone();
+            transaction["blockTime"] = result["time"]!.DeepClone();
+            transaction["confirmations"] = result["confirmations"]!.DeepClone();
+        }
+        return result;
+    }
+
+    public static JsonObject MapTransaction(JsonObject response, byte addressVersion)
+    {
+        JsonObject result = (JsonObject)response.DeepClone();
+        MapTransactionInPlace(result, addressVersion);
+        return result;
+    }
+
+    static void MapTransactionInPlace(JsonObject transaction, byte addressVersion)
+    {
+        // Neo RPC serializes these as atomic-unit integer strings, not GAS decimals.
+        Rename(transaction, "sysfee", "systemFee");
+        Rename(transaction, "netfee", "networkFee");
+        Rename(transaction, "validuntilblock", "validUntilBlock");
+        Rename(transaction, "blockhash", "blockHash");
+        Rename(transaction, "blocktime", "blockTime");
+        transaction["sender"] = transaction["sender"]!.GetValue<string>().ToScriptHash(addressVersion).ToString();
+
+        foreach (JsonNode? node in transaction["signers"]!.AsArray())
+        {
+            JsonObject signer = node!.AsObject();
+            Rename(signer, "allowedcontracts", "allowedContracts");
+            Rename(signer, "allowedgroups", "allowedGroups");
+        }
+    }
+
+    static void Rename(JsonObject value, string oldName, string newName)
+    {
+        if (value.Remove(oldName, out JsonNode? node)) value[newName] = node;
+    }
+}

--- a/tests/p2-13/DapiQueryResponseMapperTests.cs
+++ b/tests/p2-13/DapiQueryResponseMapperTests.cs
@@ -1,0 +1,208 @@
+using Neo;
+using Neo.Network.P2P.Payloads;
+using Neo.Wallets;
+using NeoOrder.OneGate.Services.RPC;
+using System.Text.Json.Nodes;
+using Xunit;
+
+namespace OneGate.DapiQuery.Tests;
+
+public class DapiQueryResponseMapperTests
+{
+    static readonly ProtocolSettings Settings = ProtocolSettings.Default;
+    static readonly UInt160 Sender = UInt160.Parse("0x682cca3ebdc66210e5847d7f8115846586079d4a");
+    static readonly UInt160 Consensus = UInt160.Parse("0x112233445566778899aabbccddeeff0011223344");
+    static readonly UInt256 BlockHash = UInt256.Parse("0x1f4d1defa46faa5e7b9b8d3f79a06bec777d7c26c4aa5f6f5899a291daa87c15");
+
+    [Theory]
+    [InlineData(0, 1)]
+    [InlineData(100000000, 12345678)]
+    [InlineData(9007199254740993, long.MaxValue)]
+    public void TransactionConvertsNodeFieldsWithoutScalingOrLosingFeePrecision(long systemFee, long networkFee)
+    {
+        JsonObject rpc = TransactionResponse(systemFee, networkFee);
+        rpc["blockhash"] = BlockHash.ToString();
+        rpc["blocktime"] = 1725000000123L;
+        rpc["confirmations"] = 19;
+        string original = rpc.ToJsonString();
+
+        JsonObject result = DapiQueryResponseMapper.MapTransaction(rpc, Settings.AddressVersion);
+
+        Assert.Equal(systemFee.ToString(System.Globalization.CultureInfo.InvariantCulture), result["systemFee"]!.GetValue<string>());
+        Assert.Equal(networkFee.ToString(System.Globalization.CultureInfo.InvariantCulture), result["networkFee"]!.GetValue<string>());
+        Assert.Equal(Sender.ToString(), result["sender"]!.GetValue<string>());
+        Assert.Equal(123456, result["validUntilBlock"]!.GetValue<int>());
+        Assert.Equal(BlockHash.ToString(), result["blockHash"]!.GetValue<string>());
+        Assert.Equal(1725000000123L, result["blockTime"]!.GetValue<long>());
+        Assert.Equal(19, result["confirmations"]!.GetValue<int>());
+        AssertPreserved(rpc, result, "hash", "size", "version", "nonce", "script", "attributes", "witnesses");
+        AssertMissing(result, "sysfee", "netfee", "validuntilblock", "blockhash", "blocktime");
+        Assert.Equal(original, rpc.ToJsonString());
+    }
+
+    [Fact]
+    public void TransactionConvertsSignerRestrictionsAndPreservesWitnessRules()
+    {
+        JsonObject rpc = TransactionResponse();
+        JsonObject signer = rpc["signers"]![0]!.AsObject();
+        signer["scopes"] = "CustomContracts, CustomGroups, WitnessRules";
+        signer["allowedcontracts"] = new JsonArray(Consensus.ToString());
+        signer["allowedgroups"] = new JsonArray("03b209fd4f53a7170ea4444e0cb0a6bb6a53c2bd016926989cf85f9b0fba17a70c");
+        signer["rules"] = JsonNode.Parse("""[{"action":"Allow","condition":{"type":"CalledByContract","hash":"0x112233445566778899aabbccddeeff0011223344"}}]""");
+        string original = rpc.ToJsonString();
+
+        JsonObject result = DapiQueryResponseMapper.MapTransaction(rpc, Settings.AddressVersion);
+        JsonObject mappedSigner = result["signers"]![0]!.AsObject();
+
+        Assert.True(JsonNode.DeepEquals(signer["allowedcontracts"], mappedSigner["allowedContracts"]));
+        Assert.True(JsonNode.DeepEquals(signer["allowedgroups"], mappedSigner["allowedGroups"]));
+        AssertPreserved(signer, mappedSigner, "account", "scopes", "rules");
+        AssertMissing(mappedSigner, "allowedcontracts", "allowedgroups");
+        Assert.Equal(original, rpc.ToJsonString());
+    }
+
+    [Fact]
+    public void UnconfirmedTransactionDoesNotInventBlockMetadataOrSignerRestrictions()
+    {
+        JsonObject result = DapiQueryResponseMapper.MapTransaction(TransactionResponse(), Settings.AddressVersion);
+
+        AssertMissing(result, "blockHash", "blockTime", "confirmations");
+        AssertMissing(result["signers"]![0]!.AsObject(), "allowedContracts", "allowedGroups");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void BlockMapsHeaderAndEveryTransactionWithParentBlockMetadata(bool hasNextBlock)
+    {
+        JsonObject rpc = BlockResponse();
+        if (hasNextBlock) rpc["nextblockhash"] = BlockHash.ToString();
+        rpc["tx"]!.AsArray().Add(TransactionResponse(9007199254740993, 9));
+        string original = rpc.ToJsonString();
+
+        JsonObject result = DapiQueryResponseMapper.MapBlock(rpc, Settings.AddressVersion);
+
+        Assert.Equal(rpc["previousblockhash"]!.GetValue<string>(), result["previousBlockHash"]!.GetValue<string>());
+        Assert.Equal(rpc["merkleroot"]!.GetValue<string>(), result["merkleRoot"]!.GetValue<string>());
+        Assert.Equal(Consensus.ToString(), result["nextConsensus"]!.GetValue<string>());
+        AssertPreserved(rpc, result, "hash", "size", "version", "time", "nonce", "index", "primary", "confirmations", "witnesses");
+        AssertMissing(result, "previousblockhash", "merkleroot", "nextconsensus", "nextblockhash");
+        if (hasNextBlock)
+            Assert.Equal(BlockHash.ToString(), result["nextBlockHash"]!.GetValue<string>());
+        else
+            AssertMissing(result, "nextBlockHash");
+        Assert.Equal(2, result["tx"]!.AsArray().Count);
+        foreach (JsonNode? node in result["tx"]!.AsArray())
+        {
+            JsonObject tx = node!.AsObject();
+            Assert.Equal(Sender.ToString(), tx["sender"]!.GetValue<string>());
+            Assert.True(JsonNode.DeepEquals(result["hash"], tx["blockHash"]));
+            Assert.True(JsonNode.DeepEquals(result["time"], tx["blockTime"]));
+            Assert.True(JsonNode.DeepEquals(result["confirmations"], tx["confirmations"]));
+            AssertMissing(tx, "sysfee", "netfee", "validuntilblock");
+        }
+        Assert.Equal("9007199254740993", result["tx"]![1]!["systemFee"]!.GetValue<string>());
+        Assert.Equal(original, rpc.ToJsonString());
+    }
+
+    [Fact]
+    public void BlockSupportsAnEmptyTransactionArray()
+    {
+        JsonObject rpc = BlockResponse();
+        rpc["tx"] = new JsonArray();
+
+        JsonObject result = DapiQueryResponseMapper.MapBlock(rpc, Settings.AddressVersion);
+
+        Assert.Empty(result["tx"]!.AsArray());
+    }
+
+    [Fact]
+    public void ReturnedNestedObjectsAreIndependentOfRpcResult()
+    {
+        JsonObject rpc = BlockResponse();
+        string original = rpc.ToJsonString();
+
+        JsonObject result = DapiQueryResponseMapper.MapBlock(rpc, Settings.AddressVersion);
+        result["tx"]![0]!["signers"]![0]!["scopes"] = "Global";
+        result["witnesses"]!.AsArray().Clear();
+
+        Assert.Equal(original, rpc.ToJsonString());
+    }
+
+    [Fact]
+    public void AddressDecodingUsesTheConfiguredAddressVersion()
+    {
+        const byte otherAddressVersion = 0x17;
+        JsonObject rpc = BlockResponse();
+        rpc["nextconsensus"] = Consensus.ToAddress(otherAddressVersion);
+        rpc["tx"]![0]!["sender"] = Sender.ToAddress(otherAddressVersion);
+
+        JsonObject result = DapiQueryResponseMapper.MapBlock(rpc, otherAddressVersion);
+
+        Assert.Equal(Consensus.ToString(), result["nextConsensus"]!.GetValue<string>());
+        Assert.Equal(Sender.ToString(), result["tx"]![0]!["sender"]!.GetValue<string>());
+        Assert.Throws<FormatException>(() => DapiQueryResponseMapper.MapBlock(rpc, Settings.AddressVersion));
+    }
+
+    [Fact]
+    public void InvalidSenderIsRejectedWithoutMutatingRpcResult()
+    {
+        JsonObject rpc = TransactionResponse();
+        rpc["sender"] = "invalid-address";
+        string original = rpc.ToJsonString();
+
+        Assert.Throws<FormatException>(() => DapiQueryResponseMapper.MapTransaction(rpc, Settings.AddressVersion));
+
+        Assert.Equal(original, rpc.ToJsonString());
+    }
+
+    static Transaction Transaction(long systemFee = 100000000, long networkFee = 12345678) => new()
+    {
+        Version = 0,
+        Nonce = 123,
+        SystemFee = systemFee,
+        NetworkFee = networkFee,
+        ValidUntilBlock = 123456,
+        Signers = [new Signer { Account = Sender, Scopes = WitnessScope.CalledByEntry }],
+        Attributes = [],
+        Script = new byte[] { 0x11 },
+        Witnesses = []
+    };
+
+    static JsonObject TransactionResponse(long systemFee = 100000000, long networkFee = 12345678) =>
+        JsonNode.Parse(Transaction(systemFee, networkFee).ToJson(Settings).ToString())!.AsObject();
+
+    static JsonObject BlockResponse()
+    {
+        Block block = new()
+        {
+            Header = new Header
+            {
+                Version = 0,
+                PrevHash = BlockHash,
+                MerkleRoot = BlockHash,
+                Timestamp = 1725000000123,
+                Nonce = ulong.MaxValue,
+                Index = 123000,
+                PrimaryIndex = 0,
+                NextConsensus = Consensus,
+                Witness = new Witness { InvocationScript = ReadOnlyMemory<byte>.Empty, VerificationScript = ReadOnlyMemory<byte>.Empty }
+            },
+            Transactions = [Transaction()]
+        };
+        JsonObject result = JsonNode.Parse(block.ToJson(Settings).ToString())!.AsObject();
+        result["confirmations"] = 19;
+        return result;
+    }
+
+    static void AssertPreserved(JsonObject rpc, JsonObject result, params string[] names)
+    {
+        foreach (string name in names)
+            Assert.True(JsonNode.DeepEquals(rpc[name], result[name]), $"{name} must be preserved");
+    }
+
+    static void AssertMissing(JsonObject result, params string[] names)
+    {
+        foreach (string name in names) Assert.False(result.ContainsKey(name), $"{name} must not be present");
+    }
+}

--- a/tests/p2-13/OneGate.DapiQuery.Tests.csproj
+++ b/tests/p2-13/OneGate.DapiQuery.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Neo" Version="3.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" PrivateAssets="all" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="../../OneGateApp/Services/RPC/DapiQueryResponseMapper.cs" Link="Production/DapiQueryResponseMapper.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../OneGateApp/OneGateApp.csproj"
+                      ReferenceOutputAssembly="false" BuildReference="false"
+                      SkipGetTargetFrameworkProperties="true" />
+  </ItemGroup>
+</Project>

--- a/tests/p2-13/README.md
+++ b/tests/p2-13/README.md
@@ -1,0 +1,63 @@
+# NEP-21 query response regression tests
+
+`getBlock` and `getTransaction` currently expose verbose node RPC JSON. This
+regression harness links the production response mapper without loading MAUI or
+opening a wallet. It uses the application's exact Neo 3.10.0 dependency to
+generate node-shaped block and transaction responses.
+
+## Contract
+
+The mapper takes a `JsonObject` and the configured Neo address version, returning
+a new object. The original RPC result is unchanged. Only these two dAPI query
+methods use the mapper; application logs and invocation results are unchanged.
+
+| Node RPC field | NEP-21 field | Conversion |
+| --- | --- | --- |
+| `sysfee`, `netfee` | `systemFee`, `networkFee` | Preserve atomic-unit integer strings exactly; no GAS scaling |
+| `validuntilblock` | `validUntilBlock` | Preserve numeric value |
+| `blockhash`, `blocktime` | `blockHash`, `blockTime` | Preserve values when supplied by the node |
+| `sender` | `sender` | Decode address to UInt160 with the configured address version |
+| `previousblockhash`, `merkleroot`, `nextblockhash` | `previousBlockHash`, `merkleRoot`, `nextBlockHash` | Preserve hashes; next hash remains optional |
+| `nextconsensus` | `nextConsensus` | Decode address to UInt160 |
+| signer `allowedcontracts`, `allowedgroups` | `allowedContracts`, `allowedGroups` | Preserve arrays |
+
+All transactions nested under `block.tx` are converted, with `blockHash`,
+`blockTime` and `confirmations` taken from the enclosing block. RPC does not add
+these properties to nested transactions. An unconfirmed standalone transaction
+has no mined-block metadata; leave it absent rather than fabricating a block or
+timestamp. Extra node properties, including witnesses, are retained for existing
+clients. Blockchain timestamps remain milliseconds; block nonce remains hex.
+
+For example, `{"sysfee":"100000000","sender":"<N3 address>"}` becomes
+`{"systemFee":"100000000","sender":"0x<40 hex digits>"}`. Clients that relied
+on nonstandard lower-case RPC names should read the NEP-21 names instead.
+
+Invalid addresses and malformed array types are rejected with standard .NET
+format/invalid-operation exceptions; the existing dAPI RPC boundary remains responsible for
+reporting errors. The mapper performs no network access, signing, state changes,
+or caching. Work and additional memory are linear in the response size. No
+configuration changes or database migration are required.
+
+## Sources
+
+- [NEP-21 types](https://github.com/neo-project/proposals/blob/master/nep-21.mediawiki)
+- [Neo 3.10.0 Transaction.ToJson](https://github.com/neo-project/neo/blob/v3.10.0/src/Neo/Network/P2P/Payloads/Transaction.cs)
+- [Neo 3.10.0 Header.ToJson](https://github.com/neo-project/neo/blob/v3.10.0/src/Neo/Network/P2P/Payloads/Header.cs)
+- [Neo 3.10.0 Signer.ToJson](https://github.com/neo-project/neo/blob/v3.10.0/src/Neo/Network/P2P/Payloads/Signer.cs)
+- [RPC block/transaction metadata](https://github.com/neo-project/neo-modules/blob/master/src/RpcServer/RpcServer.Blockchain.cs)
+- [RPC fee serialization](https://github.com/neo-project/neo-modules/blob/master/src/RpcServer/Utility.cs)
+
+## Validation and deployment
+
+```sh
+dotnet test tests/p2-13/OneGate.DapiQuery.Tests.csproj
+dotnet test tests/p2-13/OneGate.DapiQuery.Tests.csproj --collect:"XPlat Code Coverage" --settings tests/p2-13/coverage.runsettings
+```
+
+Before committing, validate on both iOS and Android simulators: in a connected
+DApp call `getBlock` by index and hash, read a nested transaction's camel-case
+properties, then call `getTransaction` for its hash. Compare fee strings,
+sender hashes, block metadata and signer restrictions. Verify the current tip
+does not invent a `nextBlockHash`, and ordinary DApp queries still load normally.
+Keep screenshots and simulator artifacts outside the repository. Deploy through
+the normal OneGate app release after review; the harness is not part of the app.

--- a/tests/p2-13/coverage.runsettings
+++ b/tests/p2-13/coverage.runsettings
@@ -1,0 +1,13 @@
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <IncludeTestAssembly>true</IncludeTestAssembly>
+          <Include>[OneGate.DapiQuery.Tests]NeoOrder.OneGate.Services.RPC.DapiQueryResponseMapper</Include>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
## Summary

Fix audit P2-13: adapt verbose node JSON returned by dAPI `getBlock` and `getTransaction` to the NEP-21 query field names and types.

- Convert node field names to camelCase, and decode sender/next-consensus addresses to script hashes using the configured address version.
- Preserve atomic fee strings exactly, including values above JavaScript's safe-integer range; do not rescale them or round through floating point.
- Convert every nested transaction, supplying metadata from its enclosing block while leaving unconfirmed standalone metadata absent.
- Preserve signer restrictions, witness rules and unrelated response fields, without mutating the source RPC object.

## Validation

- `dotnet test tests/p2-13/OneGate.DapiQuery.Tests.csproj --no-restore --nologo`: 11/11 passed. Fixtures use the application's Neo 3.10.0 serialization.
- iOS 26.5 simulator and Android API 36 arm64 emulator: 12 JavaScript assertions passed on each through the actual injected NEP-21 provider, native BridgeWebView, RpcServer, LaunchDAppPage, RpcClient, mapper and callback. Three responses retained matching IDs and completed real JS promises; the upstream sequence was getrawtransaction/getblock/getrawtransaction. Checks covered exact fees, field names, hashes, signer restrictions, nested metadata and unconfirmed transactions.
- Only upstream HTTP responses were controlled. The external fixture was removed before separate fixture-free product rebuild/install/launch checks on both platforms; normal Home/four tabs rendered with no OneGate app crash observed.
- Final tested source patch SHA-256: `479bae85c68333104a2ca1fffaa0a6d790872d940533765dd9e8b53f08ea785f`; matched to both platform evidence sets before committing.

## Limitations and integration

No live-chain query, signing, approval or broadcast was performed. Clients relying on nonstandard lowercase node fields must use the NEP-21 names; screenshots and QA fixtures remain outside the repository and are not attached here, and no hosted CI pass is claimed.

Independently based and validated on `master@623603d`; preserve solution project entries as a union and revalidate after integration rather than treating this as combined audit validation. This query-mapping change has no dependency on a bridge-origin authorization redesign.
