### PR TITLE
fix: isolate search loading failures by result group

### DIFF
--- a/OneGateApp.slnx
+++ b/OneGateApp.slnx
@@ -6,4 +6,5 @@
   <Project Path="OneGate.DebugProtocol/OneGate.DebugProtocol.csproj" />
   <Project Path="OneGate.DebugProtocol.Tests/OneGate.DebugProtocol.Tests.csproj" />
   <Project Path="OneGate.Tools/OneGate.Tools.csproj" />
+  <Project Path="tests/p2-10/SearchAvailability.Tests.csproj" />
 </Solution>

--- a/OneGateApp/Pages/GlobalSearchPage.xaml
+++ b/OneGateApp/Pages/GlobalSearchPage.xaml
@@ -18,6 +18,12 @@
             <ActivityIndicator IsRunning="{Binding LoadingService.IsLoading}"
                                IsVisible="{Binding LoadingService.IsLoading}"
                                HorizontalOptions="Center" />
+            <Border StyleClass="Card" IsVisible="{Binding HasSearchErrors}">
+                <VerticalStackLayout Spacing="8">
+                    <Label StyleClass="Secondary" Text="{Binding SearchErrorText}" />
+                    <Button Text="{x:Static og:Strings.Retry}" Command="{Binding LoadingService}" />
+                </VerticalStackLayout>
+            </Border>
             <Border StyleClass="Card" IsVisible="{Binding IsEmpty}">
                 <Label StyleClass="Secondary"
                        Text="{x:Static og:Strings.DefaultEmptyViewMessage}"

--- a/OneGateApp/Pages/GlobalSearchPage.xaml.cs
+++ b/OneGateApp/Pages/GlobalSearchPage.xaml.cs
@@ -36,7 +36,19 @@ public partial class GlobalSearchPage : ContentPage
     } = [];
     public bool HasResults => Results.Length > 0;
     public bool HasQuery => !string.IsNullOrWhiteSpace(query);
