### PR TITLE
Reject transaction signers without verification contracts

### DIFF
--- a/OneGateApp.slnx
+++ b/OneGateApp.slnx
@@ -6,4 +6,5 @@
   <Project Path="OneGate.DebugProtocol/OneGate.DebugProtocol.csproj" />
   <Project Path="OneGate.DebugProtocol.Tests/OneGate.DebugProtocol.Tests.csproj" />
   <Project Path="OneGate.Tools/OneGate.Tools.csproj" />
+  <Project Path="tests/p2-14/P2-14.Tests.csproj" />
 </Solution>

--- a/OneGateApp/Services/RPC/RpcClient.cs
+++ b/OneGateApp/Services/RPC/RpcClient.cs
@@ -252,14 +252,26 @@ public class RpcClient(IWalletProvider walletProvider, ProtocolSettings protocol
     {
         signers ??= [];
         attributes ??= [];
-        Wallet wallet = walletProvider.GetWallet()!;
+        Wallet wallet = walletProvider.GetWallet()
+            ?? throw new DapiException(10003, "No wallet is open");
         UInt160[] accounts = sender is null
             ? signers.Where(p => wallet.Contains(p.Account)).Select(p => p.Account).ToArray()
             : [sender];
-        if (accounts.Length == 0) accounts = wallet.GetAccounts().Select(p => p.ScriptHash).ToArray();
+        if (accounts.Length == 0)
+            accounts = wallet.GetAccounts().Where(p => p.Contract is not null).Select(p => p.ScriptHash).ToArray();
+        if (accounts.Length == 0)
+            throw new DapiException(10003, "No wallet account with a known verification script is available");
         foreach (var account in accounts)
         {
             Signer[] signersReorder = GetSigners(account, signers);
+            // A signer hash alone does not provide the verification script needed
+            // for fee estimation. Reject unsupported construction before simulation.
+            Witness[] witnesses = signersReorder.Select(p =>
+            {
+                Neo.SmartContract.Contract contract = wallet.GetAccount(p.Account)?.Contract
+                    ?? throw new DapiException(10001, "Transaction construction requires a known verification script for every signer");
+                return new Witness { InvocationScript = default, VerificationScript = contract.Script };
+            }).ToArray();
             var result = await InvokeScript(script, signersReorder);
             if (result.State == VMState.FAULT)
                 throw new DapiException(10004, "Script execution failed", result);
@@ -270,10 +282,7 @@ public class RpcClient(IWalletProvider walletProvider, ProtocolSettings protocol
                 Signers = signersReorder,
                 Attributes = attributes,
                 Script = script,
-                Witnesses = signersReorder
-                    .Select(p => wallet.GetAccount(p.Account)!)
-                    .Select(p => new Witness { InvocationScript = default, VerificationScript = p.Contract!.Script })
-                    .ToArray()
+                Witnesses = witnesses
             };
             if (options?.SuggestedSystemFee.HasValue == true)
                 tx.SystemFee = options.SuggestedSystemFee.Value;

--- a/tests/p2-14/P2-14.Tests.csproj
+++ b/tests/p2-14/P2-14.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Neo" Version="3.10.0" />
+    <Compile Include="../../OneGateApp/Services/RPC/RpcClient.cs" Link="RpcClient.cs" />
+    <Compile Include="../../OneGateApp/Services/RPC/RpcException.cs" Link="RpcException.cs" />
+    <Compile Include="../../OneGateApp/Services/RPC/Converters/*.cs" Link="Converters/%(Filename)%(Extension)" />
+    <Compile Include="../../OneGateApp/Services/SharedOptions.cs" Link="SharedOptions.cs" />
+    <Compile Include="../../OneGateApp/Models/DapiException.cs" Link="Models/DapiException.cs" />
+    <Compile Include="../../OneGateApp/Models/InvocationResult.cs" Link="Models/InvocationResult.cs" />
+    <Compile Include="../../OneGateApp/Models/TransactionOptions.cs" Link="Models/TransactionOptions.cs" />
+    <Compile Include="../../OneGateApp/Models/TokenInfo.cs" Link="Models/TokenInfo.cs" />
+    <Compile Include="../../OneGateApp/Models/Nep11TokenInfo.cs" Link="Models/Nep11TokenInfo.cs" />
+    <Compile Include="../../OneGateApp/Models/ITokenInfo.cs" Link="Models/ITokenInfo.cs" />
+    <Compile Include="../../OneGateApp/Models/NFT.cs" Link="Models/NFT.cs" />
+    <Compile Include="../../OneGateApp/Models/Notification.cs" Link="Models/Notification.cs" />
+    <Compile Include="../../OneGateApp/Models/Extensions.cs" Link="Models/Extensions.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../OneGateApp/OneGateApp.csproj"
+                      ReferenceOutputAssembly="false" BuildReference="false"
+                      SkipGetTargetFrameworkProperties="true" />
+  </ItemGroup>
+</Project>

--- a/tests/p2-14/PlatformStubs.cs
+++ b/tests/p2-14/PlatformStubs.cs
@@ -1,0 +1,15 @@
+// Only MAUI directory access and unused diagnostic UI types are stubbed.
+// RpcClient, its serializers, transaction models, and Neo wallets are real sources.
+namespace NeoOrder.OneGate.Services
+{
+    static class FileSystem
+    {
+        public static string AppDataDirectory => Path.GetTempPath();
+        public static string CacheDirectory => Path.GetTempPath();
+    }
+}
+
+namespace NeoOrder.OneGate.Models.Diagnostics
+{
+    public class Diagnostic { }
+}

--- a/tests/p2-14/Program.cs
+++ b/tests/p2-14/Program.cs
@@ -1,0 +1,168 @@
+using Neo;
+using Neo.Cryptography.ECC;
+using Neo.Network.P2P.Payloads;
+using Neo.SmartContract;
+using Neo.Wallets;
+using Neo.Wallets.NEP6;
+using NeoOrder.OneGate.Models;
+using NeoOrder.OneGate.Services.RPC;
+using System.Net;
+using System.Reflection;
+using System.Text.Json.Nodes;
+
+int failures = 0;
+await Run("external cosigner fails before RPC", async () =>
+{
+    var wallet = CreateWallet();
+    var local = AddContract(wallet);
+    await Reject(wallet, null, [SignerFor(local.ScriptHash), SignerFor(Hash(1))], 10001);
+});
+await Run("external-only signer fails before RPC", async () =>
+{
+    var wallet = CreateWallet();
+    AddContract(wallet);
+    await Reject(wallet, null, [SignerFor(Hash(1))], 10001);
+});
+await Run("deployed contract without local verification metadata is unsupported", async () =>
+{
+    var wallet = CreateWallet();
+    var local = AddContract(wallet);
+    await Reject(wallet, null, [SignerFor(local.ScriptHash), SignerFor(Neo.SmartContract.Native.NativeContract.GAS.Hash)], 10001);
+});
+await Run("watch-only signer fails before RPC", async () =>
+{
+    var wallet = CreateWallet();
+    AddContract(wallet);
+    var watch = wallet.CreateAccount(Hash(2));
+    await Reject(wallet, null, [SignerFor(watch.ScriptHash)], 10001);
+});
+await Run("unknown explicit sender fails before RPC", async () =>
+{
+    var wallet = CreateWallet();
+    AddContract(wallet);
+    await Reject(wallet, Hash(3), [], 10001);
+});
+await Run("watch-only explicit sender fails before RPC", async () =>
+{
+    var wallet = CreateWallet();
+    var watch = wallet.CreateAccount(Hash(2));
+    await Reject(wallet, watch.ScriptHash, [], 10001);
+});
+await Run("empty wallet has explicit missing-account response", async () =>
+{
+    var wallet = CreateWallet();
+    await Reject(wallet, null, [], 10003);
+});
+await Run("wallet with only watch-only accounts has no usable implicit payer", async () =>
+{
+    var wallet = CreateWallet();
+    wallet.CreateAccount(Hash(2));
+    await Reject(wallet, null, [], 10003);
+});
+await Run("missing wallet fails before RPC", () => Reject(null, null, [], 10003));
+await Run("known local verification contract needs no private key for construction", async () =>
+{
+    var wallet = CreateWallet();
+    var local = AddContract(wallet);
+    Assert(!local.HasKey && !local.WatchOnly, "Fixture should have verification script but no private key");
+    using var rpc = new FakeRpc();
+    var tx = await Client(wallet, rpc).MakeTransactionAsync([0x11], signers: [SignerFor(local.ScriptHash)]);
+    Assert(tx.Sender == local.ScriptHash, "Local payer changed");
+    Assert(tx.Witnesses[0].VerificationScript.Span.SequenceEqual(local.Contract!.Script), "Verification script changed");
+    Assert(tx.SystemFee == 1 && tx.NetworkFee == 2, "Fee handling changed");
+    Assert(rpc.Methods.SequenceEqual(new[] { "invokescript", "calculatenetworkfee", "getblockcount", "invokescript" }), "Normal RPC path changed");
+});
+await Run("implicit payer selection skips watch-only entries", async () =>
+{
+    var wallet = CreateWallet();
+    wallet.CreateAccount(Hash(2));
+    var local = AddContract(wallet);
+    using var rpc = new FakeRpc();
+    var tx = await Client(wallet, rpc).MakeTransactionAsync([0x11]);
+    Assert(tx.Sender == local.ScriptHash, "Incorrect implicit payer");
+});
+await Run("local multisig verification contract remains supported", async () =>
+{
+    var wallet = CreateWallet();
+    var contract = Contract.CreateMultiSigContract(1, [ECCurve.Secp256r1.G]);
+    var local = wallet.CreateAccount(contract, (KeyPair?)null);
+    using var rpc = new FakeRpc();
+    var tx = await Client(wallet, rpc).MakeTransactionAsync([0x11], signers: [SignerFor(local.ScriptHash)]);
+    Assert(tx.Witnesses[0].VerificationScript.Span.SequenceEqual(contract.Script), "Multisig verification script changed");
+});
+await Run("multiple local signers preserve scopes and sender order", async () =>
+{
+    var wallet = CreateWallet();
+    var first = AddContract(wallet);
+    var second = wallet.CreateAccount(Contract.CreateMultiSigContract(1, [ECCurve.Secp256r1.G]), (KeyPair?)null);
+    var firstSigner = new Signer { Account = first.ScriptHash, Scopes = WitnessScope.Global };
+    var secondSigner = SignerFor(second.ScriptHash);
+    using var rpc = new FakeRpc();
+    var tx = await Client(wallet, rpc).MakeTransactionAsync([0x11], second.ScriptHash, [firstSigner, secondSigner]);
+    Assert(tx.Signers.SequenceEqual(new[] { secondSigner, firstSigner }), "Signer scope or order changed");
+    Assert(tx.Witnesses[0].VerificationScript.Span.SequenceEqual(second.Contract!.Script), "Payer witness order changed");
+    Assert(tx.Witnesses[1].VerificationScript.Span.SequenceEqual(first.Contract!.Script), "Cosigner witness order changed");
+});
+Console.WriteLine($"{13 - failures}/13 passed");
+return failures == 0 ? 0 : 1;
+
+async Task Run(string name, Func<Task> test)
+{
+    try { await test(); Console.WriteLine($"PASS {name}"); }
+    catch (Exception e) { failures++; Console.Error.WriteLine($"FAIL {name}: {e.GetType().Name}: {e.Message}"); }
+}
+
+static async Task Reject(Wallet? wallet, UInt160? sender, Signer[] signers, int expectedCode)
+{
+    using var rpc = new FakeRpc();
+    try
+    {
+        await Client(wallet, rpc).MakeTransactionAsync([0x11], sender, signers);
+        throw new Exception("Expected a dAPI error");
+    }
+    catch (DapiException e)
+    {
+        Assert(e.Code == expectedCode, $"Expected dAPI {expectedCode}, got {e.Code}");
+        Assert(rpc.Methods.Count == 0, "Unsupported request reached RPC");
+    }
+}
+
+static NEP6Wallet CreateWallet() => new(Path.Combine(Path.GetTempPath(), $"onegate-p2-14-{Guid.NewGuid():N}.json"), "test-only-not-a-real-wallet", ProtocolSettings.Default, "test-only");
+static WalletAccount AddContract(Wallet wallet) => wallet.CreateAccount(Contract.CreateSignatureContract(ECCurve.Secp256r1.G), (KeyPair?)null);
+static UInt160 Hash(byte first) => new([first, .. new byte[19]]);
+static Signer SignerFor(UInt160 hash) => new() { Account = hash, Scopes = WitnessScope.CalledByEntry };
+static void Assert(bool value, string message) { if (!value) throw new Exception(message); }
+static RpcClient Client(Wallet? wallet, FakeRpc rpc)
+{
+    var client = new RpcClient(new WalletProvider(wallet), ProtocolSettings.Default);
+    // Test-only replacement of the private transport: no real node requests, signatures or wallet saves.
+    var transport = typeof(RpcClient).GetField("http", BindingFlags.Instance | BindingFlags.NonPublic)!;
+    ((HttpClient)transport.GetValue(client)!).Dispose();
+    transport.SetValue(client, new HttpClient(rpc));
+    return client;
+}
+
+sealed class WalletProvider(Wallet? wallet) : IWalletProvider
+{
+    public event EventHandler<Wallet?>? WalletChanged { add { } remove { } }
+    public Wallet? GetWallet() => wallet;
+}
+
+sealed class FakeRpc : HttpMessageHandler
+{
+    public List<string> Methods { get; } = [];
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var body = JsonNode.Parse(await request.Content!.ReadAsStringAsync(cancellationToken))!;
+        string method = body["method"]!.GetValue<string>();
+        Methods.Add(method);
+        string result = method switch
+        {
+            "invokescript" => """{"script":"","state":"HALT","gasconsumed":"1","notifications":[],"stack":[{"type":"Integer","value":"1000000000"}]}""",
+            "calculatenetworkfee" => """{"networkfee":"2"}""",
+            "getblockcount" => "100",
+            _ => throw new Exception($"Unexpected RPC method: {method}")
+        };
+        return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent($"{{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{result}}}") };
+    }
+}

--- a/tests/p2-14/README.md
+++ b/tests/p2-14/README.md
@@ -1,0 +1,39 @@
+# P2-14: Explicit unsupported signer handling
+
+Run the linked production-source harness:
+
+```sh
+dotnet run --project tests/p2-14/P2-14.Tests.csproj -p:NuGetAudit=false
+```
+
+The first 12 tests were written and executed before changing RpcClient: the old
+implementation passed 2/12 and failed the others with null dereferences or the
+wrong error. The fixed implementation passes all 13 cases, including an additional
+multiple-local-signer order/scope regression case. The harness uses the actual
+RpcClient, model and serializer sources, and the same Neo 3.10.0 package as the app.
+Only unused UI diagnostics and MAUI filesystem directories are stubbed. The private
+HTTP transport is replaced in tests with an in-memory handler: no real RPC calls,
+wallet saves, private keys, signatures or broadcasts are performed.
+
+External signers and watch-only accounts without a verification contract receive
+NEP-21 UNSUPPORTED (10001) before script simulation. Missing wallets and absent
+implicit payers receive NOT_FOUND (10003). Automatic payer selection skips
+watch-only entries. Local known verification contracts remain usable for unsigned
+transaction construction even without a private key; local multisig scripts and
+signer order/scopes are retained.
+
+This intentionally does not claim support for external multisig coordination or
+deployed-contract witness construction. A signer hash is not enough to choose or
+invent a verification script. Neo's [WalletAccount source](https://github.com/neo-project/neo/blob/33417b47238d331115cc0bd8cee93c1f2ed7a7f3/src/Neo/Wallets/WalletAccount.cs)
+defines watch-only by the absence of a Contract, independently from HasKey; its
+[fee calculation](https://github.com/neo-project/neo/blob/33417b47238d331115cc0bd8cee93c1f2ed7a7f3/src/Neo/Wallets/Helper.cs)
+handles deployed-contract verification separately. Error codes follow
+[NEP-21](https://github.com/neo-project/proposals/blob/master/nep-21.mediawiki).
+
+Platform QA, on both iOS and Android: use an authorized test DApp/wallet to request
+`makeTransaction` with a local payer and an external signer. Expect code 10001
+with an explanatory message and no wallet confirmation or simulation RPC. Repeat
+with a watch-only signer. A local-account-only `makeTransaction` should still
+produce an unsigned context; do not sign or broadcast for this QA. Verify app
+launch and ordinary account viewing. Simulator validation is not claimed by this
+console harness.


### PR DESCRIPTION
## Summary

Fix audit P2-14: fail explicitly when unsigned transaction construction cannot obtain a verification script for every signer, instead of dereferencing a missing wallet account or contract.

- Return NOT_FOUND (10003) for a missing wallet or absent implicit payer.
- Skip watch-only entries when selecting an implicit payer.
- Reject external/deployed/watch-only signer hashes without known verification contracts as UNSUPPORTED (10001), before script simulation or fee calculation.
- Preserve known local verification contracts, multisig scripts, and signer ordering/scopes. Do not remove a requested signer or invent a witness script.

This changes the existing transaction-construction path only. It does not add a dAPI method, address-read permission prompt, external multisig coordination, or deployment-contract witness support.

## Validation

- Publication rerun: 13/13 cases passed in the production-linked harness, `dotnet run --project tests/p2-14/P2-14.Tests.csproj --no-restore`. The test project is registered in `OneGateApp.slnx` and has a non-build/non-output reference to the app project.
- iPhone 17 / iOS 26.5 simulator: 8/8 assertions passed using the actual native `RpcClient`, Neo wallet models and serializers. Only the upstream HTTP transport was controlled. Missing witnesses failed before any RPC; local known-contract construction, implicit payer selection, and multisig signer order remained valid.
- The iOS fixture was removed before a full product rebuild with zero errors, install and Home/four-tab launch smoke.
- Android API 36 arm64 emulator: the same 8/8 native assertions passed using the actual production transaction builder with controlled HTTP. Both the fixture and fixture-free product fully rebuilt with zero warnings/errors; the normal product installed and displayed Home with no OneGate crash observed.
- Reviewed complete patch SHA-256: `6a3336c0c633579eeddc42a70200697435c59955546df24f8f74ad4aa31fd0a9`, independently based on `master@623603d634f07eaead14745da87920a356159be0`. Both platform evidence sets match this hash.

## Scope and limits

The native fixture called the real transaction builder with in-memory HTTP responses; it was not a live-node transaction, JavaScript-provider round trip, wallet authorization, signature or broadcast test. No real private key or funded wallet was used. Unsupported external/deployed witnesses remain unsupported, now with an explicit error.

Screenshots, fixture code and result JSON stay outside the repository; no GitHub asset upload or hosted CI pass is claimed. Before publication, recheck the current master, current feedback, duplicate PRs and the complete diff. Related independently scoped transaction/NFT changes share `RpcClient`; preserve their source and linked-test dependencies if later integrated, without treating these isolated tests as combined validation.
