### PR TITLE
fix: recover transaction confirmation after transient failures

### DIFF
--- a/OneGateApp.slnx
+++ b/OneGateApp.slnx
@@ -6,4 +6,5 @@
   <Project Path="OneGate.DebugProtocol/OneGate.DebugProtocol.csproj" />
   <Project Path="OneGate.DebugProtocol.Tests/OneGate.DebugProtocol.Tests.csproj" />
   <Project Path="OneGate.Tools/OneGate.Tools.csproj" />
+  <Project Path="tests/p2-04/TransactionConfirmation.Tests.csproj" />
 </Solution>

--- a/OneGateApp/Pages/SendingPage.xaml.cs
+++ b/OneGateApp/Pages/SendingPage.xaml.cs
@@ -1,20 +1,17 @@
 using Neo;
 using Neo.Network.P2P.Payloads;
 using Neo.SmartContract.Native;
-using Neo.VM;
 using NeoOrder.OneGate.Models.Intents;
 using NeoOrder.OneGate.Services.RPC;
 using System.Numerics;
-using System.Text.Json;
 using System.Text.Json.Nodes;
 
 namespace NeoOrder.OneGate.Pages;
 
 public partial class SendingPage : ContentPage, IQueryAttributable
 {
-    readonly CancellationTokenSource cancellation = new();
+    CancellationTokenSource? pollingCancellation;
     readonly RpcClient rpcClient;
-    bool isPolling;
 
     public required Transaction Transaction { get; set { field = value; OnPropertyChanged(null); } }
     public required TransactionIntent[] Intents { get; set { field = value; OnPropertyChanged(); } }
@@ -70,71 +67,47 @@ public partial class SendingPage : ContentPage, IQueryAttributable
     protected override void OnAppearing()
     {
         base.OnAppearing();
-        QueryTransactionStatus();
+        _ = QueryTransactionStatusAsync();
     }
 
-    protected override async void OnDisappearing()
+    protected override void OnDisappearing()
     {
         base.OnDisappearing();
-        await cancellation.CancelAsync();
-        cancellation.Dispose();
+        CancellationTokenSource? cancellation = pollingCancellation;
+        pollingCancellation = null;
+        cancellation?.Cancel();
     }
 
-    async void QueryTransactionStatus()
+    async Task QueryTransactionStatusAsync()
     {
-        if (isPolling) return;
+        if (pollingCancellation is not null || Succeeded.HasValue) return;
 
-        isPolling = true;
+        using var cancellation = new CancellationTokenSource();
+        pollingCancellation = cancellation;
         try
         {
             TimedOut = false;
-            for (int i = 0; i < 10; i++)
-            {
-                await Task.Delay(TimeSpan.FromSeconds(15), cancellation.Token);
-                JsonObject tx;
-                try
-                {
-                    tx = await rpcClient.RpcSendAsync<JsonObject>("getrawtransaction", Transaction.Hash, true);
-                }
-                catch (RpcException)
-                {
-                    continue;
-                }
-                ulong? blockTime = tx["blocktime"]?.GetValue<ulong>();
-                if (!blockTime.HasValue) continue;
-                BlockTime = blockTime;
-                Succeeded = await QueryExecutionSucceededAsync();
-                if (Succeeded.HasValue) break;
-            }
-            if (Succeeded is null) TimedOut = true;
+            var poller = new TransactionConfirmation(method => method == "getrawtransaction"
+                ? rpcClient.RpcSendAsync<JsonObject>(method, Transaction.Hash, true)
+                : rpcClient.RpcSendAsync<JsonObject>(method, Transaction.Hash));
+            ConfirmationResult result = await poller.PollAsync(cancellation.Token);
+            cancellation.Token.ThrowIfCancellationRequested();
+            BlockTime = result.BlockTime;
+            Succeeded = result.Succeeded;
+            TimedOut = !Succeeded.HasValue;
         }
         catch (OperationCanceledException)
         {
         }
         finally
         {
-            isPolling = false;
+            if (ReferenceEquals(pollingCancellation, cancellation))
+                pollingCancellation = null;
         }
     }
 
     void OnRetry(object sender, EventArgs e)
     {
-        QueryTransactionStatus();
-    }
-
-    // Block inclusion is not success: a transaction can be included in a block yet revert
-    // (VMState.FAULT). Read the application log and require HALT before reporting success.
-    async Task<bool?> QueryExecutionSucceededAsync()
-    {
-        try
-        {
-            JsonObject log = await rpcClient.RpcSendAsync<JsonObject>("getapplicationlog", Transaction.Hash);
-            JsonNode? execution = log["executions"] is JsonArray executions && executions.Count > 0 ? executions[0] : null;
-            return execution?["vmstate"]?.GetValue<string>() == nameof(VMState.HALT);
-        }
-        catch (Exception ex) when (ex is RpcException or HttpRequestException or JsonException)
-        {
-            return null;
-        }
+        _ = QueryTransactionStatusAsync();
     }
 }