-    public bool IsEmpty => HasQuery && !LoadingService.IsLoading && Results.Length == 0;
+    public bool IsEmpty => HasQuery && !LoadingService.IsLoading && !HasSearchErrors && Results.Length == 0;
+    public bool HasSearchErrors => !string.IsNullOrEmpty(SearchErrorText);
+    public string SearchErrorText
+    {
+        get;
+        private set
+        {
+            field = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(HasSearchErrors));
+            OnPropertyChanged(nameof(IsEmpty));
+        }
+    } = "";
 
     public GlobalSearchPage(IServiceProvider serviceProvider, ApplicationDbContext dbContext, TokenManager tokenManager)
     {
@@ -63,26 +75,85 @@ public partial class GlobalSearchPage : ContentPage
 
     async Task LoadSearchDataAsync()
     {
+        SearchErrorText = "";
+        // Settings are part of the discovery boundary. A prior developer-mode
+        // index cannot remain usable while settings are unavailable or pending.
+        dappIndex = [];
+        UpdateResults();
+        await LoadSearchGroupAsync(async () =>
+        {
+            contactIndex = (await dbContext.Contacts.AsNoTracking().ToArrayAsync())
+                .Select(p => new GlobalSearchIndex<Contact>(p, p.Label, p.Address))
+                .ToArray();
+        }, Strings.AddressBook);
+
+        // Read settings before starting network work: TokenManager also uses the
+        // application DbContext, which must not run concurrent database queries.
+        List<int> recentDAppIds = [];
+        bool developerModeEnabled = false;
+        bool catalogSettingsLoaded = false;
+        await LoadSearchGroupAsync(async () =>
+        {
+            recentDAppIds = await dbContext.Settings.GetAsync<List<int>>("dapps/recent") ?? [];
+            developerModeEnabled = await DAppCatalogPolicy.GetDeveloperModeEnabledAsync(dbContext);
+            catalogSettingsLoaded = true;
+        }, Strings.Apps);
+
+        await Task.WhenAll(
+            LoadSearchGroupAsync(LoadSearchAssetsAsync, Strings.Asset),
+            catalogSettingsLoaded
+                ? LoadSearchGroupAsync(() => LoadSearchDAppsAsync(recentDAppIds, developerModeEnabled), Strings.Apps)
+                : Task.CompletedTask);
+    }
+
+    async Task LoadSearchGroupAsync(Func<Task> load, string group)
+    {
+        try
+        {
+            await load();
+        }
+        catch (Exception)
+        {
+            string message = $"{group}: {Strings.Unavailable}";
+            SearchErrorText = string.IsNullOrEmpty(SearchErrorText)
+                ? message
+                : $"{SearchErrorText}{Environment.NewLine}{message}";
+        }
+        finally
+        {
+            UpdateResults();
+        }
+    }
+
+    async Task LoadSearchAssetsAsync()
+    {
         IReadOnlyList<AssetInfo> assets = await tokenManager.LoadAssetsAsync();
         assetIndex = assets
             .Select(p => new GlobalSearchIndex<AssetInfo>(p, p.Token.Symbol, p.Token.Name, p.Token.Hash.ToString()))
             .ToArray();
-        contactIndex = (await dbContext.Contacts.AsNoTracking().ToArrayAsync())
-            .Select(p => new GlobalSearchIndex<Contact>(p, p.Label, p.Address))
-            .ToArray();
-        List<int> recentDAppIds = await dbContext.Settings.GetAsync<List<int>>("dapps/recent") ?? [];
-        bool developerModeEnabled = await DAppCatalogPolicy.GetDeveloperModeEnabledAsync(dbContext);
-        await DApps.LoadAsync("/api/dapps", TimeSpan.FromDays(1));
-        dappIndex = DApps
-            .Where(p => p.IsRegularApp && DAppCatalogPolicy.IsDiscoverable(p, developerModeEnabled))
-            .Select(p => new GlobalSearchIndex<DApp>(
-                p,
-                recentDAppIds.IndexOf(p.Id),
-                p.NameLocalizer.Localize(),
-                p.DescriptionLocalizer?.Localize(),
-                p.Url,
-                p.Tags is null ? null : string.Join(' ', p.Tags.Select(DApp.LocalizeTag))))
-            .ToArray();
+    }
+
+    async Task LoadSearchDAppsAsync(List<int> recentDAppIds, bool developerModeEnabled)
+    {
+        try
+        {
+            await DApps.LoadAsync("/api/dapps", TimeSpan.FromDays(1));
+        }
+        finally
+        {
+            // CachedCollection has already loaded disk data even when refreshing
+            // the network fails. Keep those usable results alongside the error.
+            dappIndex = DApps
+                .Where(p => p.IsRegularApp && DAppCatalogPolicy.IsDiscoverable(p, developerModeEnabled))
+                .Select(p => new GlobalSearchIndex<DApp>(
+                    p,
+                    recentDAppIds.IndexOf(p.Id),
+                    p.NameLocalizer.Localize(),
+                    p.DescriptionLocalizer?.Localize(),
+                    p.Url,
+                    p.Tags is null ? null : string.Join(' ', p.Tags.Select(DApp.LocalizeTag))))
+                .ToArray();
+        }
     }
 
     void OnLoaded(object? sender, EventArgs e)
@@ -173,6 +244,7 @@ public partial class GlobalSearchPage : ContentPage
                 });
                 break;
             case GlobalSearchResultType.DApp:
+                if (!dappIndex.Any(p => ReferenceEquals(p.Item, result.DApp))) return;
                 await Commands.LaunchDApp.ExecuteAsync(result.DApp!);
                 break;
         }

--- a/tests/p2-10/SearchAvailability.Tests.csproj
+++ b/tests/p2-10/SearchAvailability.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsTestProject>true</IsTestProject>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" PrivateAssets="all" />
+    <Compile Include="../../OneGateApp/Pages/GlobalSearchPage.xaml.cs" Link="GlobalSearchPage.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- App relationship only; linked-source tests run without MAUI workloads. -->
+    <ProjectReference Include="../../OneGateApp/OneGateApp.csproj"
+                      ReferenceOutputAssembly="false" BuildReference="false"
+                      SkipGetTargetFrameworkProperties="true" />
+  </ItemGroup>
+</Project>

