### PR TITLE
Apply content preferences to global search

### DIFF
--- a/OneGateApp.slnx
+++ b/OneGateApp.slnx
@@ -6,4 +6,5 @@
   <Project Path="OneGate.DebugProtocol/OneGate.DebugProtocol.csproj" />
   <Project Path="OneGate.DebugProtocol.Tests/OneGate.DebugProtocol.Tests.csproj" />
   <Project Path="OneGate.Tools/OneGate.Tools.csproj" />
+  <Project Path="tests/p2-12/SearchContentPolicy.Tests.csproj" />
 </Solution>

--- a/OneGateApp/Pages/ContentSettingsPage.xaml.cs
+++ b/OneGateApp/Pages/ContentSettingsPage.xaml.cs
@@ -84,6 +84,7 @@ public partial class ContentSettingsPage : ContentPage
         GlobalStates.Invalidate<SettingsPage>();
         GlobalStates.Invalidate<DAppsPage>();
         GlobalStates.Invalidate<GamingPage>();
+        GlobalStates.Invalidate<GlobalSearchPage>();
     }
 
     void SetSwitchWithoutSaving(bool value)

--- a/OneGateApp/Pages/GlobalSearchPage.xaml.cs
+++ b/OneGateApp/Pages/GlobalSearchPage.xaml.cs
@@ -15,6 +15,8 @@ public partial class GlobalSearchPage : ContentPage
     readonly TokenManager tokenManager;
 
     bool hasLoaded;
+    bool allowRestrictedContent;
+    bool developerModeEnabled;
     int searchVersion;
     string query = "";
     IReadOnlyList<GlobalSearchIndex<AssetInfo>> assetIndex = [];
@@ -63,18 +65,43 @@ public partial class GlobalSearchPage : ContentPage
 
     async Task LoadSearchDataAsync()
     {
-        IReadOnlyList<AssetInfo> assets = await tokenManager.LoadAssetsAsync();
-        assetIndex = assets
-            .Select(p => new GlobalSearchIndex<AssetInfo>(p, p.Token.Symbol, p.Token.Name, p.Token.Hash.ToString()))
-            .ToArray();
-        contactIndex = (await dbContext.Contacts.AsNoTracking().ToArrayAsync())
-            .Select(p => new GlobalSearchIndex<Contact>(p, p.Label, p.Address))
-            .ToArray();
-        List<int> recentDAppIds = await dbContext.Settings.GetAsync<List<int>>("dapps/recent") ?? [];
-        bool developerModeEnabled = await DAppCatalogPolicy.GetDeveloperModeEnabledAsync(dbContext);
-        await DApps.LoadAsync("/api/dapps", TimeSpan.FromDays(1));
+        hasLoaded = false;
+        // Previously permitted results must not stay actionable while preferences
+        // are being re-read, or if a later balance/catalog request fails.
+        allowRestrictedContent = false;
+        developerModeEnabled = false;
+        dappIndex = dappIndex.Where(p => DAppCatalogPolicy.IsVisible(p.Item, false, false)).ToArray();
+        UpdateResults();
+        List<int> recentDAppIds = [];
+        try
+        {
+            bool allow = await DAppCatalogPolicy.GetAllowRestrictedContentAsync(dbContext);
+            bool developer = await DAppCatalogPolicy.GetDeveloperModeEnabledAsync(dbContext);
+            allowRestrictedContent = allow;
+            developerModeEnabled = developer;
+            RebuildDAppIndex(recentDAppIds);
+            UpdateResults();
+            IReadOnlyList<AssetInfo> assets = await tokenManager.LoadAssetsAsync();
+            assetIndex = assets
+                .Select(p => new GlobalSearchIndex<AssetInfo>(p, p.Token.Symbol, p.Token.Name, p.Token.Hash.ToString()))
+                .ToArray();
+            contactIndex = (await dbContext.Contacts.AsNoTracking().ToArrayAsync())
+                .Select(p => new GlobalSearchIndex<Contact>(p, p.Label, p.Address))
+                .ToArray();
+            recentDAppIds = await dbContext.Settings.GetAsync<List<int>>("dapps/recent") ?? [];
+            await DApps.LoadAsync("/api/dapps", TimeSpan.FromDays(1));
+        }
+        finally
+        {
+            RebuildDAppIndex(recentDAppIds);
+            UpdateResults();
+        }
+    }
+
+    void RebuildDAppIndex(List<int> recentDAppIds)
+    {
         dappIndex = DApps
-            .Where(p => p.IsRegularApp && DAppCatalogPolicy.IsDiscoverable(p, developerModeEnabled))
+            .Where(p => p.IsRegularApp && DAppCatalogPolicy.IsVisible(p, allowRestrictedContent, developerModeEnabled))
             .Select(p => new GlobalSearchIndex<DApp>(
                 p,
                 recentDAppIds.IndexOf(p.Id),
@@ -173,6 +200,8 @@ public partial class GlobalSearchPage : ContentPage
                 });
                 break;
             case GlobalSearchResultType.DApp:
+                if (!DAppCatalogPolicy.IsVisible(result.DApp!, allowRestrictedContent, developerModeEnabled)
+                    || !dappIndex.Any(p => ReferenceEquals(p.Item, result.DApp))) return;
                 await Commands.LaunchDApp.ExecuteAsync(result.DApp!);
                 break;
         }

