### PR TITLE
Clean up deferred remote debug operations by session

### DIFF
--- a/OneGateApp.slnx
+++ b/OneGateApp.slnx
@@ -6,4 +6,5 @@
   <Project Path="OneGate.DebugProtocol/OneGate.DebugProtocol.csproj" />
   <Project Path="OneGate.DebugProtocol.Tests/OneGate.DebugProtocol.Tests.csproj" />
   <Project Path="OneGate.Tools/OneGate.Tools.csproj" />
+  <Project Path="tests/p2-20/OperationTests.csproj" />
 </Solution>

--- a/OneGateApp/Services/RemoteDebug/RemoteDebugOperationStore.cs
+++ b/OneGateApp/Services/RemoteDebug/RemoteDebugOperationStore.cs
@@ -1,0 +1,160 @@
+namespace NeoOrder.OneGate.Services.RemoteDebug;
+
+sealed class RemoteDebugOperationStore<T> : IDisposable
+{
+    sealed class Entry
+    {
+        public Entry(string sessionId)
+        {
+            SessionId = sessionId;
+            Token = Cancellation.Token;
+        }
+        public string SessionId { get; }
+        public TaskCompletionSource<T> Completion { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public CancellationTokenSource Cancellation { get; } = new(Lifetime);
+        public CancellationToken Token { get; }
+        public DateTimeOffset ExpiresAt { get; } = DateTimeOffset.UtcNow + Lifetime;
+    }
+    readonly object gate = new();
+    readonly Dictionary<string, Entry> entries = new(StringComparer.Ordinal);
+    readonly HashSet<string> removingSessions = new(StringComparer.Ordinal);
+    static readonly TimeSpan Lifetime = TimeSpan.FromMinutes(2);
+    readonly int maximumOperations;
+    readonly Timer cleanup;
+    bool clearing;
+    bool disposed;
+
+    public RemoteDebugOperationStore(int maximumOperations = 64)
+    {
+        this.maximumOperations = maximumOperations;
+        cleanup = new Timer(_ => RemoveExpired(), null, Lifetime, Lifetime);
+    }
+
+    public string Start(string sessionId, Func<CancellationToken, Task<T>> start)
+    {
+        ArgumentNullException.ThrowIfNull(start);
+        RemoveExpired();
+        string id = Guid.NewGuid().ToString("N");
+        Entry entry;
+        lock (gate)
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+            if (clearing || removingSessions.Contains(sessionId))
+                throw new InvalidOperationException("The deferred operation session is stopping.");
+            if (entries.Count >= maximumOperations)
+                throw new InvalidOperationException("Too many deferred operations; collect or stop existing operations first.");
+            entry = new(sessionId);
+            entries.Add(id, entry);
+        }
+        // Reserve capacity first, but never execute host code while holding the
+        // registry lock. The completion proxy exists even during synchronous start.
+        _ = entry.Completion.Task.ContinueWith(t => _ = t.Exception,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+        try
+        {
+            entry.Token.ThrowIfCancellationRequested();
+            Task<T> task = start(entry.Token);
+            _ = task.ContinueWith(t => _ = t.Exception,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+            _ = CompleteAsync(entry, task);
+            return id;
+        }
+        catch (Exception ex)
+        {
+            bool ownsEntry;
+            lock (gate) ownsEntry = entries.Remove(id);
+            entry.Completion.TrySetException(ex);
+            if (ownsEntry) entry.Cancellation.Dispose();
+            throw;
+        }
+    }
+
+    static async Task CompleteAsync(Entry entry, Task<T> task)
+    {
+        try { entry.Completion.TrySetResult(await task.WaitAsync(entry.Token)); }
+        catch (OperationCanceledException) { entry.Completion.TrySetCanceled(entry.Token); }
+        catch (Exception ex) { entry.Completion.TrySetException(ex); }
+    }
+
+    public bool TryGet(string sessionId, string id, out Task<T>? operation)
+    {
+        RemoveExpired();
+        lock (gate)
+        {
+            operation = null;
+            if (!entries.TryGetValue(id, out var entry) || entry.SessionId != sessionId) return false;
+            operation = entry.Completion.Task;
+            if (operation.IsCompleted)
+            {
+                entries.Remove(id);
+                entry.Cancellation.Dispose();
+            }
+            return true;
+        }
+    }
+
+    public void RemoveSession(string sessionId)
+    {
+        Entry[] removed;
+        lock (gate)
+        {
+            if (!removingSessions.Add(sessionId)) return;
+            removed = TakeEntries(p => p.SessionId == sessionId);
+        }
+        try { Cancel(removed); }
+        finally { lock (gate) removingSessions.Remove(sessionId); }
+    }
+
+    void RemoveExpired()
+    {
+        Entry[] removed;
+        lock (gate) removed = TakeEntries(p => p.ExpiresAt <= DateTimeOffset.UtcNow);
+        Cancel(removed);
+    }
+
+    // Caller holds gate. Cancellation and its arbitrary callbacks happen later.
+    Entry[] TakeEntries(Func<Entry, bool> predicate)
+    {
+        var removed = entries.Where(p => predicate(p.Value)).ToArray();
+        foreach (var pair in removed) entries.Remove(pair.Key);
+        return removed.Select(p => p.Value).ToArray();
+    }
+
+    static void Cancel(Entry[] removed)
+    {
+        foreach (var entry in removed)
+        {
+            entry.Completion.TrySetCanceled(entry.Token);
+            try { entry.Cancellation.Cancel(); }
+            // A failing consumer callback must not prevent cleanup of the rest.
+            catch (AggregateException) { }
+            finally { entry.Cancellation.Dispose(); }
+        }
+    }
+
+    public void Clear()
+    {
+        Entry[] removed;
+        lock (gate)
+        {
+            if (clearing) return;
+            clearing = true;
+            removed = TakeEntries(_ => true);
+        }
+        try { Cancel(removed); }
+        finally { lock (gate) clearing = false; }
+    }
+
+    public void Dispose()
+    {
+        Entry[] removed;
+        lock (gate)
+        {
+            if (disposed) return;
+            disposed = true;
+            removed = TakeEntries(_ => true);
+        }
+        cleanup.Dispose();
+        Cancel(removed);
+    }
+}

--- a/OneGateApp/Services/RemoteDebug/RemoteDebugService.cs
+++ b/OneGateApp/Services/RemoteDebug/RemoteDebugService.cs
@@ -17,7 +17,7 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
     readonly SemaphoreSlim stateLock = new(1, 1);
     readonly SemaphoreSlim connectLock = new(1, 1);
     readonly ConcurrentDictionary<string, RemoteDebugSession> sessions = new(StringComparer.Ordinal);
-    readonly ConcurrentDictionary<string, Task<JsonNode?>> operations = new(StringComparer.Ordinal);
+    readonly RemoteDebugOperationStore<JsonNode?> operations = new();
     DebugIdentity? debugTargetIdentity;
     List<TrustedRemoteDebugger> debuggers = [];
     MdnsRemoteDebuggerDiscovery? discovery;
@@ -113,6 +113,7 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
         if (!sessions.TryGetValue(sessionId, out RemoteDebugSession? session) || !ReferenceEquals(session.Host, host))
             return;
         sessions.TryRemove(sessionId, out _);
+        operations.RemoveSession(sessionId);
         session.RejectAll();
         _ = connection?.SendEventAsync("session.closed", new JsonObject { ["sessionId"] = sessionId });
     }
@@ -408,11 +409,13 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
     {
         string expression = parameters["expression"]?.GetValue<string>()
             ?? throw new RemoteDebugCommandException("INVALID_ARGUMENT", "expression is required.");
-        Task<JsonNode?> task = RequireHost(parameters).EvaluateRemoteAsync(expression);
+        RemoteDebugSession session = GetSession(parameters);
+        IRemoteDebugSessionHost host = RequireHost(parameters);
         if (parameters["defer"]?.GetValue<bool>() != true)
-            return new JsonObject { ["value"] = await task };
-        string operationId = Guid.NewGuid().ToString("N");
-        operations[operationId] = task;
+            return new JsonObject { ["value"] = await host.EvaluateRemoteAsync(expression) };
+        string operationId = operations.Start(session.Id, token => host.EvaluateRemoteAsync(expression).WaitAsync(token));
+        // A disconnect can remove the session while the UI starts evaluation.
+        if (!sessions.ContainsKey(session.Id)) operations.RemoveSession(session.Id);
         return new JsonObject { ["deferred"] = true, ["operationId"] = operationId };
     }
 
@@ -426,6 +429,7 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
     {
         RemoteDebugSession session = GetSession(parameters);
         sessions.TryRemove(session.Id, out _);
+        operations.RemoveSession(session.Id);
         session.RejectAll();
         if (session.Host is not null) await session.Host.StopRemoteAsync();
         return new JsonObject { ["sessionId"] = session.Id, ["stopped"] = true };
@@ -458,11 +462,10 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
     {
         string operationId = parameters["operationId"]?.GetValue<string>()
             ?? throw new RemoteDebugCommandException("INVALID_ARGUMENT", "operationId is required.");
-        if (!operations.TryGetValue(operationId, out Task<JsonNode?>? operation))
+        if (!operations.TryGet(GetSession(parameters).Id, operationId, out Task<JsonNode?>? operation))
             throw new RemoteDebugCommandException("OPERATION_NOT_FOUND", $"Deferred operation was not found: {operationId}");
-        if (!operation.IsCompleted)
+        if (!operation!.IsCompleted)
             return new JsonObject { ["operationId"] = operationId, ["state"] = "pending" };
-        operations.TryRemove(operationId, out _);
         return new JsonObject { ["operationId"] = operationId, ["state"] = "completed", ["value"] = await operation };
     }
 
@@ -482,6 +485,7 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
     {
         RemoteDebugSession[] active = sessions.Values.ToArray();
         sessions.Clear();
+        operations.Clear();
         foreach (RemoteDebugSession session in active) session.RejectAll();
         await MainThread.InvokeOnMainThreadAsync(async () =>
         {
@@ -497,6 +501,7 @@ public sealed class RemoteDebugService(IServiceProvider serviceProvider) : IAsyn
         debugTargetIdentity?.Dispose();
         stateLock.Dispose();
         connectLock.Dispose();
+        operations.Dispose();
     }
 }
 

--- a/tests/p2-20/OperationTests.cs
+++ b/tests/p2-20/OperationTests.cs
@@ -1,0 +1,76 @@
+using NeoOrder.OneGate.Services.RemoteDebug;
+using Xunit;
+
+public class OperationTests
+{
+    [Fact]
+    public void DisposeRejectsNewOperationsBeforeInvokingTheDelegate()
+    {
+        var store = new RemoteDebugOperationStore<int>();
+        store.Dispose();
+        bool started = false;
+        Assert.Throws<ObjectDisposedException>(() => store.Start("session", _ => { started = true; return Task.FromResult(1); }));
+        Assert.False(started);
+    }
+
+    [Fact]
+    public void ClearCannotBeReenteredToResurrectAnOperation()
+    {
+        using var store = new RemoteDebugOperationStore<int>();
+        bool rejected = false;
+        store.Start("session", token =>
+        {
+            token.Register(() => rejected = Record.Exception(() => store.Start("session", _ => Task.FromResult(2))) is InvalidOperationException);
+            return new TaskCompletionSource<int>().Task;
+        });
+        store.Clear();
+        Assert.True(rejected);
+        // Clearing is temporary; a later valid session can start again.
+        store.Start("next", _ => Task.FromResult(3));
+    }
+
+    [Fact]
+    public void StartAndCancellationCallbacksDoNotExecuteUnderTheRegistryLock()
+    {
+        using var store = new RemoteDebugOperationStore<int>();
+        bool cancelledOutsideLock = false;
+        bool ReadFromAnotherThread() => Task.Run(() => store.TryGet("missing", "missing", out _)).Wait(TimeSpan.FromSeconds(1));
+        store.Start("session", token =>
+        {
+            Assert.True(ReadFromAnotherThread());
+            token.Register(() => cancelledOutsideLock = ReadFromAnotherThread());
+            return new TaskCompletionSource<int>().Task;
+        });
+        store.RemoveSession("session");
+        Assert.True(cancelledOutsideLock);
+    }
+
+    [Fact]
+    public async Task RemovingSessionCancelsItsOperationsAndKeepsOthers()
+    {
+        using var store = new RemoteDebugOperationStore<int>();
+        var pending = new TaskCompletionSource<int>();
+        string first = store.Start("first", token => pending.Task.WaitAsync(token));
+        string second = store.Start("second", _ => Task.FromResult(42));
+        Assert.True(store.TryGet("first", first, out var waiting));
+        store.RemoveSession("first");
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => waiting!);
+        Assert.False(store.TryGet("first", first, out _));
+        Assert.False(store.TryGet("first", second, out _));
+        Assert.True(store.TryGet("second", second, out var completed));
+        Assert.Equal(42, await completed!);
+        Assert.False(store.TryGet("second", second, out _));
+    }
+
+    [Fact]
+    public void CapacityIsCheckedBeforeStartingMoreJavaScript()
+    {
+        using var store = new RemoteDebugOperationStore<int>(maximumOperations: 1);
+        store.Start("session", _ => Task.FromResult(1));
+        bool started = false;
+        Assert.Throws<InvalidOperationException>(() => store.Start("session", _ => { started = true; return Task.FromResult(2); }));
+        Assert.False(started);
+        store.Clear();
+        store.Start("session", _ => Task.FromResult(3));
+    }
+}

--- a/tests/p2-20/OperationTests.csproj
+++ b/tests/p2-20/OperationTests.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup><TargetFramework>net10.0</TargetFramework><ImplicitUsings>enable</ImplicitUsings><Nullable>enable</Nullable><IsTestProject>true</IsTestProject></PropertyGroup>
+  <ItemGroup><PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"/><PackageReference Include="xunit" Version="2.9.3"/><PackageReference Include="xunit.runner.visualstudio" Version="3.1.4"/></ItemGroup>
+  <ItemGroup><Compile Include="../../OneGateApp/Services/RemoteDebug/RemoteDebugOperationStore.cs" Link="RemoteDebugOperationStore.cs"/></ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../OneGateApp/OneGateApp.csproj" ReferenceOutputAssembly="false" BuildReference="false" SkipGetTargetFrameworkProperties="true" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Problem

Deferred remote-debug evaluations were stored in an unbounded dictionary without session ownership or cleanup when their session ended. Uncollected operations and pending waits could outlive the host or debugger connection.

## Change

- Track existing deferred operations by session, with bounded capacity and a two-minute lifetime.
- Reserve capacity before invoking host code, and run host/cancellation callbacks outside the registry lock.
- Remove session operations on host closure or session stop; clear pending waits during connection teardown and dispose the registry with the service.
- Keep the existing remote-debug command surface. This does not add a NEP-21 method, connected-app permission center, local transaction history, or alternative dApp window navigation.

This independent change addresses audit P2-20 only, based on master `623603d634f07eaead14745da87920a356159be0`.

## Validation

- `git diff --check 623603d` passed during publication preparation.
- Five focused tests are registered in `tests/p2-20/OperationTests.csproj`, covering disposal, reentrant cancellation, callback lock boundaries, session ownership/cleanup, and capacity-before-execution. The project is included in `OneGateApp.slnx` and retains a non-build/non-output reference to `OneGateApp.csproj`.
- The publisher re-ran `dotnet test --no-restore tests/p2-20/OperationTests.csproj`: **5/5 passed**, with the reviewed source diff hash unchanged.
- Android API 36 arm64 emulator: **5/5 native fixture assertions passed** against the production `LaunchDAppPage` and `RemoteDebugService`/operation store. After removing the fixture and restoring product startup, a full product rebuild passed with zero warnings/errors, followed by successful install and the actual Welcome screen with Create wallet / Import wallet actions. This product smoke launch is separate from the native lifecycle evidence.
- iPhone 17 / iOS 26.5 simulator: **5/5 matching native fixture assertions passed**. The fixture was removed; a full product rebuild passed with zero warnings/errors, and the actual product launched with Home content and all four tabs.

Both native runs match the complete reviewed source diff SHA256 `90d12525ac0071f552afc64717285f25aea4524d03b37507f164f5df6c712b9f`.

## Native coverage and limits

The external fixture created a real native dApp host, invoked production deferred evaluation and host-closure notification, then disabled developer mode to verify registry cleanup and cancellation. A `TaskCompletionSource` controlled the pending wait; the host used a reserved `.invalid` URL. These are native-host/service lifecycle checks, not a live debugger handshake, production `session.start` navigation test, successful remote JavaScript result, or wallet/chain execution. No signing or transaction broadcast occurred. Fixtures, screenshots and result JSON are not committed.

## Remaining review gates

- The current upstream master was rechecked as `623603d634f07eaead14745da87920a356159be0`, and no PR already exists for this fork branch. The final historical review gate permits this scoped fix; that is not maintainer approval of this patch.
- Pending: required hosted checks and mergeability after publication; no hosted CI pass is claimed here.
- Pending: upload the current iOS and Android screenshots as GitHub-hosted PR assets.
- This PR is submitted for review; the checks and screenshots above are not claimed complete. If combined later with the independent P1-04 lifecycle fix, integrate operation cleanup into its drained `DisposeCoreAsync` rather than restoring the old immediate semaphore disposal.