--- a/OneGateApp/Pages/SendingPage.xaml.cs
+++ b/OneGateApp/Pages/SendingPage.xaml.cs
@@ -87,9 +87,9 @@ public partial class SendingPage : ContentPage, IQueryAttributable
         try
         {
             TimedOut = false;
-            var poller = new TransactionConfirmation(method => method == "getrawtransaction"
-                ? rpcClient.RpcSendAsync<JsonObject>(method, Transaction.Hash, true)
-                : rpcClient.RpcSendAsync<JsonObject>(method, Transaction.Hash));
+            var poller = new TransactionConfirmation((method, token) => method == "getrawtransaction"
+                ? rpcClient.RpcSendAsync<JsonObject>(method, token, Transaction.Hash, true)
+                : rpcClient.RpcSendAsync<JsonObject>(method, token, Transaction.Hash));
             ConfirmationResult result = await poller.PollAsync(cancellation.Token);
             cancellation.Token.ThrowIfCancellationRequested();
             BlockTime = result.BlockTime;

--- a/OneGateApp/Services/RPC/RpcClient.cs
+++ b/OneGateApp/Services/RPC/RpcClient.cs
@@ -22,6 +22,9 @@ public class RpcClient(IWalletProvider walletProvider, ProtocolSettings protocol
     readonly HttpClient http = new();
 
     public async Task<T> RpcSendAsync<T>(string method, params object?[] args) where T : notnull
+        => await RpcSendAsync<T>(method, CancellationToken.None, args);
+
+    public async Task<T> RpcSendAsync<T>(string method, CancellationToken cancellationToken, params object?[] args) where T : notnull
     {
         var request = new JsonObject
         {
@@ -34,9 +37,9 @@ public class RpcClient(IWalletProvider walletProvider, ProtocolSettings protocol
         {
             Content = new StringContent(request.ToJsonString(), Utility.StrictUTF8, "application/json")
         };
-        var responseMsg = await http.SendAsync(requestMsg);
+        var responseMsg = await http.SendAsync(requestMsg, cancellationToken);
         responseMsg.EnsureSuccessStatusCode();
-        JsonObject response = (await responseMsg.Content.ReadFromJsonAsync<JsonObject>(SharedOptions.JsonSerializerOptions))!;
+        JsonObject response = (await responseMsg.Content.ReadFromJsonAsync<JsonObject>(SharedOptions.JsonSerializerOptions, cancellationToken))!;
         if (response["error"] is JsonObject error)
         {
             int code = error["code"]!.GetValue<int>();

--- a/OneGateApp/Services/RPC/TransactionConfirmation.cs
+++ b/OneGateApp/Services/RPC/TransactionConfirmation.cs
@@ -1,0 +1,47 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace NeoOrder.OneGate.Services.RPC;
+
+internal sealed class TransactionConfirmation(
+    Func<string, Task<JsonObject>> read,
+    Func<TimeSpan, CancellationToken, Task>? delay = null)
+{
+    public async Task<ConfirmationResult> PollAsync(CancellationToken cancellationToken)
+    {
+        ulong? blockTime = null;
+        for (int attempt = 0; attempt < 10; attempt++)
+        {
+            await (delay ?? Task.Delay)(TimeSpan.FromSeconds(15), cancellationToken);
+            try
+            {
+                JsonObject? tx = await read("getrawtransaction").WaitAsync(cancellationToken);
+                if (tx is null) continue;
+                blockTime = tx["blocktime"]?.GetValue<ulong>();
+                if (!blockTime.HasValue) continue;
+                JsonObject? log = await read("getapplicationlog").WaitAsync(cancellationToken);
+                JsonNode? execution = log?["executions"] is JsonArray executions && executions.Count > 0 ? executions[0] : null;
+                bool? succeeded = execution?["vmstate"]?.GetValue<string>() switch
+                {
+                    "HALT" => true,
+                    "FAULT" => false,
+                    _ => null
+                };
+                if (succeeded.HasValue) return new(blockTime, succeeded);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex) when (ex is RpcException or HttpRequestException or JsonException
+                or OperationCanceledException or InvalidOperationException or FormatException or OverflowException)
+            {
+                // A failed status read says nothing about a transaction already broadcast.
+                // Keep it pending and only retry the read, never the broadcast.
+            }
+        }
+        return new(blockTime, null);
+    }
+}
+
+internal readonly record struct ConfirmationResult(ulong? BlockTime, bool? Succeeded);

--- a/OneGateApp/Services/RPC/TransactionConfirmation.cs
+++ b/OneGateApp/Services/RPC/TransactionConfirmation.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Nodes;
 namespace NeoOrder.OneGate.Services.RPC;
 
 internal sealed class TransactionConfirmation(
-    Func<string, Task<JsonObject>> read,
+    Func<string, CancellationToken, Task<JsonObject>> read,
     Func<TimeSpan, CancellationToken, Task>? delay = null)
 {
     public async Task<ConfirmationResult> PollAsync(CancellationToken cancellationToken)
@@ -15,11 +15,11 @@ internal sealed class TransactionConfirmation(
             await (delay ?? Task.Delay)(TimeSpan.FromSeconds(15), cancellationToken);
             try
             {
-                JsonObject? tx = await read("getrawtransaction").WaitAsync(cancellationToken);
+                JsonObject? tx = await read("getrawtransaction", cancellationToken);
                 if (tx is null) continue;
                 blockTime = tx["blocktime"]?.GetValue<ulong>();
                 if (!blockTime.HasValue) continue;
-                JsonObject? log = await read("getapplicationlog").WaitAsync(cancellationToken);
+                JsonObject? log = await read("getapplicationlog", cancellationToken);
                 JsonNode? execution = log?["executions"] is JsonArray executions && executions.Count > 0 ? executions[0] : null;
                 bool? succeeded = execution?["vmstate"]?.GetValue<string>() switch
                 {

--- a/tests/p2-04/TransactionConfirmation.Tests.csproj
+++ b/tests/p2-04/TransactionConfirmation.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsTestProject>true</IsTestProject>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" PrivateAssets="all" />
+    <Compile Include="../../OneGateApp/Services/RPC/TransactionConfirmation.cs" Link="TransactionConfirmation.cs" />
+    <Compile Include="../../OneGateApp/Services/RPC/RpcException.cs" Link="RpcException.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../OneGateApp/OneGateApp.csproj" ReferenceOutputAssembly="false" BuildReference="false" SkipGetTargetFrameworkProperties="true" />
+  </ItemGroup>
+</Project>

--- a/tests/p2-04/TransactionConfirmationTests.cs
+++ b/tests/p2-04/TransactionConfirmationTests.cs
@@ -16,7 +16,7 @@ public class TransactionConfirmationTests
     {
         int attempts = 0;
         var methods = new List<string>();
-        Task<JsonObject> Read(string method)
+        Task<JsonObject> Read(string method, CancellationToken _)
         {
             methods.Add(method);
             if (method == "getapplicationlog")
@@ -46,7 +46,7 @@ public class TransactionConfirmationTests
     [InlineData("{\"executions\":[{\"vmstate\":\"HALT\"}]}", true)]
     public async Task UnknownExecutionIsPending(string log, bool? expected)
     {
-        var poller = new TransactionConfirmation(method => Task.FromResult(JsonNode.Parse(
+        var poller = new TransactionConfirmation((method, _) => Task.FromResult(JsonNode.Parse(
             method == "getrawtransaction" ? "{\"blocktime\":42}" : log)!.AsObject()), NoDelay);
         var result = await poller.PollAsync(CancellationToken.None);
         Assert.Equal(expected, result.Succeeded);
@@ -55,7 +55,7 @@ public class TransactionConfirmationTests
     [Fact]
     public async Task NullResultRemainsPending()
     {
-        var poller = new TransactionConfirmation(_ => Task.FromResult<JsonObject>(null!), NoDelay);
+        var poller = new TransactionConfirmation((_, _) => Task.FromResult<JsonObject>(null!), NoDelay);
         Assert.Null((await poller.PollAsync(CancellationToken.None)).Succeeded);
     }
 
@@ -63,11 +63,18 @@ public class TransactionConfirmationTests
     public async Task CancelStopsInFlightReadAndAnotherPollCanStart()
     {
         var blocked = new TaskCompletionSource<JsonObject>();
+        CancellationToken observedToken = default;
         using var cancellation = new CancellationTokenSource();
-        var first = new TransactionConfirmation(_ => blocked.Task, NoDelay).PollAsync(cancellation.Token);
+        var first = new TransactionConfirmation((_, token) =>
+        {
+            observedToken = token;
+            token.Register(() => blocked.TrySetCanceled(token));
+            return blocked.Task;
+        }, NoDelay).PollAsync(cancellation.Token);
         cancellation.Cancel();
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => first);
-        var next = new TransactionConfirmation(_ => Task.FromException<JsonObject>(new RpcException(-100, "not found")), NoDelay);
+        Assert.True(observedToken.CanBeCanceled);
+        var next = new TransactionConfirmation((_, _) => Task.FromException<JsonObject>(new RpcException(-100, "not found")), NoDelay);
         Assert.Null((await next.PollAsync(CancellationToken.None)).Succeeded);
     }
 }

--- a/tests/p2-04/TransactionConfirmationTests.cs
+++ b/tests/p2-04/TransactionConfirmationTests.cs
@@ -1,0 +1,73 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using NeoOrder.OneGate.Services.RPC;
+using Xunit;
+
+public class TransactionConfirmationTests
+{
+    static Task NoDelay(TimeSpan _, CancellationToken token)
+    {
+        token.ThrowIfCancellationRequested();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task NetworkAndPayloadErrorsRecoverWithoutBroadcasting()
+    {
+        int attempts = 0;
+        var methods = new List<string>();
+        Task<JsonObject> Read(string method)
+        {
+            methods.Add(method);
+            if (method == "getapplicationlog")
+                return Task.FromResult(JsonNode.Parse("{\"executions\":[{\"vmstate\":\"HALT\"}]}")!.AsObject());
+            return ++attempts switch
+            {
+                1 => Task.FromException<JsonObject>(new HttpRequestException("offline")),
+                2 => Task.FromException<JsonObject>(new HttpRequestException("502")),
+                3 => Task.FromException<JsonObject>(new JsonException("invalid JSON")),
+                4 => Task.FromException<JsonObject>(new TaskCanceledException("HTTP timeout")),
+                5 => Task.FromResult(JsonNode.Parse("{\"blocktime\":{}}")!.AsObject()),
+                _ => Task.FromResult(JsonNode.Parse("{\"blocktime\":42}")!.AsObject())
+            };
+        }
+        var result = await new TransactionConfirmation(Read, NoDelay).PollAsync(CancellationToken.None);
+        Assert.True(result.Succeeded);
+        Assert.Equal(42UL, result.BlockTime);
+        Assert.Equal(6, attempts);
+        Assert.DoesNotContain("sendrawtransaction", methods);
+    }
+
+    [Theory]
+    [InlineData("{}", null)]
+    [InlineData("{\"executions\":[]}", null)]
+    [InlineData("{\"executions\":[{\"vmstate\":\"BREAK\"}]}", null)]
+    [InlineData("{\"executions\":[{\"vmstate\":\"FAULT\"}]}", false)]
+    [InlineData("{\"executions\":[{\"vmstate\":\"HALT\"}]}", true)]
+    public async Task UnknownExecutionIsPending(string log, bool? expected)
+    {
+        var poller = new TransactionConfirmation(method => Task.FromResult(JsonNode.Parse(
+            method == "getrawtransaction" ? "{\"blocktime\":42}" : log)!.AsObject()), NoDelay);
+        var result = await poller.PollAsync(CancellationToken.None);
+        Assert.Equal(expected, result.Succeeded);
+    }
+
+    [Fact]
+    public async Task NullResultRemainsPending()
+    {
+        var poller = new TransactionConfirmation(_ => Task.FromResult<JsonObject>(null!), NoDelay);
+        Assert.Null((await poller.PollAsync(CancellationToken.None)).Succeeded);
+    }
+
+    [Fact]
+    public async Task CancelStopsInFlightReadAndAnotherPollCanStart()
+    {
+        var blocked = new TaskCompletionSource<JsonObject>();
+        using var cancellation = new CancellationTokenSource();
+        var first = new TransactionConfirmation(_ => blocked.Task, NoDelay).PollAsync(cancellation.Token);
+        cancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => first);
+        var next = new TransactionConfirmation(_ => Task.FromException<JsonObject>(new RpcException(-100, "not found")), NoDelay);
+        Assert.Null((await next.PollAsync(CancellationToken.None)).Succeeded);
+    }
+}


### PR DESCRIPTION
## Summary

Fix audit P2-04: leaving the Sending page now cancels the underlying transaction-confirmation HTTP request instead of only cancelling an outer wait.

- Add a cancellation-aware `RpcSendAsync` overload and pass the token to `HttpClient.SendAsync` and JSON body deserialization.
- Thread the page cancellation token through `TransactionConfirmation` reads for both transaction and application-log polling.
- Keep the existing no-argument RPC API and broadcast behavior unchanged.
- Add regression coverage proving an in-flight read observes the cancellation token and terminates promptly.

## Validation

- `dotnet test tests/p2-04/TransactionConfirmation.Tests.csproj --no-restore --nologo`: 8/8 passed.
- iOS simulator: `OneGateApp` rebuilt for `net10.0-ios`, installed and launched on the iPhone 17 simulator; normal welcome UI displayed.
- Android API 36 `onegate_api36` emulator: self-contained APK rebuilt with `EmbedAssembliesIntoApk=true`, installed and launched directly through the resolved MAUI `MainActivity`; normal welcome UI displayed.
- Screenshots and device logs are outside the repository under `/tmp`.

The cancellation regression is covered by the focused test project; simulator validation exercised the resulting production app startup on both platforms. No wallet signing, game play, or chain submission was performed.

This PR remains independently based on `master@623603d`; no historical Erik-rejected approach or STOP item was changed.