--- a/tests/p2-12/SearchContentPolicy.Tests.csproj
+++ b/tests/p2-12/SearchContentPolicy.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <DefineConstants>ANDROID</DefineConstants>
+    <IsTestProject>true</IsTestProject>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" PrivateAssets="all" />
+    <Compile Include="../../OneGateApp/Pages/GlobalSearchPage.xaml.cs" Link="GlobalSearchPage.cs" />
+    <Compile Include="../../OneGateApp/Services/DAppCatalogPolicy.cs" Link="DAppCatalogPolicy.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- App relationship only; linked-source tests run without MAUI workloads. -->
+    <ProjectReference Include="../../OneGateApp/OneGateApp.csproj"
+                      ReferenceOutputAssembly="false" BuildReference="false"
+                      SkipGetTargetFrameworkProperties="true" />
+  </ItemGroup>
+</Project>

--- a/tests/p2-12/SearchContentPolicyTests.cs
+++ b/tests/p2-12/SearchContentPolicyTests.cs
@@ -1,0 +1,86 @@
+using NeoOrder.OneGate.Data;
+using NeoOrder.OneGate.Models;
+using NeoOrder.OneGate.Pages;
+using NeoOrder.OneGate.Services;
+using Xunit;
+
+public class SearchContentPolicyTests
+{
+    [Theory]
+    [InlineData("asset")]
+    [InlineData("catalog")]
+    [InlineData("settings")]
+    public async Task TightenedPreferencesRemoveOldResultsEvenWhenReloadFails(string failure)
+    {
+        var catalog = new CachedCollection<DApp>
+        {
+            new() { Name = "App safe" },
+            new() { Name = "App restricted", Warnings = ContentWarnings.Violence },
+            new() { Name = "App developing", IsInDevelopment = true }
+        };
+        var database = new ApplicationDbContext();
+        database.Settings.Values[DAppCatalogPolicy.AllowRestrictedContentKey] = true;
+        database.Settings.Values[DAppCatalogPolicy.DeveloperModeKey] = true;
+        var tokens = new TokenManager();
+        var page = new GlobalSearchPage(new TestServices(catalog), database, tokens);
+        await page.LoadForTestAsync();
+        page.ChangeQueryForTest("App"); page.Dispatcher.Flush();
+        Assert.Equal(3, page.Results.Length);
+        GlobalSearchResult stale = page.Results.Single(p => p.DApp!.IsInDevelopment);
+        database.Settings.Values[DAppCatalogPolicy.AllowRestrictedContentKey] = false;
+        database.Settings.Values[DAppCatalogPolicy.DeveloperModeKey] = false;
+        if (failure == "asset") tokens.Load = () => throw new HttpRequestException("offline");
+        if (failure == "catalog") catalog.Load = () => throw new HttpRequestException("offline");
+        if (failure == "settings") database.Settings.Failure = new IOException("settings unavailable");
+        await Assert.ThrowsAnyAsync<Exception>(() => page.LoadForTestAsync());
+        Assert.Single(page.Results);
+        Assert.Equal("App safe", page.Results[0].Title);
+        Commands.LaunchDApp.Last = null;
+        await page.OpenForTestAsync(stale);
+        Assert.Null(Commands.LaunchDApp.Last);
+    }
+
+    [Fact]
+    public async Task PreviousPrivilegedResultsAreHiddenBeforeSettingsReadCompletes()
+    {
+        var catalog = new CachedCollection<DApp> { new() { Name = "App developing", IsInDevelopment = true } };
+        var database = new ApplicationDbContext();
+        database.Settings.Values[DAppCatalogPolicy.DeveloperModeKey] = true;
+        var page = new GlobalSearchPage(new TestServices(catalog), database, new());
+        await page.LoadForTestAsync(); page.ChangeQueryForTest("App"); page.Dispatcher.Flush();
+        Assert.Single(page.Results);
+        var blocked = new TaskCompletionSource();
+        database.Settings.BeforeRead = () => blocked.Task;
+        Task load = page.LoadForTestAsync();
+        try { Assert.Empty(page.Results); }
+        finally { blocked.SetResult(); await load; }
+    }
+
+    [Theory]
+    [InlineData(false, false, "App safe")]
+    [InlineData(true, false, "App restricted,App safe")]
+    [InlineData(false, true, "App developing,App safe")]
+    [InlineData(true, true, "App developing,App restricted,App safe")]
+    public async Task GlobalSearchUsesSameContentAndDiscoveryPolicyAsCatalog(bool restricted, bool developer, string expected)
+    {
+        var catalog = new CachedCollection<DApp>
+        {
+            new() { Name = "App safe" },
+            new() { Name = "App restricted", Warnings = ContentWarnings.Violence },
+            new() { Name = "App developing", IsInDevelopment = true },
+            new() { Name = "App hidden", IsHiddenFromCatalog = true },
+            new() { Name = "App unsupported", SupportedPlatforms = DAppPlatforms.iOS },
+            new() { Name = "App game", IsRegularApp = false }
+        };
+        var database = new ApplicationDbContext();
+        database.Settings.Values[DAppCatalogPolicy.AllowRestrictedContentKey] = restricted;
+        database.Settings.Values[DAppCatalogPolicy.DeveloperModeKey] = developer;
+        var page = new GlobalSearchPage(new TestServices(catalog), database, new());
+
+        await page.LoadForTestAsync();
+        page.ChangeQueryForTest("App");
+        page.Dispatcher.Flush();
+
+        Assert.Equal(expected, string.Join(',', page.Results.Select(item => item.Title)));
+    }
+}

