### PR TITLE
Treat biometric cancellation as rejected authorization

### DIFF
--- a/OneGateApp.slnx
+++ b/OneGateApp.slnx
@@ -6,4 +6,5 @@
   <Project Path="OneGate.DebugProtocol/OneGate.DebugProtocol.csproj" />
   <Project Path="OneGate.DebugProtocol.Tests/OneGate.DebugProtocol.Tests.csproj" />
   <Project Path="OneGate.Tools/OneGate.Tools.csproj" />
+  <Project Path="tests/P2-03/AuthorizationCancellation.Tests.csproj" />
 </Solution>

--- a/OneGateApp/Services/DataProtectionService.Android.cs
+++ b/OneGateApp/Services/DataProtectionService.Android.cs
@@ -129,7 +129,7 @@ partial class DataProtectionService
         var builder = new BiometricPrompt.Builder(activity)
             .SetTitle(title ?? Strings.BiometricAuthentication)
             .SetSubtitle(message ?? Strings.VerifyBiometricText);
-        builder = builder.SetNegativeButton(Strings.Cancel, executor, new NegativeClickListener(() => tcs.TrySetCanceled()));
+        builder = builder.SetNegativeButton(Strings.Cancel, executor, new NegativeClickListener(() => tcs.TrySetResult(false)));
         var prompt = builder.Build();
         if (cipher is null)
         {

--- a/OneGateApp/Services/WalletAuthorizationService.cs
+++ b/OneGateApp/Services/WalletAuthorizationService.cs
@@ -10,6 +10,20 @@ public class WalletAuthorizationService(IServiceProvider serviceProvider, Applic
 {
     public async Task<bool> RequestAuthorizationAsync(Page page, string title, string? message = null, string? domain = null)
     {
+        try
+        {
+            return await RequestAuthorizationCoreAsync(page, title, message, domain);
+        }
+        catch (OperationCanceledException)
+        {
+            // Cancelling an authorization is a rejected request in every path,
+            // including when the in-memory wallet has already been unlocked.
+            return false;
+        }
+    }
+
+    async Task<bool> RequestAuthorizationCoreAsync(Page page, string title, string? message, string? domain)
+    {
         byte[]? credential = await dbContext.Settings.GetAsync<byte[]>("biometric/credential");
         if (credential is null)
         {
@@ -35,19 +49,11 @@ public class WalletAuthorizationService(IServiceProvider serviceProvider, Applic
             }
             else
             {
-                string password;
                 using var progressOverlay = new ProgressWindowOverlay(page.GetParentWindow(), title, Strings.UnlockingWallet);
-                try
-                {
-                    password = await DataProtectionService.UnprotectAsync(credential, title, message);
-                    if (!await Task.Run(() => wallet.VerifyPassword(password)))
-                        throw new InvalidOperationException("Stored credential is invalid.");
-                    return true;
-                }
-                catch (OperationCanceledException)
-                {
-                    return false;
-                }
+                string password = await DataProtectionService.UnprotectAsync(credential, title, message);
+                if (!await Task.Run(() => wallet.VerifyPassword(password)))
+                    throw new InvalidOperationException("Stored credential is invalid.");
+                return true;
             }
         }
     }

--- a/tests/P2-03/AuthorizationCancellation.Tests.csproj
+++ b/tests/P2-03/AuthorizationCancellation.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../OneGateApp/OneGateApp.csproj" ReferenceOutputAssembly="false" BuildReference="false" SkipGetTargetFrameworkProperties="true" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="Neo" Version="3.10.0" />
+    <Compile Include="../../OneGateApp/Services/WalletAuthorizationService.cs" Link="WalletAuthorizationService.cs" />
+  </ItemGroup>
+</Project>

--- a/tests/P2-03/AuthorizationCancellationTests.cs
+++ b/tests/P2-03/AuthorizationCancellationTests.cs
@@ -1,0 +1,74 @@
+using Neo;
+using Neo.Wallets;
+using NeoOrder.OneGate.Data;
+using NeoOrder.OneGate.Services;
+using Xunit;
+
+public class AuthorizationCancellationTests
+{
+    [Fact]
+    public async Task Unlocked_wallet_cancelled_biometrics_returns_false()
+    {
+        using var fixture = new WalletFixture(locked: false);
+        DataProtectionService.Authenticate = () => Task.FromCanceled<bool>(new CancellationToken(true));
+        Assert.False(await fixture.Service.RequestAuthorizationAsync(new Page(), "Export"));
+    }
+
+    [Fact]
+    public async Task Locked_wallet_cancelled_biometrics_returns_false_and_stays_locked()
+    {
+        using var fixture = new WalletFixture(locked: true);
+        DataProtectionService.Unprotect = () => Task.FromCanceled<string>(new CancellationToken(true));
+        Assert.False(await fixture.Service.RequestAuthorizationAsync(new Page(), "Send"));
+        Assert.False(fixture.Wallet.IsUnlocked);
+    }
+
+    [Fact]
+    public async Task Rejected_biometrics_does_not_authorize()
+    {
+        using var fixture = new WalletFixture(locked: false);
+        DataProtectionService.Authenticate = () => Task.FromResult(false);
+        Assert.False(await fixture.Service.RequestAuthorizationAsync(new Page(), "Send"));
+    }
+
+    [Fact]
+    public async Task Successful_biometrics_authorizes_both_wallet_states()
+    {
+        using var fixture = new WalletFixture(locked: true);
+        DataProtectionService.Unprotect = () => Task.FromResult(WalletFixture.Password);
+        Assert.True(await fixture.Service.RequestAuthorizationAsync(new Page(), "Export"));
+        Assert.True(fixture.Wallet.IsUnlocked);
+        DataProtectionService.Authenticate = () => Task.FromResult(true);
+        Assert.True(await fixture.Service.RequestAuthorizationAsync(new Page(), "Export"));
+    }
+
+    [Fact]
+    public async Task System_failure_is_not_silently_converted_to_user_cancellation()
+    {
+        using var fixture = new WalletFixture(locked: false);
+        DataProtectionService.Authenticate = () => Task.FromException<bool>(new InvalidOperationException("Biometric hardware unavailable"));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => fixture.Service.RequestAuthorizationAsync(new Page(), "Export"));
+    }
+}
+
+sealed class WalletFixture : IWalletProvider, IDisposable
+{
+    public const string Password = "disposable-authorization-password";
+    readonly string directory = Directory.CreateTempSubdirectory("onegate-authorization-test-").FullName;
+    public Wallet Wallet { get; }
+    public WalletAuthorizationService Service { get; }
+    public event EventHandler<Wallet?>? WalletChanged { add { } remove { } }
+    public WalletFixture(bool locked)
+    {
+        string path = Path.Combine(directory, "wallet.json");
+        Wallet = Neo.Wallets.Wallet.Create("Disposable authorization wallet", path, Password, ProtocolSettings.Default)!;
+        Wallet.CreateAccount();
+        Wallet.Save();
+        if (locked) Wallet = Neo.Wallets.Wallet.Open(path, null, ProtocolSettings.Default)!;
+        DataProtectionService.Authenticate = () => throw new InvalidOperationException("Unexpected authentication branch");
+        DataProtectionService.Unprotect = () => throw new InvalidOperationException("Unexpected unprotect branch");
+        Service = new(new EmptyServices(), new ApplicationDbContext(), this);
+    }
+    public Wallet? GetWallet() => Wallet;
+    public void Dispose() => Directory.Delete(directory, true);
+}

--- a/tests/P2-03/PlatformStubs.cs
+++ b/tests/P2-03/PlatformStubs.cs
@@ -1,0 +1,57 @@
+// Exercise the linked production authorization service with real Neo wallet
+// states, replacing only platform prompts, MAUI views and the settings store.
+public sealed class Page { public object GetParentWindow() => new(); }
+public sealed class EmptyServices : IServiceProvider { public object? GetService(Type type) => null; }
+namespace NeoOrder.OneGate.Services
+{
+    public static class ServiceExtensions
+    {
+        public static T GetServiceOrCreateInstance<T>(this IServiceProvider services) where T : new() => new();
+    }
+    public sealed class ProgressWindowOverlay : IDisposable
+    {
+        public ProgressWindowOverlay(object window, string title, string message) { }
+        public void Dispose() { }
+    }
+    public static class DataProtectionService
+    {
+        public static Func<Task<bool>> Authenticate { get; set; } = () => Task.FromResult(false);
+        public static Func<Task<string>> Unprotect { get; set; } = () => Task.FromResult("");
+        public static Task<bool> AuthenticateAsync(string title, string? message) => Authenticate();
+        public static Task<string> UnprotectAsync(byte[] credential, string title, string? message) => Unprotect();
+    }
+}
+namespace NeoOrder.OneGate.Controls.Popups
+{
+    public sealed class WalletAuthorizationPopup
+    {
+        public string? Title { get; set; }
+        public string? Message { get; set; }
+        public string? Domain { get; set; }
+    }
+}
+namespace CommunityToolkit.Maui.Extensions
+{
+    public sealed class PopupResult<T> { public T? Result { get; set; } }
+    public static class PopupExtensions
+    {
+        public static Task<PopupResult<T>> ShowPopupAsync<T>(this Page page, object popup) => Task.FromResult(new PopupResult<T>());
+    }
+}
+namespace NeoOrder.OneGate.Data
+{
+    public sealed class ApplicationDbContext { public SettingsStore Settings { get; } = new(); }
+    public sealed class SettingsStore
+    {
+        public Task<T?> GetAsync<T>(string key) => Task.FromResult((T?)(object)new byte[] { 1 });
+    }
+}
+namespace NeoOrder.OneGate.Properties
+{
+    public static class Strings
+    {
+        public const string LoginRequestText = "Login request";
+        public const string Domain = "Domain";
+        public const string UnlockingWallet = "Unlocking wallet";
+    }
+}

--- a/tests/P2-03/README.md
+++ b/tests/P2-03/README.md
@@ -1,0 +1,15 @@
+# P2-03 consistent authorization cancellation
+
+Run `dotnet test tests/P2-03/AuthorizationCancellation.Tests.csproj`.
+
+Tests link the production WalletAuthorizationService and use Neo 3.10.0 to
+create disposable locked/unlocked wallets. Platform prompt doubles inject user
+cancellation, rejection, success and a separate hardware error. No credentials
+or real wallets are accessed. This verifies cancellation semantics rather than
+claiming that a desktop test displays the native biometric prompt.
+
+On both mobile simulators: use a disposable wallet and enrolled test biometrics,
+authorize once, then cancel another transfer/export authorization. Cancellation
+must return to the previous screen without a signature, export or crash.
+Repeat after a cold start while the wallet is locked. Real native cancellation
+and both caller flows are required before submission.


### PR DESCRIPTION
## Problem

Cancelling a biometric authorization could escape as an exception when the wallet was already unlocked, instead of rejecting the authorization normally. The Android native negative button also completed the prompt task as cancelled rather than returning a rejected result.

## Change

- Treat `OperationCanceledException` consistently as `false` at the existing wallet-authorization boundary, including the already-unlocked path.
- Return `false` from Android's existing biometric negative button.
- Preserve successful authorization and propagate unrelated system failures. No new authorization entry point, domain prompt, connected-app grant, or public-address permission is added.

This independent change addresses audit P2-03 only, based on master `623603d634f07eaead14745da87920a356159be0`.

## Validation

- `git diff --check 623603d` passed during publication preparation.
- Five focused tests are registered in `tests/P2-03/AuthorizationCancellation.Tests.csproj`, covering locked/unlocked cancellation, rejection, successful authorization in both wallet states, and propagation of unrelated errors. They link the production authorization service and use disposable real Neo wallets, with platform-prompt, MAUI-view and settings doubles.
- The test project is included in `OneGateApp.slnx` and retains a non-build/non-output reference to `OneGateApp.csproj`.
- Publication rerun: **5/5 passed**, `dotnet test tests/P2-03/AuthorizationCancellation.Tests.csproj --no-restore --verbosity minimal`.
- Android API 36 arm64 emulator: **3/3 native cancellation checks passed for an already-unlocked disposable wallet**. The real fingerprint negative button was exercised through the production authorization service, actual `ExportWalletPage`, and actual `SendTransactionPopup`; cancellation left export data undisclosed and transfer approval incomplete. No fingerprint match, signature or transaction broadcast occurred.
- After removing the external fixture and restoring product startup, the Android full product rebuild passed with zero warnings/errors, followed by successful install and product smoke launch. Product startup is separate from the functional cancellation evidence above.
- iPhone 17 / iOS 26.5 simulator: **3/3 real system-biometric cancellation checks passed for an already-unlocked disposable wallet**, through the production authorization service, export page and transfer popup. Simulator Face ID was enrolled; the actual system presentation was observed and cancelled. Initial unenrolled rejection and an interaction timeout were retained as failed attempts, then successfully rerun, not counted as passing evidence.
- iOS: removed the external fixture, fully rebuilt with zero warnings/errors, installed the product and verified Home/four-tab startup. No private key was shown and no transaction was signed or broadcast.

Both platform source snapshots match the complete reviewed diff SHA256 `d3be7ee2e10155ade9c8a8969edd074e74d9b0de9668a5b3edc8938bb5ef621b`. Both changed production files also match the restored Android build copy byte-for-byte. Fixtures, screenshots and result JSON are not committed.

## Scope and limits

This fixes the already-unlocked cancellation path. Locked-wallet cancellation and successful authorization are covered by local regression tests, not native cold-start/locked-wallet device-flow checks. iOS native rejection returns a boolean and does not demonstrate Android's prior cancellation exception. No live-wallet signing or transfer was performed.

Screenshots remain outside the repository and have not been uploaded as GitHub assets. Hosted CI results and maintainer approval are not claimed.