--- a/tests/p2-10/SearchAvailabilityTests.cs
+++ b/tests/p2-10/SearchAvailabilityTests.cs
@@ -1,0 +1,136 @@
+using NeoOrder.OneGate.Data;
+using NeoOrder.OneGate.Models;
+using NeoOrder.OneGate.Pages;
+using NeoOrder.OneGate.Services;
+using Xunit;
+
+public class SearchAvailabilityTests
+{
+    [Fact]
+    public async Task SettingsFailureDropsOldAppIndexAndRetryRebuildsWithCurrentPolicy()
+    {
+        var catalog = new CachedCollection<DApp> { new() { Name = "Find developer", IsInDevelopment = true }, new() { Name = "Find safe" } };
+        var database = new ApplicationDbContext();
+        database.Settings.Values["developer"] = true;
+        database.Contacts.Add(new() { Label = "Find contact" });
+        var page = new GlobalSearchPage(new TestServices(catalog), database, new());
+        page.ChangeQueryForTest("Find");
+        await page.LoadForTestAsync();
+        Assert.Equal(3, page.Results.Length);
+        GlobalSearchResult stale = page.Results.Single(p => p.DApp?.IsInDevelopment == true);
+        database.Settings.Failure = new IOException("settings unavailable");
+        await page.LoadForTestAsync();
+        Assert.DoesNotContain(page.Results, p => p.Type == GlobalSearchResultType.DApp);
+        Assert.Contains(page.Results, p => p.Type == GlobalSearchResultType.Contact);
+        Assert.True(page.HasSearchErrors);
+        Commands.LaunchDApp.Last = null;
+        await page.OpenForTestAsync(stale);
+        Assert.Null(Commands.LaunchDApp.Last);
+        database.Settings.Failure = null;
+        database.Settings.Values["developer"] = false;
+        await page.LoadForTestAsync();
+        Assert.False(page.HasSearchErrors);
+        Assert.Equal(2, page.Results.Length);
+        Assert.DoesNotContain(page.Results, p => p.Title == "Find developer");
+    }
+
+    [Fact]
+    public async Task SettingsPendingCannotExposePreviousDeveloperIndex()
+    {
+        var catalog = new CachedCollection<DApp> { new() { Name = "Find developer", IsInDevelopment = true } };
+        var database = new ApplicationDbContext();
+        database.Settings.Values["developer"] = true;
+        var page = new GlobalSearchPage(new TestServices(catalog), database, new());
+        page.ChangeQueryForTest("Find"); await page.LoadForTestAsync(); Assert.Single(page.Results);
+        var blocked = new TaskCompletionSource(); database.Settings.BeforeRead = () => blocked.Task;
+        Task load = page.LoadForTestAsync();
+        try { Assert.Empty(page.Results); }
+        finally { blocked.SetResult(); await load; }
+    }
+
+    [Fact]
+    public async Task AssetFailureDoesNotHideLocalContactsOrApplications()
+    {
+        var catalog = new CachedCollection<DApp> { new() { Name = "Find application" } };
+        var database = new ApplicationDbContext();
+        database.Contacts.Add(new() { Label = "Find contact" });
+        var tokens = new TokenManager { Load = () => throw new HttpRequestException("RPC unavailable") };
+        var page = new GlobalSearchPage(new TestServices(catalog), database, tokens);
+        page.ChangeQueryForTest("Find");
+
+        await page.LoadForTestAsync();
+
+        Assert.Equal(2, page.Results.Length);
+        Assert.Contains(page.Results, result => result.Type == GlobalSearchResultType.Contact);
+        Assert.Contains(page.Results, result => result.Type == GlobalSearchResultType.DApp);
+    }
+
+    [Fact]
+    public async Task LocalResultsAppearWhileAssetRequestIsStillPending()
+    {
+        var pendingAssets = new TaskCompletionSource<IReadOnlyList<AssetInfo>>();
+        var catalog = new CachedCollection<DApp> { new() { Name = "Find application" } };
+        var database = new ApplicationDbContext();
+        database.Contacts.Add(new() { Label = "Find contact" });
+        var page = new GlobalSearchPage(new TestServices(catalog), database, new() { Load = () => pendingAssets.Task });
+        page.ChangeQueryForTest("Find");
+
+        Task load = page.LoadForTestAsync();
+        try
+        {
+            Assert.Contains(page.Results, result => result.Type == GlobalSearchResultType.Contact);
+            Assert.Contains(page.Results, result => result.Type == GlobalSearchResultType.DApp);
+        }
+        finally
+        {
+            pendingAssets.SetResult([]);
+            await load;
+        }
+    }
+
+    [Fact]
+    public async Task CatalogFailureRetainsCachedDAppsAndOtherGroups()
+    {
+        var catalog = new CachedCollection<DApp> { new() { Name = "Find cached application" } };
+        catalog.Load = () => throw new HttpRequestException("Catalog unavailable");
+        var page = new GlobalSearchPage(new TestServices(catalog), new(), new() { Load = () => Task.FromResult<IReadOnlyList<AssetInfo>>([new()]) });
+
+        await page.LoadForTestAsync();
+        page.ChangeQueryForTest("Find");
+        page.Dispatcher.Flush();
+        Assert.Single(page.Results);
+        page.ChangeQueryForTest("NEO");
+        page.Dispatcher.Flush();
+        Assert.Single(page.Results);
+    }
+
+    [Fact]
+    public async Task FailedGroupsDoNotPretendToBeAnEmptySuccessfulSearch()
+    {
+        var catalog = new CachedCollection<DApp> { Load = () => throw new HttpRequestException() };
+        var page = new GlobalSearchPage(new TestServices(catalog), new(), new() { Load = () => throw new HttpRequestException() });
+        page.ChangeQueryForTest("anything");
+
+        await page.LoadForTestAsync();
+
+        Assert.Empty(page.Results);
+        Assert.False(page.IsEmpty);
+        Assert.True(page.HasSearchErrors);
+    }
+
+    [Fact]
+    public async Task RetryClearsErrorsAndSuccessfulNoMatchesShowsEmptyState()
+    {
+        var tokens = new TokenManager { Load = () => throw new HttpRequestException() };
+        var page = new GlobalSearchPage(new TestServices(new()), new(), tokens);
+        page.ChangeQueryForTest("missing");
+        await page.LoadForTestAsync();
+        Assert.True(page.HasSearchErrors);
+
+        tokens.Load = () => Task.FromResult<IReadOnlyList<AssetInfo>>([]);
+        await page.LoadForTestAsync();
+
+        Assert.False(page.HasSearchErrors);
+        Assert.True(page.IsEmpty);
+    }
+}