--- a/tests/p2-12/TestBoundary.cs
+++ b/tests/p2-12/TestBoundary.cs
@@ -1,0 +1,130 @@
+// Only native UI, persistence, and network boundaries are substituted. The page
+// source linked by this project contains the production search/event logic.
+using NeoOrder.OneGate.Data;
+using NeoOrder.OneGate.Models;
+
+public class ContentPage
+{
+    public TestDispatcher Dispatcher { get; } = new();
+    protected virtual void OnAppearing() { }
+    protected void OnPropertyChanged(string? property = null) { }
+}
+public class TestDispatcher
+{
+    readonly List<Action> actions = [];
+    public void DispatchDelayed(TimeSpan delay, Action action) => actions.Add(action);
+    public void Flush() { Action[] pending = [.. actions]; actions.Clear(); foreach (Action action in pending) action(); }
+}
+public class TextChangedEventArgs(string? text) : EventArgs { public string? NewTextValue => text; }
+public class TappedEventArgs : EventArgs { public object? Parameter { get; set; } }
+public class TestSearchBar { public bool Focus() => true; public void Unfocus() { } }
+public class Shell
+{
+    public static Shell Current { get; } = new();
+    public Task GoToAsync(string route, Dictionary<string, object> args) => Task.CompletedTask;
+}
+public class TestServices(CachedCollection<DApp> catalog) : IServiceProvider
+{
+    public object? GetService(Type type) => type == typeof(CachedCollection<DApp>) ? catalog : null;
+}
+namespace Microsoft.EntityFrameworkCore
+{
+    public static class QueryExtensions
+    {
+        public static IEnumerable<T> AsNoTracking<T>(this IEnumerable<T> source) => source;
+        public static Task<T[]> ToArrayAsync<T>(this IEnumerable<T> source) => Task.FromResult(source.ToArray());
+    }
+}
+namespace NeoOrder.OneGate.Data
+{
+    public class ApplicationDbContext
+    {
+        public TestSettings Settings { get; } = new();
+        public List<Contact> Contacts { get; } = [];
+    }
+    public class TestSettings
+    {
+        public Dictionary<string, object> Values { get; } = [];
+        public Exception? Failure { get; set; }
+        public Func<Task>? BeforeRead { get; set; }
+        public async Task<T?> GetAsync<T>(string key) where T : notnull
+        {
+            if (BeforeRead is not null) await BeforeRead();
+            if (Failure is not null) throw Failure;
+            return Values.TryGetValue(key, out object? value) ? (T)value : default;
+        }
+    }
+    public class Contact { public string Label { get; set; } = ""; public string Address { get; set; } = ""; }
+    [Flags] public enum ContentWarnings { None = 0, Violence = 1 }
+    [Flags] public enum DAppPlatforms { None = 0, Android = 1, iOS = 2, MacCatalyst = 4, Windows = 8, All = 15 }
+    public class DApp
+    {
+        public int Id { get; set; }
+        public ContentWarnings Warnings { get; set; }
+        public bool IsHiddenFromCatalog { get; set; }
+        public bool IsInDevelopment { get; set; }
+        public DAppPlatforms SupportedPlatforms { get; set; } = DAppPlatforms.All;
+        public string Name { get; set; } = "";
+        public bool IsRegularApp { get; set; } = true;
+        public string Url { get; set; } = "https://example.com";
+        public string? IconUrl { get; set; }
+        public string[]? Tags { get; set; }
+        public Dictionary<string, string> NameLocalizer => new() { ["en"] = Name };
+        public Dictionary<string, string>? DescriptionLocalizer => null;
+        public static string LocalizeTag(string tag) => tag;
+    }
+}
+namespace NeoOrder.OneGate.Models
+{
+    public class CachedCollection<T> : List<T>
+    {
+        public Func<Task> Load { get; set; } = () => Task.CompletedTask;
+        public Task LoadAsync(string url, TimeSpan ttl) => Load();
+    }
+    public class AssetInfo { public Token Token { get; } = new(); public string DisplayBalance => "0"; }
+    public class Token { public string Symbol => "NEO"; public string Name => "Neo"; public string Hash => "hash"; public string? Icon => null; }
+}
+namespace NeoOrder.OneGate.Services
+{
+    public class TokenManager { public Func<Task<IReadOnlyList<AssetInfo>>> Load { get; set; } = () => Task.FromResult<IReadOnlyList<AssetInfo>>([]); public Task<IReadOnlyList<AssetInfo>> LoadAssetsAsync() => Load(); }
+    public class LoadingService(Func<Task> action)
+    {
+        public event EventHandler? Loaded;
+        public event System.ComponentModel.PropertyChangedEventHandler? PropertyChanged;
+        public bool IsLoading => false;
+        public async void BeginLoad() { await action(); Loaded?.Invoke(this, EventArgs.Empty); PropertyChanged?.Invoke(this, new(nameof(IsLoading))); }
+    }
+    public static class Extensions
+    {
+        public static T GetServiceOrCreateInstance<T>(this IServiceProvider services) => (T)services.GetService(typeof(T))!;
+        public static bool ShouldRefresh(this ContentPage page) => false;
+        public static string? Localize(this Dictionary<string, string> value) => value.Values.FirstOrDefault();
+    }
+}
+namespace NeoOrder.OneGate.Properties
+{
+    public static class Strings
+    {
+        public static string Asset => "Asset";
+        public static string AddressBook => "Address book";
+        public static string Apps => "Apps";
+    }
+}
+namespace NeoOrder.OneGate.Pages
+{
+    public static class Commands { public static TestCommand LaunchDApp { get; } = new(); }
+    public class TestCommand
+    {
+        public DApp? Last { get; set; }
+        public Task ExecuteAsync(DApp app) { Last = app; return Task.CompletedTask; }
+    }
+    public partial class GlobalSearchPage
+    {
+        readonly TestSearchBar searchBar = new();
+        void InitializeComponent() { }
+        public async Task LoadForTestAsync() { await LoadSearchDataAsync(); OnLoaded(this, EventArgs.Empty); }
+        public void ChangeQueryForTest(string text) => OnSearchTextChanged(this, new(text));
+        public void ConfirmForTest() => OnSearchButtonPressed(this, EventArgs.Empty);
+        public Task OpenForTestAsync(GlobalSearchResult result) => OpenResultAsync(result);
+    }
+}


