### PR TITLE
Load additional NFT pages and release iterator sessions

### DIFF
--- a/OneGateApp.slnx
+++ b/OneGateApp.slnx
@@ -6,4 +6,5 @@
   <Project Path="OneGate.DebugProtocol/OneGate.DebugProtocol.csproj" />
   <Project Path="OneGate.DebugProtocol.Tests/OneGate.DebugProtocol.Tests.csproj" />
   <Project Path="OneGate.Tools/OneGate.Tools.csproj" />
+  <Project Path="tests/p2-06/NftPager.Tests.csproj" />
 </Solution>

--- a/OneGateApp/Pages/WalletPage.xaml
+++ b/OneGateApp/Pages/WalletPage.xaml
@@ -157,6 +157,13 @@
                 </Border>
                 <Border StyleClass="Card" Padding="0" IsVisible="{Binding SelectedIndex, Source={x:Reference tabBarAssetType}, Converter={StaticResource IsEqualConverter}, ConverterParameter={x:Int32 1}}">
                     <CollectionView ItemsSource="{Binding NFTs}" MinimumHeightRequest="150">
+                    <CollectionView.Footer>
+                        <VerticalStackLayout Padding="12" Spacing="8">
+                            <Label Text="{x:Static og:Strings.NFTLoadFailed}" IsVisible="{Binding NftLoadFailed}" HorizontalTextAlignment="Center" />
+                            <ActivityIndicator IsRunning="{Binding IsLoadingNFTs}" IsVisible="{Binding IsLoadingNFTs}" />
+                            <Button Text="{x:Static og:Strings.LoadMoreNFTs}" IsVisible="{Binding HasMoreNFTs}" IsEnabled="{Binding IsLoadingNFTs, Converter={StaticResource InvertedBoolConverter}}" Clicked="OnLoadMoreNFTs" />
+                        </VerticalStackLayout>
+                    </CollectionView.Footer>
                     <CollectionView.EmptyView>
                         <Grid>
                             <Label IsVisible="{Binding LoadingService.IsLoading}">
@@ -171,7 +178,7 @@
                                 <Border StrokeShape="Ellipse" BackgroundColor="{toolkit:AppThemeResource TextBox}" WidthRequest="100" HeightRequest="100">
                                     <Image Source="empty.png" WidthRequest="32" HeightRequest="32" />
                                 </Border>
-                                <Label StyleClass="Secondary" Text="{x:Static og:Strings.NoNftText}" HorizontalOptions="Center" />
+                                <Label StyleClass="Secondary" Text="{x:Static og:Strings.NoNftText}" IsVisible="{Binding ShowNftEmptyState}" HorizontalOptions="Center" />
                             </VerticalStackLayout>
                         </Grid>
                     </CollectionView.EmptyView>

--- a/OneGateApp/Pages/WalletPage.xaml.cs
+++ b/OneGateApp/Pages/WalletPage.xaml.cs
@@ -87,7 +87,7 @@ public partial class WalletPage : ContentPage
         nftSession = session;
         NFTs.Clear();
         NftLoadFailed = false;
-        HasMoreNFTs = true;
+        HasMoreNFTs = false;
         IsLoadingNFTs = false;
         if (previous is not null) await CloseNftSessionAsync(previous);
         await LoadNFTPageAsync(session);
@@ -124,6 +124,7 @@ public partial class WalletPage : ContentPage
 
     async void OnLoadMoreNFTs(object sender, EventArgs e)
     {
+        if (!HasMoreNFTs || IsLoadingNFTs) return;
         if (nftSession is not null) await LoadNFTPageAsync(nftSession);
     }
 

--- a/OneGateApp/Pages/WalletPage.xaml.cs
+++ b/OneGateApp/Pages/WalletPage.xaml.cs
@@ -6,6 +6,7 @@ using NeoOrder.OneGate.Data;
 using NeoOrder.OneGate.Models;
 using NeoOrder.OneGate.Properties;
 using NeoOrder.OneGate.Services;
+using System.Collections.ObjectModel;
 
 namespace NeoOrder.OneGate.Pages;
 
@@ -13,6 +14,7 @@ public partial class WalletPage : ContentPage
 {
     readonly ApplicationDbContext dbContext;
     readonly TokenManager tokenManager;
+    NftPageSession? nftSession;
 
     public LoadingService LoadingService { get; set { field = value; OnPropertyChanged(); } }
     public Wallet Wallet { get; set { field = value; OnPropertyChanged(); } }
@@ -20,7 +22,11 @@ public partial class WalletPage : ContentPage
     public WalletAccount DefaultAccount => Wallet.GetDefaultAccount()!;
     public UInt160 ScriptHash => DefaultAccount.ScriptHash;
     public IReadOnlyList<AssetInfo>? Assets { get; set { field = value; OnPropertyChanged(); } }
-    public IReadOnlyList<NFT>? NFTs { get; set { field = value; OnPropertyChanged(); } }
+    public ObservableCollection<NFT> NFTs { get; } = [];
+    public bool HasMoreNFTs { get; set { field = value; OnPropertyChanged(); } }
+    public bool IsLoadingNFTs { get; set { field = value; OnPropertyChanged(); OnPropertyChanged(nameof(ShowNftEmptyState)); } }
+    public bool NftLoadFailed { get; set { field = value; OnPropertyChanged(); OnPropertyChanged(nameof(ShowNftEmptyState)); } }
+    public bool ShowNftEmptyState => !IsLoadingNFTs && !NftLoadFailed;
     public string TotalValuation { get; set { field = value; OnPropertyChanged(); } } = "N/A";
 
     public WalletPage(ApplicationDbContext dbContext, IWalletProvider walletProvider, TokenManager tokenManager)
@@ -39,6 +45,18 @@ public partial class WalletPage : ContentPage
         base.OnAppearing();
         if (this.ShouldRefresh())
             LoadingService.BeginLoad();
+        else if (nftSession is null)
+            _ = LoadNFTsAsync();
+    }
+
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+        NftPageSession? session = nftSession;
+        nftSession = null;
+        HasMoreNFTs = false;
+        IsLoadingNFTs = false;
+        if (session is not null) _ = CloseNftSessionAsync(session);
     }
 
     async void OnToggleShowBalance(object sender, EventArgs e)