--- a/tests/p2-10/TestBoundary.cs
+++ b/tests/p2-10/TestBoundary.cs
@@ -1,0 +1,131 @@
+// Only native UI, persistence, and network boundaries are substituted. The page
+// source linked by this project contains the production search/event logic.
+using NeoOrder.OneGate.Data;
+using NeoOrder.OneGate.Models;
+
+public class ContentPage
+{
+    public TestDispatcher Dispatcher { get; } = new();
+    protected virtual void OnAppearing() { }
+    protected void OnPropertyChanged(string? property = null) { }
+}
+public class TestDispatcher
+{
+    readonly List<Action> actions = [];
+    public void DispatchDelayed(TimeSpan delay, Action action) => actions.Add(action);
+    public void Flush() { Action[] pending = [.. actions]; actions.Clear(); foreach (Action action in pending) action(); }
+}
+public class TextChangedEventArgs(string? text) : EventArgs { public string? NewTextValue => text; }
+public class TappedEventArgs : EventArgs { public object? Parameter { get; set; } }
+public class TestSearchBar { public bool Focus() => true; public void Unfocus() { } }
+public class Shell
+{
+    public static Shell Current { get; } = new();
+    public Task GoToAsync(string route, Dictionary<string, object> args) => Task.CompletedTask;
+}
+public class TestServices(CachedCollection<DApp> catalog) : IServiceProvider
+{
+    public object? GetService(Type type) => type == typeof(CachedCollection<DApp>) ? catalog : null;
+}
+namespace Microsoft.EntityFrameworkCore
+{
+    public static class QueryExtensions
+    {
+        public static IEnumerable<T> AsNoTracking<T>(this IEnumerable<T> source) => source;
+        public static Task<T[]> ToArrayAsync<T>(this IEnumerable<T> source) => Task.FromResult(source.ToArray());
+    }
+}
+namespace NeoOrder.OneGate.Data
+{
+    public class ApplicationDbContext
+    {
+        public TestSettings Settings { get; } = new();
+        public List<Contact> Contacts { get; } = [];
+    }
+    public class TestSettings
+    {
+        public Dictionary<string, object> Values { get; } = [];
+        public Exception? Failure { get; set; }
+        public Func<Task>? BeforeRead { get; set; }
+        public async Task<T?> GetAsync<T>(string key) where T : notnull
+        {
+            if (BeforeRead is not null) await BeforeRead();
+            if (Failure is not null) throw Failure;
+            return Values.TryGetValue(key, out object? value) ? (T)value : default;
+        }
+    }
+    public class Contact { public string Label { get; set; } = ""; public string Address { get; set; } = ""; }
+    public class DApp
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+        public bool IsRegularApp { get; set; } = true;
+        public bool IsInDevelopment { get; set; }
+        public string Url { get; set; } = "https://example.com";
+        public string? IconUrl { get; set; }
+        public string[]? Tags { get; set; }
+        public Dictionary<string, string> NameLocalizer => new() { ["en"] = Name };
+        public Dictionary<string, string>? DescriptionLocalizer => null;
+        public static string LocalizeTag(string tag) => tag;
+    }
+}
+namespace NeoOrder.OneGate.Models
+{
+    public class CachedCollection<T> : List<T>
+    {
+        public Func<Task> Load { get; set; } = () => Task.CompletedTask;
+        public Task LoadAsync(string url, TimeSpan ttl) => Load();
+    }
+    public class AssetInfo { public Token Token { get; } = new(); public string DisplayBalance => "0"; }
+    public class Token { public string Symbol => "NEO"; public string Name => "Neo"; public string Hash => "hash"; public string? Icon => null; }
+}
+namespace NeoOrder.OneGate.Services
+{
+    public class TokenManager { public Func<Task<IReadOnlyList<AssetInfo>>> Load { get; set; } = () => Task.FromResult<IReadOnlyList<AssetInfo>>([]); public Task<IReadOnlyList<AssetInfo>> LoadAssetsAsync() => Load(); }
+    public class LoadingService(Func<Task> action)
+    {
+        public event EventHandler? Loaded;
+        public event System.ComponentModel.PropertyChangedEventHandler? PropertyChanged;
+        public bool IsLoading => false;
+        public async void BeginLoad() { await action(); Loaded?.Invoke(this, EventArgs.Empty); PropertyChanged?.Invoke(this, new(nameof(IsLoading))); }
+    }
+    public static class DAppCatalogPolicy
+    {
+        public static Task<bool> GetDeveloperModeEnabledAsync(ApplicationDbContext context) => context.Settings.GetAsync<bool>("developer");
+        public static bool IsDiscoverable(DApp app, bool developerMode) => !app.IsInDevelopment || developerMode;
+    }
+    public static class Extensions
+    {
+        public static T GetServiceOrCreateInstance<T>(this IServiceProvider services) => (T)services.GetService(typeof(T))!;
+        public static bool ShouldRefresh(this ContentPage page) => false;
+        public static string? Localize(this Dictionary<string, string> value) => value.Values.FirstOrDefault();
+    }
+}
+namespace NeoOrder.OneGate.Properties
+{
+    public static class Strings
+    {
+        public static string Asset => "Asset";
+        public static string AddressBook => "Address book";
+        public static string Apps => "Apps";
+        public static string Unavailable => "Unavailable";
+    }
+}
+namespace NeoOrder.OneGate.Pages
+{
+    public static class Commands { public static TestCommand LaunchDApp { get; } = new(); }
+    public class TestCommand
+    {
+        public DApp? Last { get; set; }
+        public Task ExecuteAsync(DApp app) { Last = app; return Task.CompletedTask; }
+    }
+    public partial class GlobalSearchPage
+    {
+        readonly TestSearchBar searchBar = new();
+        void InitializeComponent() { }
+        public async Task LoadForTestAsync() { await LoadSearchDataAsync(); OnLoaded(this, EventArgs.Empty); }
+        public void ChangeQueryForTest(string text) => OnSearchTextChanged(this, new(text));
+        public void ConfirmForTest() => OnSearchButtonPressed(this, EventArgs.Empty);
+        public Task OpenForTestAsync(GlobalSearchResult result) => OpenResultAsync(result);
+    }
+}