### PR DESCRIPTION
## Summary

- Apply the existing catalog content/developer preferences to global-search dApp results.
- Invalidate search when content settings change. Remove previously permitted results immediately while preferences reload; keep restrictive defaults if settings cannot be read.
- Reject a stale tapped dApp result after its visibility has changed. This does not add permissions, trust classifications, or a new dApp launch path.

## Validation

- `dotnet test tests/p2-12/SearchContentPolicy.Tests.csproj --no-restore`: 8 passed.
- iOS 26.5 Simulator and Android emulator: ran the actual `GlobalSearchPage` and `ContentSettingsPage`, disposable SQLite/EF settings, and controlled catalog/balance HTTP responses. Each platform passed four content/developer combinations plus six failure/retry assertions: settings invalidation, tighter policy after balance/catalog failure, unreadable settings fail closed, retry on page appearance, and hiding restricted results again.
- Both platforms: removed the external QA entry point, fully rebuilt the product, installed it under an isolated audit application ID, and verified Home/four-tab startup. No original wallet access, signing, or broadcasting.
- Native validation corresponds to source diff SHA-256 `52e6b1ca29660498c42975cc156a6dc4e0eb48926496b178ed685b5370569826` against `master` at `623603d`.
- Screenshots and QA fixtures remain outside the repository; screenshots have not been uploaded to GitHub. Hosted CI status is separate from this local validation and is not claimed as passing.

## Scope

One issue only: search must honor existing content preferences, including during failed reloads. Does not include independent search-group loading from #116 or add a new policy model. Tests retain the solution entry and non-build/non-output app project reference.