@@ -64,7 +82,55 @@ public partial class WalletPage : ContentPage
 
     async Task LoadNFTsAsync()
     {
-        NFTs = await tokenManager.LoadNFTsAsync();
+        NftPageSession? previous = nftSession;
+        var session = new NftPageSession(token => tokenManager.LoadNFTPagesAsync(cancellationToken: token));
+        nftSession = session;
+        NFTs.Clear();
+        NftLoadFailed = false;
+        HasMoreNFTs = true;
+        IsLoadingNFTs = false;
+        if (previous is not null) await CloseNftSessionAsync(previous);
+        await LoadNFTPageAsync(session);
+    }
+
+    async Task LoadNFTPageAsync(NftPageSession session)
+    {
+        if (!ReferenceEquals(nftSession, session) || IsLoadingNFTs) return;
+        IsLoadingNFTs = true;
+        try
+        {
+            NFT[]? page = await session.ReadNextAsync();
+            if (!ReferenceEquals(nftSession, session)) return;
+            if (page is not null) foreach (NFT nft in page) NFTs.Add(nft);
+            HasMoreNFTs = page?.Length == 100;
+            if (!HasMoreNFTs) await CloseNftSessionAsync(session);
+        }
+        catch (OperationCanceledException) when (!ReferenceEquals(nftSession, session)) { }
+        catch (Exception ex)
+        {
+            if (ReferenceEquals(nftSession, session))
+            {
+                HasMoreNFTs = false;
+                NftLoadFailed = true;
+                await Toast.Show(ex.Message);
+            }
+            await CloseNftSessionAsync(session);
+        }
+        finally
+        {
+            if (ReferenceEquals(nftSession, session)) IsLoadingNFTs = false;
+        }
+    }
+
+    async void OnLoadMoreNFTs(object sender, EventArgs e)
+    {
+        if (nftSession is not null) await LoadNFTPageAsync(nftSession);
+    }
+
+    static async Task CloseNftSessionAsync(NftPageSession session)
+    {
+        try { await session.DisposeAsync(); }
+        catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"NFT pagination cleanup failed: {ex.Message}"); }
     }
 
     async void OnSendClicked(object sender, EventArgs e)

--- a/OneGateApp/Properties/Strings.Designer.cs
+++ b/OneGateApp/Properties/Strings.Designer.cs
@@ -3531,6 +3531,14 @@ namespace NeoOrder.OneGate.Properties {
             get { return ResourceManager.GetString("RemoteDebugPairingTitle", resourceCulture); }
         }
 
+        internal static string LoadMoreNFTs {
+            get { return ResourceManager.GetString("LoadMoreNFTs", resourceCulture); }
+        }
+
+        internal static string NFTLoadFailed {
+            get { return ResourceManager.GetString("NFTLoadFailed", resourceCulture); }
+        }
+
         internal static string RemoteDebugPairingPrompt {
             get { return ResourceManager.GetString("RemoteDebugPairingPrompt", resourceCulture); }
         }