### PR DESCRIPTION
## Summary

Fix audit P2-10: keep usable search groups available when another data source is slow or fails.

- Publish contacts/settings before independent asset/catalog network loading. Serialize shared DbContext reads rather than starting competing database queries.
- Report group-level failures with retry; rebuild results after each group, including already-cached catalog data after a refresh failure.
- Clear old DApp search entries while discovery settings are pending/unreadable, and reject stale DApp taps. Do not let an old developer index remain accessible after settings failure.

## Validation before commit

- 7 local regression tests exercise production search loading with controlled boundaries.
- **iOS 26.5 and Android API 36 ARM64: 8/8 native assertions on each**, running the real GlobalSearchPage, disposable SQLite contacts/catalog, production token/RPC loading, controlled HTTP and actual EF settings-read failure interception.
- Verified local results while RPC is pending, RPC/price/catalog failures isolated from usable groups, cached catalog availability, fail-closed settings behavior and recovery using the current policy. The actual search UI displayed the expected local contact and catalog app.
- Both platforms then passed fixture-free full product Rebuild/install/startup smoke. No OneGate app crash observed; Android's device-wide log contains unrelated system Bluetooth crashes and is not described as empty.
- Source patch SHA-256: `89333059895d1e7ad950b82805175ce37a3ca56fa71ef691a40ff65dd9e3d75b`. No signing or chain broadcasts. Screenshots and QA fixture stay outside the repository; no upload is claimed.

## Integration

Independently validated on master `623603d634f07eaead14745da87920a356159be0`. Coordinate with P2-12's preference filtering and [P2-11 / #109](https://github.com/neoorder/OneGateApp/pull/109): preserve fail-closed policy, partial error/retry behavior, and immediate-Enter current-query handling. Adapt linked-source test boundaries to the combined page and rerun all three suites/native flows. Preserve the solution-project union. No combined 25-PR validation is claimed.