--- a/OneGateApp/Properties/Strings.de.resx
+++ b/OneGateApp/Properties/Strings.de.resx
@@ -1288,4 +1288,10 @@ Es wird empfohlen, den NEP-2-Schlüssel und das Passwort getrennt aufzubewahren 
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>Warten auf einen vertrauenswürdigen Remote-Debugger</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Remote-Debugger koppeln</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>Remote-Debugger „{0}“ fordert Zugriff an. Fingerabdruck: {1}. Nur autorisieren, wenn du diesem Remote-Debugger vertraust.</value></data>
+  <data name="LoadMoreNFTs" xml:space="preserve">
+    <value>Mehr NFTs laden</value>
+  </data>
+  <data name="NFTLoadFailed" xml:space="preserve">
+    <value>Einige NFTs konnten nicht geladen werden. Zum erneuten Versuch nach unten ziehen.</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.es.resx
+++ b/OneGateApp/Properties/Strings.es.resx
@@ -1288,4 +1288,10 @@ Se recomienda almacenar la clave NEP-2 y la contraseña por separado y realizar 
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>Esperando un depurador remoto de confianza</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Emparejar depurador remoto</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>El depurador remoto «{0}» solicita acceso. Huella: {1}. Autoriza solo si confías en este depurador remoto.</value></data>
+  <data name="LoadMoreNFTs" xml:space="preserve">
+    <value>Cargar más NFT</value>
+  </data>
+  <data name="NFTLoadFailed" xml:space="preserve">
+    <value>No se pudieron cargar algunos NFT. Desliza hacia abajo para volver a intentarlo.</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.fr.resx
+++ b/OneGateApp/Properties/Strings.fr.resx
@@ -1288,4 +1288,10 @@ Il est recommandé de conserver séparément la clé NEP-2 et le mot de passe, e
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>En attente d’un débogueur distant approuvé</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Associer le débogueur distant</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>Le débogueur distant « {0} » demande l’accès. Empreinte : {1}. Autorisez uniquement si vous faites confiance à ce débogueur distant.</value></data>
+  <data name="LoadMoreNFTs" xml:space="preserve">
+    <value>Charger plus de NFT</value>
+  </data>
+  <data name="NFTLoadFailed" xml:space="preserve">
+    <value>Certains NFT n’ont pas pu être chargés. Tirez vers le bas pour réessayer.</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.id.resx
+++ b/OneGateApp/Properties/Strings.id.resx
@@ -1288,4 +1288,10 @@ Disarankan untuk menyimpan kunci NEP-2 dan kata sandinya secara terpisah serta m
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>Menunggu debugger jarak jauh tepercaya</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Pasangkan debugger jarak jauh</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>Debugger jarak jauh “{0}” meminta akses. Sidik jari: {1}. Izinkan hanya jika Anda memercayai debugger jarak jauh ini.</value></data>
+  <data name="LoadMoreNFTs" xml:space="preserve">
+    <value>Muat lebih banyak NFT</value>
+  </data>
+  <data name="NFTLoadFailed" xml:space="preserve">
+    <value>Beberapa NFT tidak dapat dimuat. Tarik ke bawah untuk mencoba lagi.</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.it.resx
+++ b/OneGateApp/Properties/Strings.it.resx
@@ -1288,4 +1288,10 @@ Si consiglia di conservare separatamente la chiave NEP-2 e la password e di eseg
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>In attesa di un debugger remoto attendibile</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Associa debugger remoto</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>Il debugger remoto “{0}” richiede l’accesso. Impronta: {1}. Autorizza solo se ritieni attendibile questo debugger remoto.</value></data>
+  <data name="LoadMoreNFTs" xml:space="preserve">
+    <value>Carica altri NFT</value>
+  </data>
+  <data name="NFTLoadFailed" xml:space="preserve">
+    <value>Impossibile caricare alcuni NFT. Trascina verso il basso per riprovare.</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.ja.resx
+++ b/OneGateApp/Properties/Strings.ja.resx
@@ -1288,4 +1288,10 @@ NEP-2 とパスワードは別々に保管し、それぞれを安全にバッ�
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>信頼済みリモートデバッガーを待機中</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>リモートデバッガーをペアリング</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>リモートデバッガー「{0}」がアクセスを要求しています。フィンガープリント: {1}。このリモートデバッガーを信頼する場合のみ許可してください。</value></data>
+  <data name="LoadMoreNFTs" xml:space="preserve">
+    <value>NFTをさらに読み込む</value>
+  </data>
+  <data name="NFTLoadFailed" xml:space="preserve">
+    <value>一部のNFTを読み込めませんでした。下に引いて再試行してください。</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.ko.resx
+++ b/OneGateApp/Properties/Strings.ko.resx
@@ -1288,4 +1288,10 @@ NEP-2와 비밀번호는 별도로 보관하고 각각 안전하게 백업하는
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>신뢰할 수 있는 원격 디버거 대기 중</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>원격 디버거 페어링</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>원격 디버거 “{0}”이(가) 액세스를 요청합니다. 지문: {1}. 이 원격 디버거를 신뢰하는 경우에만 허용하세요.</value></data>
+  <data name="LoadMoreNFTs" xml:space="preserve">
+    <value>NFT 더 불러오기</value>
+  </data>
+  <data name="NFTLoadFailed" xml:space="preserve">
+    <value>일부 NFT를 불러오지 못했습니다. 아래로 당겨 다시 시도하세요.</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.nl.resx
+++ b/OneGateApp/Properties/Strings.nl.resx
@@ -1288,4 +1288,10 @@ Het wordt aanbevolen om de NEP-2-sleutel en het wachtwoord apart op te slaan en 
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>Wachten op een vertrouwde externe debugger</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Externe debugger koppelen</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>Externe debugger ‘{0}’ vraagt toegang. Vingerafdruk: {1}. Autoriseer alleen als je deze externe debugger vertrouwt.</value></data>
+  <data name="LoadMoreNFTs" xml:space="preserve">
+    <value>Meer NFT's laden</value>
+  </data>
+  <data name="NFTLoadFailed" xml:space="preserve">
+    <value>Sommige NFT's konden niet worden geladen. Trek omlaag om het opnieuw te proberen.</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.pt-BR.resx
+++ b/OneGateApp/Properties/Strings.pt-BR.resx
@@ -1288,4 +1288,10 @@ Recomenda-se armazenar a chave NEP-2 e a senha separadamente e fazer backups seg
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>Aguardando um depurador remoto confiável</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Parear depurador remoto</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>O depurador remoto “{0}” está solicitando acesso. Impressão digital: {1}. Autorize apenas se confiar neste depurador remoto.</value></data>
+  <data name="LoadMoreNFTs" xml:space="preserve">
+    <value>Carregar mais NFTs</value>
+  </data>
+  <data name="NFTLoadFailed" xml:space="preserve">
+    <value>Não foi possível carregar alguns NFTs. Puxe para baixo para tentar novamente.</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.resx
+++ b/OneGateApp/Properties/Strings.resx
@@ -1288,4 +1288,10 @@ It is recommended to store the NEP-2 key and password separately and back them u
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>Waiting for a trusted remote debugger</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Pair remote debugger</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>Remote debugger “{0}” is requesting access. Fingerprint: {1}. Authorize only if you trust this remote debugger.</value></data>
+  <data name="LoadMoreNFTs" xml:space="preserve">
+    <value>Load more NFTs</value>
+  </data>
+  <data name="NFTLoadFailed" xml:space="preserve">
+    <value>Some NFTs could not be loaded. Pull down to retry.</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.ru.resx
+++ b/OneGateApp/Properties/Strings.ru.resx
@@ -1288,4 +1288,10 @@
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>Ожидание доверенного удалённого отладчика</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Сопряжение удалённого отладчика</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>Удалённый отладчик «{0}» запрашивает доступ. Отпечаток: {1}. Разрешайте только если доверяете этому удалённому отладчику.</value></data>
+  <data name="LoadMoreNFTs" xml:space="preserve">
+    <value>Загрузить ещё NFT</value>
+  </data>
+  <data name="NFTLoadFailed" xml:space="preserve">
+    <value>Не удалось загрузить некоторые NFT. Потяните вниз, чтобы повторить попытку.</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.tr.resx
+++ b/OneGateApp/Properties/Strings.tr.resx
@@ -1288,4 +1288,10 @@ NEP-2 anahtarı ile şifreyi ayrı ayrı saklamanız ve güvenli şekilde yedekl
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>Güvenilir bir uzaktan hata ayıklayıcı bekleniyor</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Uzaktan hata ayıklayıcıyı eşleştir</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>“{0}” uzaktan hata ayıklayıcısı erişim istiyor. Parmak izi: {1}. Yalnızca bu uzaktan hata ayıklayıcıya güveniyorsanız izin verin.</value></data>
+  <data name="LoadMoreNFTs" xml:space="preserve">
+    <value>Daha fazla NFT yükle</value>
+  </data>
+  <data name="NFTLoadFailed" xml:space="preserve">
+    <value>Bazı NFT'ler yüklenemedi. Tekrar denemek için aşağı çekin.</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.vi.resx
+++ b/OneGateApp/Properties/Strings.vi.resx
@@ -1288,4 +1288,10 @@ Nên lưu trữ riêng khóa NEP-2 và mật khẩu, đồng thời sao lưu ch�
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>Đang chờ trình gỡ lỗi từ xa đáng tin cậy</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Ghép nối trình gỡ lỗi từ xa</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>Trình gỡ lỗi từ xa “{0}” đang yêu cầu quyền truy cập. Dấu vân tay: {1}. Chỉ cho phép nếu bạn tin cậy trình gỡ lỗi từ xa này.</value></data>
+  <data name="LoadMoreNFTs" xml:space="preserve">
+    <value>Tải thêm NFT</value>
+  </data>
+  <data name="NFTLoadFailed" xml:space="preserve">
+    <value>Không thể tải một số NFT. Kéo xuống để thử lại.</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.zh-Hans.resx
+++ b/OneGateApp/Properties/Strings.zh-Hans.resx
@@ -1288,4 +1288,10 @@
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>正在等待已信任的远程调试器</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>配对远程调试器</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>远程调试器“{0}”正在请求访问。指纹：{1}。仅在你信任此远程调试器时授权。</value></data>
+  <data name="LoadMoreNFTs" xml:space="preserve">
+    <value>加载更多 NFT</value>
+  </data>
+  <data name="NFTLoadFailed" xml:space="preserve">
+    <value>部分 NFT 未能加载，请下拉重试。</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.zh-Hant.resx
+++ b/OneGateApp/Properties/Strings.zh-Hant.resx
@@ -1288,4 +1288,10 @@
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>正在等待已信任的遠端偵錯器</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>配對遠端偵錯器</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>遠端偵錯器「{0}」正在要求存取。指紋：{1}。僅在你信任此遠端偵錯器時授權。</value></data>
+  <data name="LoadMoreNFTs" xml:space="preserve">
+    <value>載入更多 NFT</value>
+  </data>
+  <data name="NFTLoadFailed" xml:space="preserve">
+    <value>部分 NFT 未能載入，請下拉重試。</value>
+  </data>
 </root>

--- a/OneGateApp/Services/NftPageSession.cs
+++ b/OneGateApp/Services/NftPageSession.cs
@@ -1,0 +1,49 @@
+using NeoOrder.OneGate.Models;
+
+namespace NeoOrder.OneGate.Services;
+
+// Owns one UI pagination session. Closing cancels a pending read before disposing
+// the async iterator, which must never be disposed during MoveNextAsync.
+internal sealed class NftPageSession : IAsyncDisposable
+{
+    readonly CancellationTokenSource cancellation = new();
+    readonly SemaphoreSlim gate = new(1);
+    readonly IAsyncEnumerator<NFT[]> pages;
+    Task? closeTask;
+
+    public NftPageSession(Func<CancellationToken, IAsyncEnumerable<NFT[]>> createPages)
+    {
+        pages = createPages(cancellation.Token).GetAsyncEnumerator(cancellation.Token);
+    }
+
+    public async Task<NFT[]?> ReadNextAsync()
+    {
+        await gate.WaitAsync(cancellation.Token);
+        try
+        {
+            cancellation.Token.ThrowIfCancellationRequested();
+            return await pages.MoveNextAsync() ? pages.Current : null;
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        lock (gate) return new(closeTask ??= CloseAsync());
+    }
+
+    async Task CloseAsync()
+    {
+        cancellation.Cancel();
+        await gate.WaitAsync();
+        try { await pages.DisposeAsync(); }
+        finally
+        {
+            gate.Release();
+            cancellation.Dispose();
+        }
+    }
+}

--- a/OneGateApp/Services/RPC/NftPager.cs
+++ b/OneGateApp/Services/RPC/NftPager.cs
@@ -1,0 +1,49 @@
+using NeoOrder.OneGate.Models;
+using System.Runtime.CompilerServices;
+
+namespace NeoOrder.OneGate.Services.RPC;
+
+internal readonly record struct NftIteratorSession(Guid Id, Guid[] Iterators);
+
+internal static class NftPager
+{
+    public static async IAsyncEnumerable<NFT[]> ReadAsync(
+        Func<CancellationToken, Task<NftIteratorSession>> open,
+        Func<Guid, Guid, int, CancellationToken, Task<byte[][]>> traverse,
+        Func<int, byte[][], CancellationToken, Task<NFT[]>> metadata,
+        Func<Guid, Task> close,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        NftIteratorSession session = await open(cancellationToken);
+        var page = new List<NFT>(100);
+        try
+        {
+            for (int collection = 0; collection < session.Iterators.Length; collection++)
+            {
+                while (true)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    int count = Math.Min(25, 100 - page.Count);
+                    byte[][] ids = await traverse(session.Id, session.Iterators[collection], count, cancellationToken);
+                    if (ids.Length == 0) break;
+                    if (ids.Length > count) throw new InvalidDataException("NFT iterator returned more items than requested.");
+                    NFT[] items = await metadata(collection, ids, cancellationToken);
+                    if (items.Length != ids.Length) throw new InvalidDataException("NFT metadata response is incomplete.");
+                    page.AddRange(items);
+                    if (page.Count == 100)
+                    {
+                        yield return page.ToArray();
+                        page.Clear();
+                    }
+                    // Nodes may enforce a smaller traversal limit. Only an empty reply
+                    // proves exhaustion, not a reply shorter than the requested batch.
+                }
+            }
+        }
+        finally
+        {
+            await close(session.Id);
+        }
+        if (page.Count > 0) yield return page.ToArray();
+    }
+}

--- a/OneGateApp/Services/RPC/RpcClient.cs
+++ b/OneGateApp/Services/RPC/RpcClient.cs
@@ -22,6 +22,9 @@ public class RpcClient(IWalletProvider walletProvider, ProtocolSettings protocol
     readonly HttpClient http = new();
 
     public async Task<T> RpcSendAsync<T>(string method, params object?[] args) where T : notnull
+        => await RpcSendAsync<T>(method, CancellationToken.None, args);
+
+    public async Task<T> RpcSendAsync<T>(string method, CancellationToken cancellationToken, params object?[] args) where T : notnull
     {
         var request = new JsonObject
         {
@@ -30,13 +33,13 @@ public class RpcClient(IWalletProvider walletProvider, ProtocolSettings protocol
             ["method"] = method,
             ["params"] = new JsonArray(args.Select(p => JsonSerializer.SerializeToNode(p, SharedOptions.JsonSerializerOptions)).ToArray())
         };
-        var requestMsg = new HttpRequestMessage(HttpMethod.Post, SharedOptions.RpcServerUri)
+        using var requestMsg = new HttpRequestMessage(HttpMethod.Post, SharedOptions.RpcServerUri)
         {
             Content = new StringContent(request.ToJsonString(), Utility.StrictUTF8, "application/json")
         };
-        var responseMsg = await http.SendAsync(requestMsg);
+        using var responseMsg = await http.SendAsync(requestMsg, cancellationToken);
         responseMsg.EnsureSuccessStatusCode();
-        JsonObject response = (await responseMsg.Content.ReadFromJsonAsync<JsonObject>(SharedOptions.JsonSerializerOptions))!;
+        JsonObject response = (await responseMsg.Content.ReadFromJsonAsync<JsonObject>(SharedOptions.JsonSerializerOptions, cancellationToken))!;
         if (response["error"] is JsonObject error)
         {
             int code = error["code"]!.GetValue<int>();
@@ -163,48 +166,61 @@ public class RpcClient(IWalletProvider walletProvider, ProtocolSettings protocol
         };
     }
 
-    public async Task<NFT[]> GetNFTs(UInt160 account, UInt160[] assets, int limit = 100)
+    public IAsyncEnumerable<NFT[]> GetNFTPages(UInt160 account, UInt160[] assets, CancellationToken cancellationToken = default)
     {
-        byte[] script;
-        using (var builder = new ScriptBuilder())
-        {
-            foreach (var asset in assets)
-                builder.EmitDynamicCall(asset, "tokensOf", account);
-            script = builder.ToArray();
-        }
-        JsonObject iterators = await RpcSendAsync<JsonObject>("invokescript", script);
-        Guid sessionId = iterators["session"]!.GetValue<Guid>();
-        var tokens = assets.Zip(iterators["stack"]!.AsArray(), (x, y) => new
-        {
-            Hash = x,
-            Iterator = y!["id"]!.GetValue<Guid>(),
-            NFTs = new List<NFT>()
-        }).ToArray();
-        foreach (var token in tokens)
-        {
-            StackItem[] items = await RpcSendAsync<StackItem[]>("traverseiterator", sessionId, token.Iterator, limit);
-            limit -= items.Length;
-            if (items.Length == 0) continue;
-            using (var builder = new ScriptBuilder())
+        return NftPager.ReadAsync(async token =>
             {
-                foreach (var tokenId in items)
-                    builder.EmitDynamicCall(token.Hash, "properties", tokenId.ToParameter());
-                script = builder.ToArray();
-            }
-            InvocationResult result = await Invoke(script);
-            var nfts = items.Zip(result.Stack.Cast<Map>(), (id, map) => new NFT
+                if (assets.Length == 0) return new NftIteratorSession(Guid.Empty, []);
+                using var builder = new ScriptBuilder();
+                foreach (var asset in assets) builder.EmitDynamicCall(asset, "tokensOf", account);
+                JsonObject response = await RpcSendAsync<JsonObject>("invokescript", token, builder.ToArray());
+                Guid sessionId = response["session"]!.GetValue<Guid>();
+                try
+                {
+                    if (response["state"]?.GetValue<string>() != nameof(VMState.HALT))
+                        throw new DapiException(10004, "NFT enumeration failed");
+                    Guid[] iterators = response["stack"]!.AsArray().Select(p => p!["id"]!.GetValue<Guid>()).ToArray();
+                    if (iterators.Length != assets.Length) throw new InvalidDataException("NFT iterator response is incomplete.");
+                    return new NftIteratorSession(sessionId, iterators);
+                }
+                catch
+                {
+                    await CloseNftSessionAsync(sessionId);
+                    throw;
+                }
+            },
+            async (session, iterator, count, token) =>
             {
-                CollectionId = token.Hash,
-                TokenId = id.GetSpan().ToArray(),
-                Name = map["name"].GetString()!,
-                Description = map.TryGetString("description"),
-                Image = map.TryGetString("image"),
-                TokenURI = map.TryGetString("tokenURI")
-            });
-            token.NFTs.AddRange(nfts);
-            if (limit <= 0) break;
+                StackItem[] items = await RpcSendAsync<StackItem[]>("traverseiterator", token, session, iterator, count);
+                return items.Select(p => p.GetSpan().ToArray()).ToArray();
+            },
+            async (collection, ids, token) =>
+            {
+                using var builder = new ScriptBuilder();
+                foreach (var id in ids) builder.EmitDynamicCall(assets[collection], "properties", id);
+                InvocationResult result = await RpcSendAsync<InvocationResult>("invokescript", token, builder.ToArray());
+                result.EnsureSuccess();
+                if (result.Stack.Length != ids.Length) throw new InvalidDataException("NFT metadata response is incomplete.");
+                return ids.Zip(result.Stack.Cast<Map>(), (id, map) => new NFT
+                {
+                    CollectionId = assets[collection], TokenId = id, Name = map["name"].GetString()!,
+                    Description = map.TryGetString("description"), Image = map.TryGetString("image"), TokenURI = map.TryGetString("tokenURI")
+                }).ToArray();
+            }, CloseNftSessionAsync, cancellationToken);
+    }
+
+    async Task CloseNftSessionAsync(Guid sessionId)
+    {
+        if (sessionId == Guid.Empty) return;
+        try
+        {
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await RpcSendAsync<bool>("terminatesession", timeout.Token, sessionId);
         }
-        return tokens.SelectMany(p => p.NFTs).ToArray();
+        catch (Exception ex) when (ex is RpcException or HttpRequestException or JsonException or OperationCanceledException)
+        {
+            System.Diagnostics.Debug.WriteLine($"Unable to release NFT iterator session: {ex.Message}");
+        }
     }
 
     public async Task<uint> GetBlockCount()

--- a/OneGateApp/Services/TokenManager.cs
+++ b/OneGateApp/Services/TokenManager.cs
@@ -7,6 +7,7 @@ using NeoOrder.OneGate.Resources;
 using NeoOrder.OneGate.Services.RPC;
 using System.Net.Http.Json;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 
 namespace NeoOrder.OneGate.Services;
 
@@ -71,15 +72,16 @@ public class TokenManager(ApplicationDbContext dbContext, IWalletProvider wallet
         return tokens;
     }
 
-    public async Task<IReadOnlyList<NFT>> LoadNFTsAsync(bool includeHiddens = false)
+    public async IAsyncEnumerable<NFT[]> LoadNFTPagesAsync(bool includeHiddens = false, [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         Wallet wallet = walletProvider.GetWallet()!;
         WalletAccount account = wallet.GetDefaultAccount()!;
         var tokens = await LoadNep11TokensAsync(includeHiddens);
-        NFT[] nfts = await rpcClient.GetNFTs(account.ScriptHash, tokens.Select(p => p.Hash).ToArray());
-        foreach (NFT nft in nfts)
-            nft.TokenInfo = tokens.First(p => p.Hash == nft.CollectionId);
-        return nfts;
+        await foreach (NFT[] nfts in rpcClient.GetNFTPages(account.ScriptHash, tokens.Select(p => p.Hash).ToArray(), cancellationToken))
+        {
+            foreach (NFT nft in nfts) nft.TokenInfo = tokens.First(p => p.Hash == nft.CollectionId);
+            yield return nfts;
+        }
     }
 
     public async Task<IReadOnlyList<ITokenInfo>> LoadHiddenTokens()

--- a/tests/p2-06/NftPager.Tests.csproj
+++ b/tests/p2-06/NftPager.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup><TargetFramework>net10.0</TargetFramework><ImplicitUsings>enable</ImplicitUsings><Nullable>enable</Nullable><IsPackable>false</IsPackable><IsTestProject>true</IsTestProject></PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" PrivateAssets="all" />
+    <PackageReference Include="Neo" Version="3.10.0" />
+    <Compile Include="../../OneGateApp/Services/RPC/NftPager.cs" Link="NftPager.cs" />
+    <Compile Include="../../OneGateApp/Services/NftPageSession.cs" Link="NftPageSession.cs" />
+    <Compile Include="../../OneGateApp/Models/NFT.cs" Link="NFT.cs" />
+    <Compile Include="../../OneGateApp/Models/Nep11TokenInfo.cs" Link="Nep11TokenInfo.cs" />
+    <Compile Include="../../OneGateApp/Models/ITokenInfo.cs" Link="ITokenInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../OneGateApp/OneGateApp.csproj" ReferenceOutputAssembly="false" BuildReference="false" SkipGetTargetFrameworkProperties="true" />
+  </ItemGroup>
+</Project>

--- a/tests/p2-06/NftPager.Tests.csproj
+++ b/tests/p2-06/NftPager.Tests.csproj
@@ -7,6 +7,8 @@
     <PackageReference Include="Neo" Version="3.10.0" />
     <Compile Include="../../OneGateApp/Services/RPC/NftPager.cs" Link="NftPager.cs" />
     <Compile Include="../../OneGateApp/Services/NftPageSession.cs" Link="NftPageSession.cs" />
+    <Compile Include="../../OneGateApp/Pages/WalletPage.xaml.cs" Link="WalletPage.xaml.cs" />
+    <Compile Include="../../OneGateApp/Services/LoadingService.cs" Link="LoadingService.cs" />
     <Compile Include="../../OneGateApp/Models/NFT.cs" Link="NFT.cs" />
     <Compile Include="../../OneGateApp/Models/Nep11TokenInfo.cs" Link="Nep11TokenInfo.cs" />
     <Compile Include="../../OneGateApp/Models/ITokenInfo.cs" Link="ITokenInfo.cs" />

--- a/tests/p2-06/NftPagerTests.cs
+++ b/tests/p2-06/NftPagerTests.cs
@@ -1,0 +1,132 @@
+using Neo;
+using NeoOrder.OneGate.Models;
+using NeoOrder.OneGate.Services.RPC;
+using NeoOrder.OneGate.Services;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class NftPagerTests
+{
+    sealed class Fixture
+    {
+        public readonly Guid Session = Guid.NewGuid();
+        public readonly Guid[] Iterators = [Guid.NewGuid(), Guid.NewGuid()];
+        public readonly int[] Remaining = [125, 12];
+        public int Closed;
+        public bool FailMetadata;
+        public bool OversizedBatch;
+        public List<int> Requested = [];
+        public List<int> MetadataBatchSizes = [];
+        public int MetadataCount;
+
+        public IAsyncEnumerable<NFT[]> Pages(CancellationToken token = default) => NftPager.ReadAsync(
+            _ => Task.FromResult(new NftIteratorSession(Session, Iterators)),
+            (session, iterator, count, cancellation) =>
+            {
+                cancellation.ThrowIfCancellationRequested();
+                Assert.Equal(Session, session);
+                Requested.Add(count);
+                int index = Array.IndexOf(Iterators, iterator);
+                int available = OversizedBatch ? count + 1 : Math.Min(Math.Min(count, 7), Remaining[index]);
+                var ids = Enumerable.Range(0, available).Select(_ => BitConverter.GetBytes(--Remaining[index])).ToArray();
+                return Task.FromResult(ids);
+            },
+            (collection, ids, _) =>
+            {
+                if (FailMetadata) throw new HttpRequestException("metadata offline");
+                MetadataBatchSizes.Add(ids.Length);
+                MetadataCount += ids.Length;
+                return Task.FromResult(ids.Select(id => new NFT { CollectionId = UInt160.Zero, TokenId = id, Name = $"collection{collection}-{BitConverter.ToInt32(id)}" }).ToArray());
+            },
+            session => { Assert.Equal(Session, session); Closed++; return Task.CompletedTask; }, token);
+    }
+
+    [Fact]
+    public async Task AllCollectionsRemainReachableWithSmallServerBatchLimit()
+    {
+        var fixture = new Fixture();
+        var pages = new List<NFT[]>();
+        await foreach (var page in fixture.Pages()) pages.Add(page);
+        Assert.Equal(new[] { 100, 37 }, pages.Select(p => p.Length));
+        Assert.Equal(137, pages.SelectMany(p => p).Select(p => p.Name).Distinct().Count());
+        Assert.Contains(pages.SelectMany(p => p), p => p.Name.StartsWith("collection1-"));
+        Assert.All(fixture.Requested, n => Assert.InRange(n, 1, 25));
+        Assert.All(fixture.MetadataBatchSizes, n => Assert.InRange(n, 1, 25));
+        Assert.Equal(1, fixture.Closed);
+    }
+
+    [Fact]
+    public async Task DisposingAfterFirstPageStopsRequestsAndClosesSession()
+    {
+        var fixture = new Fixture();
+        await using (var pages = fixture.Pages().GetAsyncEnumerator())
+        {
+            Assert.True(await pages.MoveNextAsync());
+            Assert.Equal(100, pages.Current.Length);
+            Assert.Equal(100, fixture.MetadataCount);
+        }
+        Assert.Equal(1, fixture.Closed);
+    }
+
+    [Fact]
+    public async Task CancellationClosesSession()
+    {
+        var fixture = new Fixture();
+        using var cancellation = new CancellationTokenSource();
+        await using var pages = fixture.Pages(cancellation.Token).GetAsyncEnumerator();
+        Assert.True(await pages.MoveNextAsync());
+        cancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await pages.MoveNextAsync());
+        Assert.Equal(1, fixture.Closed);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task FailedMetadataOrOversizedReplyClosesSession(bool oversized)
+    {
+        var fixture = new Fixture { FailMetadata = !oversized, OversizedBatch = oversized };
+        await using var pages = fixture.Pages().GetAsyncEnumerator();
+        await Assert.ThrowsAnyAsync<Exception>(async () => await pages.MoveNextAsync());
+        Assert.Equal(1, fixture.Closed);
+    }
+
+    [Fact]
+    public async Task ClosingUiSessionWaitsForCancelledReadBeforeDisposing()
+    {
+        int closed = 0;
+        var started = new TaskCompletionSource();
+        async IAsyncEnumerable<NFT[]> Blocked([EnumeratorCancellation] CancellationToken token)
+        {
+            try
+            {
+                started.SetResult();
+                await Task.Delay(Timeout.InfiniteTimeSpan, token);
+                yield return [];
+            }
+            finally { closed++; }
+        }
+        var session = new NftPageSession(Blocked);
+        Task<NFT[]?> read = session.ReadNextAsync();
+        await started.Task;
+        await session.DisposeAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => read);
+        await session.DisposeAsync();
+        Assert.Equal(1, closed);
+    }
+
+    [Fact]
+    public async Task NodeTimeoutPropagatesAsFailureAndClosesSession()
+    {
+        int closed = 0;
+        var sessionId = Guid.NewGuid();
+        var pages = NftPager.ReadAsync(
+            _ => Task.FromResult(new NftIteratorSession(sessionId, [Guid.NewGuid()])),
+            (_, _, _, _) => Task.FromException<byte[][]>(new TaskCanceledException("HTTP timeout")),
+            (_, _, _) => Task.FromResult(Array.Empty<NFT>()),
+            _ => { closed++; return Task.CompletedTask; });
+        await using var session = new NftPageSession(_ => pages);
+        await Assert.ThrowsAsync<TaskCanceledException>(() => session.ReadNextAsync());
+        Assert.Equal(1, closed);
+    }
+}

--- a/tests/p2-06/NftPagingLocalizationTests.cs
+++ b/tests/p2-06/NftPagingLocalizationTests.cs
@@ -1,0 +1,37 @@
+using System.Runtime.CompilerServices;
+using System.Xml.Linq;
+using Xunit;
+
+public class NftPagingLocalizationTests
+{
+    [Theory]
+    [InlineData("de")]
+    [InlineData("es")]
+    [InlineData("fr")]
+    [InlineData("id")]
+    [InlineData("it")]
+    [InlineData("ja")]
+    [InlineData("ko")]
+    [InlineData("nl")]
+    [InlineData("pt-BR")]
+    [InlineData("ru")]
+    [InlineData("tr")]
+    [InlineData("vi")]
+    [InlineData("zh-Hant")]
+    public void ExistingLocaleDefinesBothNftPagingStringsWithoutEnglishFallback(string culture)
+    {
+        string resources = Path.GetFullPath(Path.Combine(TestDirectory(), "../../OneGateApp/Properties"));
+        XDocument neutral = XDocument.Load(Path.Combine(resources, "Strings.resx"));
+        XDocument translated = XDocument.Load(Path.Combine(resources, $"Strings.{culture}.resx"));
+        foreach (string key in new[] { "LoadMoreNFTs", "NFTLoadFailed" })
+        {
+            XElement entry = Assert.Single(translated.Root!.Elements("data"), p => (string?)p.Attribute("name") == key);
+            string? value = (string?)entry.Element("value");
+            Assert.False(string.IsNullOrWhiteSpace(value));
+            string? english = (string?)neutral.Root!.Elements("data").Single(p => (string?)p.Attribute("name") == key).Element("value");
+            Assert.NotEqual(english, value);
+        }
+    }
+
+    static string TestDirectory([CallerFilePath] string source = "") => Path.GetDirectoryName(source)!;
+}

--- a/tests/p2-06/WalletPageBoundary.cs
+++ b/tests/p2-06/WalletPageBoundary.cs
@@ -1,0 +1,60 @@
+// Link the production WalletPage, LoadingService and NftPageSession. Replace
+// only MAUI/storage/navigation and the upstream inventory, not paging logic.
+using Neo.Wallets;
+using NeoOrder.OneGate.Models;
+
+public class ContentPage
+{
+    protected virtual void OnAppearing() { }
+    protected virtual void OnDisappearing() { }
+    protected void OnPropertyChanged(string? name = null) { }
+}
+public sealed class TappedEventArgs : EventArgs { public object Parameter { get; init; } = null!; }
+public sealed class Shell
+{
+    public static Shell Current { get; } = new();
+    public Task GoToAsync(string route, IDictionary<string, object> parameters) => Task.CompletedTask;
+}
+namespace NeoOrder.OneGate.Controls
+{
+    public static class PageRefreshBoundary
+    {
+        public static bool ShouldRefresh(this ContentPage page) => false;
+    }
+}
+namespace NeoOrder.OneGate.Pages
+{
+    public partial class WalletPage
+    {
+        void InitializeComponent() { }
+    }
+}
+namespace NeoOrder.OneGate.Models
+{
+    public sealed class AssetInfo { public decimal? Valuation { get; init; } }
+}
+namespace NeoOrder.OneGate.Data
+{
+    public sealed class ApplicationDbContext { public SettingsBoundary Settings { get; } = new(); }
+    public sealed class SettingsBoundary
+    {
+        public T Get<T>(string key) => default!;
+        public Task PutAsync<T>(string key, T value) => Task.CompletedTask;
+    }
+}
+namespace NeoOrder.OneGate.Services
+{
+    public sealed class TokenManager(Func<CancellationToken, IAsyncEnumerable<NFT[]>> pages)
+    {
+        public Task<IReadOnlyList<AssetInfo>> LoadAssetsAsync() => Task.FromResult<IReadOnlyList<AssetInfo>>([]);
+        public IAsyncEnumerable<NFT[]> LoadNFTPagesAsync(bool includeHiddens = false, CancellationToken cancellationToken = default) => pages(cancellationToken);
+    }
+}
+namespace NeoOrder.OneGate.Properties
+{
+    public static class Strings { public const string LoadingWalletData = "Loading wallet data"; }
+}
+namespace CommunityToolkit.Maui.Alerts
+{
+    public static class Toast { public static Task Show(string message) => Task.CompletedTask; }
+}

--- a/tests/p2-06/WalletPageHandoverTests.cs
+++ b/tests/p2-06/WalletPageHandoverTests.cs
@@ -1,0 +1,109 @@
+using Neo;
+using Neo.Wallets;
+using NeoOrder.OneGate.Data;
+using NeoOrder.OneGate.Models;
+using NeoOrder.OneGate.Pages;
+using NeoOrder.OneGate.Services;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class WalletPageHandoverTests
+{
+    const BindingFlags Hidden = BindingFlags.Instance | BindingFlags.NonPublic;
+    sealed class UnusedWalletProvider : IWalletProvider
+    {
+        public Wallet? GetWallet() => null;
+        public event EventHandler<Wallet?>? WalletChanged { add { } remove { } }
+    }
+
+    sealed class Inventory(int firstPageSize, bool pauseClose = false)
+    {
+        public int Reads;
+        public int Closed;
+        public readonly TaskCompletionSource CloseEntered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public readonly TaskCompletionSource ReleaseClose = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async IAsyncEnumerable<NFT[]> Pages([EnumeratorCancellation] CancellationToken token)
+        {
+            try
+            {
+                token.ThrowIfCancellationRequested();
+                Reads++;
+                yield return Items(firstPageSize);
+                token.ThrowIfCancellationRequested();
+                Reads++;
+                yield return Items(37);
+            }
+            finally
+            {
+                CloseEntered.TrySetResult();
+                if (pauseClose) await ReleaseClose.Task;
+                Closed++;
+            }
+        }
+    }
+
+    static NFT[] Items(int count) => Enumerable.Range(0, count)
+        .Select(i => new NFT { CollectionId = UInt160.Zero, TokenId = BitConverter.GetBytes(i), Name = $"NFT-{i}" }).ToArray();
+    static void LoadMore(WalletPage page) => typeof(WalletPage).GetMethod("OnLoadMoreNFTs", Hidden)!.Invoke(page, [page, EventArgs.Empty]);
+    static Task Refresh(WalletPage page) => (Task)typeof(WalletPage).GetMethod("LoadNFTsAsync", Hidden)!.Invoke(page, null)!;
+    static void Leave(WalletPage page) => typeof(WalletPage).GetMethod("OnDisappearing", Hidden)!.Invoke(page, null);
+
+    [Theory]
+    [InlineData(100)]
+    [InlineData(37)]
+    public async Task HeldPreviousCloseCannotAdmitQueuedLoadMoreOrReadReplacementTwice(int replacementPageSize)
+    {
+        var previous = new Inventory(100, pauseClose: true);
+        var replacement = new Inventory(replacementPageSize);
+        int created = 0;
+        var manager = new TokenManager(token => (++created == 1 ? previous : replacement).Pages(token));
+        var page = new WalletPage(new ApplicationDbContext(), new UnusedWalletProvider(), manager);
+        Assert.Equal(100, page.NFTs.Count);
+        Assert.True(page.HasMoreNFTs);
+        Assert.False(page.LoadingService.IsLoading);
+
+        Task refresh = Refresh(page);
+        try
+        {
+            await previous.CloseEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.False(refresh.IsCompleted);
+            Assert.False(page.HasMoreNFTs);
+            Assert.Empty(page.NFTs);
+            // Invoke the real handler even though the button should be hidden:
+            // this represents a tap queued before refresh changed the binding.
+            LoadMore(page);
+            LoadMore(page);
+            Assert.Equal(0, replacement.Reads);
+            Assert.False(page.NftLoadFailed);
+
+            previous.ReleaseClose.TrySetResult();
+            await refresh.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.Equal(1, previous.Closed);
+            Assert.Equal(1, replacement.Reads);
+            Assert.Equal(replacementPageSize, page.NFTs.Count);
+            Assert.Equal(replacementPageSize == 100, page.HasMoreNFTs);
+            Assert.False(page.NftLoadFailed);
+            Assert.False(page.IsLoadingNFTs);
+
+            if (replacementPageSize == 100)
+            {
+                LoadMore(page);
+                Assert.Equal(137, page.NFTs.Count);
+                Assert.Equal(2, replacement.Reads);
+            }
+            // A queued event after the final page must not read its disposed
+            // session or turn successful completion into a load failure.
+            LoadMore(page);
+            Assert.False(page.NftLoadFailed);
+            Assert.Equal(1, replacement.Closed);
+        }
+        finally
+        {
+            previous.ReleaseClose.TrySetResult();
+            await refresh.WaitAsync(TimeSpan.FromSeconds(5));
+            Leave(page);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The wallet currently stops NFT enumeration after 100 items across all curated collections. This change adds explicit load-more pagination so later items and collections remain reachable, while releasing the node iterator session when enumeration finishes, fails, or the wallet page is left.

- Append pages of up to 100 NFTs; bound iterator and metadata batches to 25, and continue when a node returns a smaller nonempty batch.
- Add loading, load-more, and localized failure states without treating a failed request as an empty NFT collection.
- Keep load-more unavailable while replacing a pagination session; queued clicks cannot consume the first page twice or read an already completed session. Preserve the existing serialized cleanup order.
- Supply the two paging messages in all existing resource locales.
- Cancel active reads before disposing the iterator; terminate remote sessions with an independent cleanup timeout.
- Keep the existing curated NFT collection source. No custom-token entry, dAPI asset picker, or transaction broadcasting is added.

## Validation

- `dotnet test tests/p2-06/NftPager.Tests.csproj --no-restore --nologo`: **22 passed**. Covers 137 NFTs across two collections with a seven-item server limit, disposal/cancellation, failure, oversized replies, serialized cleanup, two production-WalletPage handover regressions and 13 satellite locales.
- **iOS 26.5 / iPhone 17 simulator: follow-up 26/26 native assertions passed.**
- **Android API 36 / arm64 emulator: follow-up 26/26 native assertions passed.**
- Both native runs exercised the actual `WalletPage`, `TokenManager`, and `RpcClient` using controlled HTTP responses: first 100 items, load-more to all 137 including the second collection, iterator cleanup on completion and leaving, fresh first-page loading on return, and bounded requests. No live assets were signed or broadcast. This is synthetic-inventory integration evidence, not live-chain wallet validation.
- Follow-up native runs held the actual `terminatesession` HTTP request. During that wait, two actual load-more handler calls could not start reading the replacement session. After release only its first 100 items loaded; extra clicks after all 137 items completed did not set failure. Each of 13 actual satellite resource sets supplied both keys without parent/English fallback.
- Follow-up product validation: after removing all external QA entry points, both platforms fully rebuilt with zero warnings/errors, installed and displayed the actual Home/four-tab product UI. No OneGate crash was observed; Android's device-wide buffer retained an earlier unrelated system Bluetooth crash.
- The follow-up patch against the initial PR commit `c159c9a` has SHA-256 `b9fc1d71adf60ad3e62c30603a46c0d30df4c19ff0455104520343904af1d520`; full patch against `623603d` is `3d5e097d003edba687aee579b1420034b0f85256a623244fe9bbb169b4633cb5`. Both native follow-up runs match these hashes; older 8-check runs are not used as substitute evidence. Screenshots and QA artifacts remain outside the repository; no uploaded screenshot or hosted CI result is claimed here.

## Limits and integration notes

- A node may expire an idle iterator session. This change does not add keepalive or cursor resumption; a later failure preserves already displayed items and asks the user to pull down to restart loading.
- Leaving the wallet page releases its session. Returning, including from NFT details, reloads the first page of up to 100 items; later-page position and scrolling are not preserved.
- This is an independent change against `master` at `623603d634f07eaead14745da87920a356159be0`, not a combined validation of other audit branches. When integrating other accepted `RpcClient` fixes, preserve their transfer/signer checks alongside this cancellation and pagination code; linked-source test projects that include `RpcClient` will also need the new pager source.
- Preserve the solution test-project and localization-key union when integrating other independent PRs. The new test project retains a non-build/non-output relationship to the app without triggering MAUI builds for its standalone test run.
