### PR TITLE
Explain unsupported Android WebView capabilities

### DIFF
--- a/OneGateApp.slnx
+++ b/OneGateApp.slnx
@@ -6,4 +6,5 @@
   <Project Path="OneGate.DebugProtocol/OneGate.DebugProtocol.csproj" />
   <Project Path="OneGate.DebugProtocol.Tests/OneGate.DebugProtocol.Tests.csproj" />
   <Project Path="OneGate.Tools/OneGate.Tools.csproj" />
+  <Project Path="tests/p2-16/OneGate.WebViewSupport.Tests.csproj" />
 </Solution>

--- a/OneGateApp/Pages/LaunchDAppPage.Android.cs
+++ b/OneGateApp/Pages/LaunchDAppPage.Android.cs
@@ -1,0 +1,81 @@
+#if ANDROID
+using AndroidX.WebKit;
+using NeoOrder.OneGate.Controls;
+using NeoOrder.OneGate.Properties;
+using NeoOrder.OneGate.Services;
+
+namespace NeoOrder.OneGate.Pages;
+
+partial class LaunchDAppPage
+{
+    WebViewLaunchSupport? androidWebViewLaunchSupport;
+
+    bool ShowWebViewUpdatePageIfRequired()
+    {
+        bool documentStartScriptSupported = WebViewFeature.IsFeatureSupported(WebViewFeature.DocumentStartScript);
+        string? package = documentStartScriptSupported ? null
+            : WebViewCompat.GetCurrentWebViewPackage(global::Android.App.Application.Context)?.PackageName;
+        androidWebViewLaunchSupport = new(documentStartScriptSupported, package);
+        if (androidWebViewLaunchSupport.CanLaunchDApp) return false;
+
+        // Replace the unconnected view before any dApp URL is assigned. The
+        // unavailable page must never construct a native bridge or load a dApp.
+        ToolbarItems.Clear();
+        Title = Strings.WebViewUpdateRequired;
+        Button update = new() { Text = Strings.UpdateWebView };
+        update.Clicked += OnUpdateWebViewClicked;
+        Button close = new() { Text = Strings.CloseDApp };
+        close.Clicked += async (_, _) => await this.GoBackOrCloseAsync();
+        Content = new ScrollView
+        {
+            Content = new VerticalStackLayout
+            {
+                Padding = new Thickness(24),
+                Spacing = 20,
+                VerticalOptions = LayoutOptions.Center,
+                Children =
+                {
+                    new Label
+                    {
+                        Text = Strings.WebViewUpdateRequired,
+                        FontSize = 24,
+                        FontAttributes = FontAttributes.Bold,
+                        HorizontalTextAlignment = TextAlignment.Center
+                    },
+                    new Label
+                    {
+                        Text = Strings.WebViewUpdateRequiredText,
+                        HorizontalTextAlignment = TextAlignment.Center
+                    },
+                    update,
+                    close
+                }
+            }
+        };
+        return true;
+    }
+
+    async void OnUpdateWebViewClicked(object? sender, EventArgs e)
+    {
+        if (sender is not Button button || androidWebViewLaunchSupport is null) return;
+        button.IsEnabled = false;
+        bool opened;
+        try
+        {
+            opened = await androidWebViewLaunchSupport.OpenUpdateAsync(uri => Launcher.Default.TryOpenAsync(uri));
+        }
+        catch (Exception)
+        {
+            // Some providers have no store/browser handler. Keep the unavailable
+            // page visible and offer manual update instructions below.
+            opened = false;
+        }
+        finally
+        {
+            button.IsEnabled = true;
+        }
+        if (!opened)
+            await DisplayAlertAsync(Strings.WebViewUpdateRequired, Strings.WebViewUpdateOpenFailed, Strings.OK);
+    }
+}
+#endif

--- a/OneGateApp/Pages/LaunchDAppPage.xaml.cs
+++ b/OneGateApp/Pages/LaunchDAppPage.xaml.cs
@@ -50,6 +50,9 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable, IRemoteDe
         this.rpcClient = rpcClient;
         IsDeveloperToolsEnabled = dbContext.Settings.Get<bool>(DAppCatalogPolicy.DeveloperModeKey);
         InitializeComponent();
+#if ANDROID
+        if (ShowWebViewUpdatePageIfRequired()) return;
+#endif
         webView.DocumentStartScript = CreateDocumentStartScript();
         if (!homeShortcutService.IsSupported)
             ToolbarItems.Remove(addToHomeScreenButton);
@@ -159,6 +162,9 @@ public partial class LaunchDAppPage : ContentPage, IQueryAttributable, IRemoteDe
 
     public async void ApplyQueryAttributes(IDictionary<string, object> query)
     {
+#if ANDROID
+        if (androidWebViewLaunchSupport?.CanLaunchDApp == false) return;
+#endif
         if (query.TryGetValue("dapp", out var value))
         {
             DApp = (DApp)value;

--- a/OneGateApp/Properties/Strings.Designer.cs
+++ b/OneGateApp/Properties/Strings.Designer.cs
@@ -259,6 +259,51 @@ namespace NeoOrder.OneGate.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to WebView update required.
+        /// </summary>
+        internal static string WebViewUpdateRequired {
+            get {
+                return ResourceManager.GetString("WebViewUpdateRequired", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up localized guidance for updating the device's WebView.
+        /// </summary>
+        internal static string WebViewUpdateRequiredText {
+            get {
+                return ResourceManager.GetString("WebViewUpdateRequiredText", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Update WebView.
+        /// </summary>
+        internal static string UpdateWebView {
+            get {
+                return ResourceManager.GetString("UpdateWebView", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Close dApp.
+        /// </summary>
+        internal static string CloseDApp {
+            get {
+                return ResourceManager.GetString("CloseDApp", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up localized guidance for manually opening the app store.
+        /// </summary>
+        internal static string WebViewUpdateOpenFailed {
+            get {
+                return ResourceManager.GetString("WebViewUpdateOpenFailed", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   查找类似 This DApp is not available on the current platform. 的本地化字符串。
         /// </summary>
         internal static string DAppUnavailableOnCurrentPlatform {

--- a/OneGateApp/Properties/Strings.de.resx
+++ b/OneGateApp/Properties/Strings.de.resx
@@ -1288,4 +1288,19 @@ Es wird empfohlen, den NEP-2-Schlüssel und das Passwort getrennt aufzubewahren 
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>Warten auf einen vertrauenswürdigen Remote-Debugger</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Remote-Debugger koppeln</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>Remote-Debugger „{0}“ fordert Zugriff an. Fingerabdruck: {1}. Nur autorisieren, wenn du diesem Remote-Debugger vertraust.</value></data>
+  <data name="WebViewUpdateRequired" xml:space="preserve">
+    <value>WebView-Update erforderlich</value>
+  </data>
+  <data name="WebViewUpdateRequiredText" xml:space="preserve">
+    <value>Dem WebView Ihres Geräts fehlt eine Funktion, die diese dApp für die Verbindung mit OneGate benötigt. Aktualisieren Sie WebView oder Chrome und starten Sie OneGate neu.</value>
+  </data>
+  <data name="UpdateWebView" xml:space="preserve">
+    <value>WebView aktualisieren</value>
+  </data>
+  <data name="CloseDApp" xml:space="preserve">
+    <value>dApp schließen</value>
+  </data>
+  <data name="WebViewUpdateOpenFailed" xml:space="preserve">
+    <value>Öffnen Sie Google Play oder den App-Store Ihres Geräts, aktualisieren Sie den WebView-Anbieter (Android System WebView oder Chrome) und starten Sie OneGate neu.</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.es.resx
+++ b/OneGateApp/Properties/Strings.es.resx
@@ -1288,4 +1288,19 @@ Se recomienda almacenar la clave NEP-2 y la contraseña por separado y realizar 
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>Esperando un depurador remoto de confianza</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Emparejar depurador remoto</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>El depurador remoto «{0}» solicita acceso. Huella: {1}. Autoriza solo si confías en este depurador remoto.</value></data>
+  <data name="WebViewUpdateRequired" xml:space="preserve">
+    <value>Es necesario actualizar WebView</value>
+  </data>
+  <data name="WebViewUpdateRequiredText" xml:space="preserve">
+    <value>El WebView de tu dispositivo no tiene una función necesaria para conectar esta dApp a OneGate. Actualiza WebView o Chrome y reinicia OneGate.</value>
+  </data>
+  <data name="UpdateWebView" xml:space="preserve">
+    <value>Actualizar WebView</value>
+  </data>
+  <data name="CloseDApp" xml:space="preserve">
+    <value>Cerrar dApp</value>
+  </data>
+  <data name="WebViewUpdateOpenFailed" xml:space="preserve">
+    <value>Abre Google Play o la tienda de aplicaciones de tu dispositivo, actualiza el proveedor de WebView (Android System WebView o Chrome) y reinicia OneGate.</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.fr.resx
+++ b/OneGateApp/Properties/Strings.fr.resx
@@ -1288,4 +1288,19 @@ Il est recommandé de conserver séparément la clé NEP-2 et le mot de passe, e
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>En attente d’un débogueur distant approuvé</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Associer le débogueur distant</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>Le débogueur distant « {0} » demande l’accès. Empreinte : {1}. Autorisez uniquement si vous faites confiance à ce débogueur distant.</value></data>
+  <data name="WebViewUpdateRequired" xml:space="preserve">
+    <value>Mise à jour de WebView requise</value>
+  </data>
+  <data name="WebViewUpdateRequiredText" xml:space="preserve">
+    <value>Le WebView de votre appareil ne dispose pas d’une fonction nécessaire pour connecter cette dApp à OneGate. Mettez à jour WebView ou Chrome, puis redémarrez OneGate.</value>
+  </data>
+  <data name="UpdateWebView" xml:space="preserve">
+    <value>Mettre à jour WebView</value>
+  </data>
+  <data name="CloseDApp" xml:space="preserve">
+    <value>Fermer la dApp</value>
+  </data>
+  <data name="WebViewUpdateOpenFailed" xml:space="preserve">
+    <value>Ouvrez Google Play ou la boutique d’applications de votre appareil, mettez à jour le fournisseur WebView (Android System WebView ou Chrome), puis redémarrez OneGate.</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.id.resx
+++ b/OneGateApp/Properties/Strings.id.resx
@@ -1288,4 +1288,19 @@ Disarankan untuk menyimpan kunci NEP-2 dan kata sandinya secara terpisah serta m
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>Menunggu debugger jarak jauh tepercaya</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Pasangkan debugger jarak jauh</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>Debugger jarak jauh “{0}” meminta akses. Sidik jari: {1}. Izinkan hanya jika Anda memercayai debugger jarak jauh ini.</value></data>
+  <data name="WebViewUpdateRequired" xml:space="preserve">
+    <value>WebView perlu diperbarui</value>
+  </data>
+  <data name="WebViewUpdateRequiredText" xml:space="preserve">
+    <value>WebView perangkat Anda belum memiliki fitur yang diperlukan untuk menghubungkan dApp ini ke OneGate. Perbarui WebView atau Chrome, lalu mulai ulang OneGate.</value>
+  </data>
+  <data name="UpdateWebView" xml:space="preserve">
+    <value>Perbarui WebView</value>
+  </data>
+  <data name="CloseDApp" xml:space="preserve">
+    <value>Tutup dApp</value>
+  </data>
+  <data name="WebViewUpdateOpenFailed" xml:space="preserve">
+    <value>Buka Google Play atau toko aplikasi perangkat Anda, perbarui penyedia WebView (Android System WebView atau Chrome), lalu mulai ulang OneGate.</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.it.resx
+++ b/OneGateApp/Properties/Strings.it.resx
@@ -1288,4 +1288,19 @@ Si consiglia di conservare separatamente la chiave NEP-2 e la password e di eseg
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>In attesa di un debugger remoto attendibile</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Associa debugger remoto</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>Il debugger remoto “{0}” richiede l’accesso. Impronta: {1}. Autorizza solo se ritieni attendibile questo debugger remoto.</value></data>
+  <data name="WebViewUpdateRequired" xml:space="preserve">
+    <value>Aggiornamento WebView necessario</value>
+  </data>
+  <data name="WebViewUpdateRequiredText" xml:space="preserve">
+    <value>Il WebView del dispositivo non dispone di una funzione necessaria per collegare questa dApp a OneGate. Aggiorna WebView o Chrome, quindi riavvia OneGate.</value>
+  </data>
+  <data name="UpdateWebView" xml:space="preserve">
+    <value>Aggiorna WebView</value>
+  </data>
+  <data name="CloseDApp" xml:space="preserve">
+    <value>Chiudi dApp</value>
+  </data>
+  <data name="WebViewUpdateOpenFailed" xml:space="preserve">
+    <value>Apri Google Play o lo store del dispositivo, aggiorna il provider WebView (Android System WebView o Chrome), quindi riavvia OneGate.</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.ja.resx
+++ b/OneGateApp/Properties/Strings.ja.resx
@@ -1288,4 +1288,19 @@ NEP-2 とパスワードは別々に保管し、それぞれを安全にバッ�
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>信頼済みリモートデバッガーを待機中</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>リモートデバッガーをペアリング</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>リモートデバッガー「{0}」がアクセスを要求しています。フィンガープリント: {1}。このリモートデバッガーを信頼する場合のみ許可してください。</value></data>
+  <data name="WebViewUpdateRequired" xml:space="preserve">
+    <value>WebView の更新が必要です</value>
+  </data>
+  <data name="WebViewUpdateRequiredText" xml:space="preserve">
+    <value>この端末の WebView には、この dApp を OneGate に接続するための機能がありません。WebView または Chrome を更新してから、OneGate を再起動してください。</value>
+  </data>
+  <data name="UpdateWebView" xml:space="preserve">
+    <value>WebView を更新</value>
+  </data>
+  <data name="CloseDApp" xml:space="preserve">
+    <value>dApp を閉じる</value>
+  </data>
+  <data name="WebViewUpdateOpenFailed" xml:space="preserve">
+    <value>Google Play または端末のアプリストアを開き、WebView プロバイダ（Android System WebView または Chrome）を更新してから、OneGate を再起動してください。</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.ko.resx
+++ b/OneGateApp/Properties/Strings.ko.resx
@@ -1288,4 +1288,19 @@ NEP-2와 비밀번호는 별도로 보관하고 각각 안전하게 백업하는
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>신뢰할 수 있는 원격 디버거 대기 중</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>원격 디버거 페어링</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>원격 디버거 “{0}”이(가) 액세스를 요청합니다. 지문: {1}. 이 원격 디버거를 신뢰하는 경우에만 허용하세요.</value></data>
+  <data name="WebViewUpdateRequired" xml:space="preserve">
+    <value>WebView 업데이트 필요</value>
+  </data>
+  <data name="WebViewUpdateRequiredText" xml:space="preserve">
+    <value>기기의 WebView에 이 dApp을 OneGate에 연결하는 데 필요한 기능이 없습니다. WebView 또는 Chrome을 업데이트한 후 OneGate를 다시 시작하세요.</value>
+  </data>
+  <data name="UpdateWebView" xml:space="preserve">
+    <value>WebView 업데이트</value>
+  </data>
+  <data name="CloseDApp" xml:space="preserve">
+    <value>dApp 닫기</value>
+  </data>
+  <data name="WebViewUpdateOpenFailed" xml:space="preserve">
+    <value>Google Play 또는 기기의 앱 스토어에서 WebView 제공자(Android System WebView 또는 Chrome)를 업데이트한 후 OneGate를 다시 시작하세요.</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.nl.resx
+++ b/OneGateApp/Properties/Strings.nl.resx
@@ -1288,4 +1288,19 @@ Het wordt aanbevolen om de NEP-2-sleutel en het wachtwoord apart op te slaan en 
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>Wachten op een vertrouwde externe debugger</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Externe debugger koppelen</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>Externe debugger ‘{0}’ vraagt toegang. Vingerafdruk: {1}. Autoriseer alleen als je deze externe debugger vertrouwt.</value></data>
+  <data name="WebViewUpdateRequired" xml:space="preserve">
+    <value>WebView-update vereist</value>
+  </data>
+  <data name="WebViewUpdateRequiredText" xml:space="preserve">
+    <value>De WebView op je apparaat mist een functie die nodig is om deze dApp met OneGate te verbinden. Werk WebView of Chrome bij en start OneGate opnieuw.</value>
+  </data>
+  <data name="UpdateWebView" xml:space="preserve">
+    <value>WebView bijwerken</value>
+  </data>
+  <data name="CloseDApp" xml:space="preserve">
+    <value>dApp sluiten</value>
+  </data>
+  <data name="WebViewUpdateOpenFailed" xml:space="preserve">
+    <value>Open Google Play of de appwinkel van je apparaat, werk de WebView-provider (Android System WebView of Chrome) bij en start OneGate opnieuw.</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.pt-BR.resx
+++ b/OneGateApp/Properties/Strings.pt-BR.resx
@@ -1288,4 +1288,19 @@ Recomenda-se armazenar a chave NEP-2 e a senha separadamente e fazer backups seg
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>Aguardando um depurador remoto confiável</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Parear depurador remoto</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>O depurador remoto “{0}” está solicitando acesso. Impressão digital: {1}. Autorize apenas se confiar neste depurador remoto.</value></data>
+  <data name="WebViewUpdateRequired" xml:space="preserve">
+    <value>É necessário atualizar o WebView</value>
+  </data>
+  <data name="WebViewUpdateRequiredText" xml:space="preserve">
+    <value>O WebView do seu dispositivo não tem um recurso necessário para conectar este dApp ao OneGate. Atualize o WebView ou o Chrome e reinicie o OneGate.</value>
+  </data>
+  <data name="UpdateWebView" xml:space="preserve">
+    <value>Atualizar WebView</value>
+  </data>
+  <data name="CloseDApp" xml:space="preserve">
+    <value>Fechar dApp</value>
+  </data>
+  <data name="WebViewUpdateOpenFailed" xml:space="preserve">
+    <value>Abra o Google Play ou a loja de aplicativos do dispositivo, atualize o provedor WebView (Android System WebView ou Chrome) e reinicie o OneGate.</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.resx
+++ b/OneGateApp/Properties/Strings.resx
@@ -1288,4 +1288,19 @@ It is recommended to store the NEP-2 key and password separately and back them u
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>Waiting for a trusted remote debugger</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Pair remote debugger</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>Remote debugger “{0}” is requesting access. Fingerprint: {1}. Authorize only if you trust this remote debugger.</value></data>
+  <data name="WebViewUpdateRequired" xml:space="preserve">
+    <value>WebView update required</value>
+  </data>
+  <data name="WebViewUpdateRequiredText" xml:space="preserve">
+    <value>Your device’s WebView is missing a feature needed to connect this dApp to OneGate. Update WebView or Chrome, then restart OneGate.</value>
+  </data>
+  <data name="UpdateWebView" xml:space="preserve">
+    <value>Update WebView</value>
+  </data>
+  <data name="CloseDApp" xml:space="preserve">
+    <value>Close dApp</value>
+  </data>
+  <data name="WebViewUpdateOpenFailed" xml:space="preserve">
+    <value>Open Google Play or your device’s app store and update your WebView provider (Android System WebView or Chrome), then restart OneGate.</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.ru.resx
+++ b/OneGateApp/Properties/Strings.ru.resx
@@ -1288,4 +1288,19 @@
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>Ожидание доверенного удалённого отладчика</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Сопряжение удалённого отладчика</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>Удалённый отладчик «{0}» запрашивает доступ. Отпечаток: {1}. Разрешайте только если доверяете этому удалённому отладчику.</value></data>
+  <data name="WebViewUpdateRequired" xml:space="preserve">
+    <value>Требуется обновление WebView</value>
+  </data>
+  <data name="WebViewUpdateRequiredText" xml:space="preserve">
+    <value>В WebView вашего устройства нет функции, необходимой для подключения этого dApp к OneGate. Обновите WebView или Chrome, затем перезапустите OneGate.</value>
+  </data>
+  <data name="UpdateWebView" xml:space="preserve">
+    <value>Обновить WebView</value>
+  </data>
+  <data name="CloseDApp" xml:space="preserve">
+    <value>Закрыть dApp</value>
+  </data>
+  <data name="WebViewUpdateOpenFailed" xml:space="preserve">
+    <value>Откройте Google Play или магазин приложений устройства, обновите провайдер WebView (Android System WebView или Chrome), затем перезапустите OneGate.</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.tr.resx
+++ b/OneGateApp/Properties/Strings.tr.resx
@@ -1288,4 +1288,19 @@ NEP-2 anahtarı ile şifreyi ayrı ayrı saklamanız ve güvenli şekilde yedekl
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>Güvenilir bir uzaktan hata ayıklayıcı bekleniyor</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Uzaktan hata ayıklayıcıyı eşleştir</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>“{0}” uzaktan hata ayıklayıcısı erişim istiyor. Parmak izi: {1}. Yalnızca bu uzaktan hata ayıklayıcıya güveniyorsanız izin verin.</value></data>
+  <data name="WebViewUpdateRequired" xml:space="preserve">
+    <value>WebView güncellemesi gerekli</value>
+  </data>
+  <data name="WebViewUpdateRequiredText" xml:space="preserve">
+    <value>Cihazınızın WebView bileşeninde bu dApp'i OneGate'e bağlamak için gereken bir özellik eksik. WebView veya Chrome'u güncelleyin, ardından OneGate'i yeniden başlatın.</value>
+  </data>
+  <data name="UpdateWebView" xml:space="preserve">
+    <value>WebView'i güncelle</value>
+  </data>
+  <data name="CloseDApp" xml:space="preserve">
+    <value>dApp'i kapat</value>
+  </data>
+  <data name="WebViewUpdateOpenFailed" xml:space="preserve">
+    <value>Google Play'i veya cihazınızın uygulama mağazasını açın, WebView sağlayıcısını (Android System WebView veya Chrome) güncelleyin, ardından OneGate'i yeniden başlatın.</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.vi.resx
+++ b/OneGateApp/Properties/Strings.vi.resx
@@ -1288,4 +1288,19 @@ Nên lưu trữ riêng khóa NEP-2 và mật khẩu, đồng thời sao lưu ch�
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>Đang chờ trình gỡ lỗi từ xa đáng tin cậy</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>Ghép nối trình gỡ lỗi từ xa</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>Trình gỡ lỗi từ xa “{0}” đang yêu cầu quyền truy cập. Dấu vân tay: {1}. Chỉ cho phép nếu bạn tin cậy trình gỡ lỗi từ xa này.</value></data>
+  <data name="WebViewUpdateRequired" xml:space="preserve">
+    <value>Cần cập nhật WebView</value>
+  </data>
+  <data name="WebViewUpdateRequiredText" xml:space="preserve">
+    <value>WebView trên thiết bị của bạn thiếu tính năng cần thiết để kết nối dApp này với OneGate. Hãy cập nhật WebView hoặc Chrome, rồi khởi động lại OneGate.</value>
+  </data>
+  <data name="UpdateWebView" xml:space="preserve">
+    <value>Cập nhật WebView</value>
+  </data>
+  <data name="CloseDApp" xml:space="preserve">
+    <value>Đóng dApp</value>
+  </data>
+  <data name="WebViewUpdateOpenFailed" xml:space="preserve">
+    <value>Mở Google Play hoặc cửa hàng ứng dụng trên thiết bị, cập nhật trình cung cấp WebView (Android System WebView hoặc Chrome), rồi khởi động lại OneGate.</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.zh-Hans.resx
+++ b/OneGateApp/Properties/Strings.zh-Hans.resx
@@ -1288,4 +1288,19 @@
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>正在等待已信任的远程调试器</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>配对远程调试器</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>远程调试器“{0}”正在请求访问。指纹：{1}。仅在你信任此远程调试器时授权。</value></data>
+  <data name="WebViewUpdateRequired" xml:space="preserve">
+    <value>需要更新 WebView</value>
+  </data>
+  <data name="WebViewUpdateRequiredText" xml:space="preserve">
+    <value>设备上的 WebView 缺少连接此 dApp 与 OneGate 所需的功能。请更新 WebView 或 Chrome，然后重启 OneGate。</value>
+  </data>
+  <data name="UpdateWebView" xml:space="preserve">
+    <value>更新 WebView</value>
+  </data>
+  <data name="CloseDApp" xml:space="preserve">
+    <value>关闭 dApp</value>
+  </data>
+  <data name="WebViewUpdateOpenFailed" xml:space="preserve">
+    <value>请打开 Google Play 或设备的应用商店，更新 WebView 提供程序（Android System WebView 或 Chrome），然后重启 OneGate。</value>
+  </data>
 </root>

--- a/OneGateApp/Properties/Strings.zh-Hant.resx
+++ b/OneGateApp/Properties/Strings.zh-Hant.resx
@@ -1288,4 +1288,19 @@
   <data name="RemoteDebugWaiting" xml:space="preserve"><value>正在等待已信任的遠端偵錯器</value></data>
   <data name="RemoteDebugPairingTitle" xml:space="preserve"><value>配對遠端偵錯器</value></data>
   <data name="RemoteDebugPairingPrompt" xml:space="preserve"><value>遠端偵錯器「{0}」正在要求存取。指紋：{1}。僅在你信任此遠端偵錯器時授權。</value></data>
+  <data name="WebViewUpdateRequired" xml:space="preserve">
+    <value>需要更新 WebView</value>
+  </data>
+  <data name="WebViewUpdateRequiredText" xml:space="preserve">
+    <value>裝置上的 WebView 缺少連接此 dApp 與 OneGate 所需的功能。請更新 WebView 或 Chrome，然後重新啟動 OneGate。</value>
+  </data>
+  <data name="UpdateWebView" xml:space="preserve">
+    <value>更新 WebView</value>
+  </data>
+  <data name="CloseDApp" xml:space="preserve">
+    <value>關閉 dApp</value>
+  </data>
+  <data name="WebViewUpdateOpenFailed" xml:space="preserve">
+    <value>請開啟 Google Play 或裝置的應用程式商店，更新 WebView 提供程式（Android System WebView 或 Chrome），然後重新啟動 OneGate。</value>
+  </data>
 </root>

--- a/OneGateApp/Services/WebViewLaunchSupport.cs
+++ b/OneGateApp/Services/WebViewLaunchSupport.cs
@@ -1,0 +1,17 @@
+namespace NeoOrder.OneGate.Services;
+
+sealed class WebViewLaunchSupport(bool documentStartScriptSupported, string? providerPackage)
+{
+    const string DefaultProviderPackage = "com.google.android.webview";
+
+    public bool CanLaunchDApp => documentStartScriptSupported;
+
+    public async Task<bool> OpenUpdateAsync(Func<Uri, Task<bool>> tryOpen)
+    {
+        string package = Uri.EscapeDataString(string.IsNullOrWhiteSpace(providerPackage)
+            ? DefaultProviderPackage
+            : providerPackage);
+        if (await tryOpen(new Uri($"market://details?id={package}"))) return true;
+        return await tryOpen(new Uri($"https://play.google.com/store/apps/details?id={package}"));
+    }
+}

--- a/tests/p2-16/OneGate.WebViewSupport.Tests.csproj
+++ b/tests/p2-16/OneGate.WebViewSupport.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" PrivateAssets="all" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="../../OneGateApp/Services/WebViewLaunchSupport.cs" Link="Production/WebViewLaunchSupport.cs" />
+    <None Include="../../OneGateApp/Properties/Strings*.resx" Link="Resources/%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../OneGateApp/OneGateApp.csproj"
+                      ReferenceOutputAssembly="false" BuildReference="false"
+                      SkipGetTargetFrameworkProperties="true" />
+  </ItemGroup>
+</Project>

--- a/tests/p2-16/README.md
+++ b/tests/p2-16/README.md
@@ -1,0 +1,51 @@
+# Android WebView compatibility gate
+
+Android providers without `DOCUMENT_START_SCRIPT` previously opened a dApp without
+installing OneGate's wallet provider, leaving the page unable to connect. The
+Android launch page now checks this capability before it assigns a URL or creates
+a native WebView handler. Unsupported devices see a native, localized page with
+Update WebView and Close dApp actions. No late JavaScript injection is attempted.
+
+`WebViewLaunchSupport` holds the capability decision and builds update links for
+the installed provider package. The native page obtains that package through
+AndroidX `WebViewCompat.GetCurrentWebViewPackage`; if absent, the link targets
+`com.google.android.webview`. The market link is tried first, followed by its
+HTTPS Google Play page. If neither can open, native guidance explains how to
+update from the device's app store. Package names are URL-escaped. Closing uses
+the existing close-window/back-navigation behavior.
+
+Example: package `com.android.chrome` opens
+`market://details?id=com.android.chrome`; an unsupported launch never writes
+recently opened history or records a wallet connection. After an update the user
+restarts OneGate and reopens the dApp. This is a local capability check, with no
+wallet access, data migration, extra permissions, or background network requests.
+The policy has constant cost. iOS and other platform launch paths are unchanged.
+
+## Tests
+
+The independent harness links the production helper. Tests cover supported and
+unsupported providers, unknown package fallback, URI encoding, successful store
+opening, browser fallback, failure, and all 15 locale resources.
+
+```sh
+dotnet test tests/p2-16/OneGate.WebViewSupport.Tests.csproj
+```
+
+## Simulator validation before commit
+
+1. Android normal capability: open a dApp and verify normal wallet discovery.
+2. In a temporary QA build, force the `documentStartScriptSupported` argument to
+   `false` in `LaunchDAppPage.Android.cs`. Do not commit this override.
+3. Open a dApp from catalog and an app link: native upgrade page appears, no
+   remote content/bridge loads, no recently-opened or connection entry is added.
+4. Verify Update targets the installed WebView package, the HTTPS fallback on an
+   emulator without Play Store, and manual instructions if no handler exists.
+5. Verify Close returns to the prior page or closes the dApp document window.
+   Check English, simplified Chinese, and large text without clipped controls.
+6. Remove the override and rebuild. Verify an iOS dApp still loads normally.
+
+Keep screenshots outside the repository. Release with the normal app build after
+both simulators and review pass.
+
+Sources: [AndroidX capability detection](https://developer.android.com/reference/androidx/webkit/WebViewFeature)
+and [installed WebView provider](https://developer.android.com/reference/androidx/webkit/WebViewCompat#getCurrentWebViewPackage(android.content.Context)).

--- a/tests/p2-16/WebViewLaunchSupportTests.cs
+++ b/tests/p2-16/WebViewLaunchSupportTests.cs
@@ -1,0 +1,117 @@
+using NeoOrder.OneGate.Services;
+using System.Xml.Linq;
+using Xunit;
+
+namespace OneGate.WebViewSupport.Tests;
+
+public class WebViewLaunchSupportTests
+{
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void LaunchRequiresDocumentStartScript(bool supported)
+    {
+        WebViewLaunchSupport support = new(supported, "com.android.chrome");
+
+        Assert.Equal(supported, support.CanLaunchDApp);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public async Task UnknownProviderUsesAndroidSystemWebView(string? package)
+    {
+        WebViewLaunchSupport support = new(false, package);
+        Uri? opened = null;
+
+        Assert.True(await support.OpenUpdateAsync(uri =>
+        {
+            opened = uri;
+            return Task.FromResult(true);
+        }));
+
+        Assert.Equal(new Uri("market://details?id=com.google.android.webview"), opened);
+    }
+
+    [Fact]
+    public async Task InstalledProviderIsOpenedWithoutTryingBrowserWhenMarketSucceeds()
+    {
+        WebViewLaunchSupport support = new(false, "com.android.chrome");
+        List<Uri> opened = [];
+
+        Assert.True(await support.OpenUpdateAsync(uri =>
+        {
+            opened.Add(uri);
+            return Task.FromResult(true);
+        }));
+
+        Assert.Equal(new Uri("market://details?id=com.android.chrome"), Assert.Single(opened));
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task MissingMarketFallsBackToHttpsAndReportsResult(bool browserResult)
+    {
+        WebViewLaunchSupport support = new(false, "com.android.webview");
+        List<Uri> opened = [];
+
+        bool result = await support.OpenUpdateAsync(uri =>
+        {
+            opened.Add(uri);
+            return Task.FromResult(opened.Count == 2 && browserResult);
+        });
+
+        Assert.Equal(browserResult, result);
+        Assert.Collection(opened,
+            uri => Assert.Equal(new Uri("market://details?id=com.android.webview"), uri),
+            uri => Assert.Equal(new Uri("https://play.google.com/store/apps/details?id=com.android.webview"), uri));
+    }
+
+    [Fact]
+    public async Task PackageValueCannotInjectAdditionalQueryArguments()
+    {
+        const string package = "provider&referrer=untrusted#fragment";
+        WebViewLaunchSupport support = new(false, package);
+        List<Uri> opened = [];
+
+        await support.OpenUpdateAsync(uri =>
+        {
+            opened.Add(uri);
+            return Task.FromResult(false);
+        });
+
+        Assert.All(opened, uri =>
+        {
+            Assert.Empty(uri.Fragment);
+            Assert.Equal("?id=" + Uri.EscapeDataString(package), uri.Query);
+        });
+    }
+
+    [Fact]
+    public async Task LauncherExceptionsRemainAvailableToNativeErrorGuidance()
+    {
+        WebViewLaunchSupport support = new(false, null);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => support.OpenUpdateAsync(_ =>
+            throw new InvalidOperationException("No foreground activity")));
+    }
+
+    [Fact]
+    public void EverySupportedLocaleHasCompleteUpgradeGuidance()
+    {
+        string[] keys = ["WebViewUpdateRequired", "WebViewUpdateRequiredText", "UpdateWebView", "CloseDApp", "WebViewUpdateOpenFailed"];
+        string[] resources = Directory.GetFiles(Path.Combine(AppContext.BaseDirectory, "Resources"), "Strings*.resx");
+        Assert.Equal(15, resources.Length);
+        foreach (string path in resources)
+        {
+            XElement root = XDocument.Load(path).Root!;
+            foreach (string key in keys)
+            {
+                XElement resource = Assert.Single(root.Elements("data"), element => (string?)element.Attribute("name") == key);
+                Assert.False(string.IsNullOrWhiteSpace((string?)resource.Element("value")), $"Missing {key} in {Path.GetFileName(path)}");
+            }
+        }
+    }
+}

--- a/tests/p2-16/coverage.runsettings
+++ b/tests/p2-16/coverage.runsettings
@@ -1,0 +1,13 @@
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <IncludeTestAssembly>true</IncludeTestAssembly>
+          <Include>[OneGate.WebViewSupport.Tests]NeoOrder.OneGate.Services.WebViewLaunchSupport*</Include>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
## Summary

Fix audit P2-16: when an Android WebView provider lacks the document-start capability required by OneGate's existing wallet provider, show an actionable native update page instead of loading a dApp with no injected provider.

- Check `DOCUMENT_START_SCRIPT` before assigning a dApp URL or creating its native handler.
- Show localized Update WebView and Close dApp actions; prevent unsupported launches from entering the normal query/load path.
- Target the installed WebView provider's store page, with an HTTPS fallback and manual-update guidance when no opener succeeds.
- Keep the existing close/back behavior, supported-provider injection and non-Android paths unchanged.

This is a capability-failure page, not third-party DOM/CSS adaptation, a JavaScript polyfill or late-injection fallback, a file picker, a new dAPI, or a window-routing change.

## Validation

- `dotnet test tests/p2-16/OneGate.WebViewSupport.Tests.csproj`: 11/11 passed, re-run after the documentation-only cleanup. Tests cover the capability policy, update links/failure and all 15 locale resources. The project is registered in `OneGateApp.slnx` and retains a non-build/non-output app project reference.
- Android API 36 arm64: 11/11 native assertions passed against the actual production `LaunchDAppPage`, query guard and WebView handler. The unavailable-capability input was forced only in the temporary QA copy. A separate supported-provider run verified the native document-start provider was present.
- The actual Update click launched the external browser; browser first-run setup prevented verifying a completed store page/update. The actual Close action returned from the unavailable page. Controlled-opener tests separately verified the exact market/HTTPS URL sequence. This does not claim the system WebView was upgraded.
- After removing the fixture, the Android product was fully rebuilt, installed and launched to the actual Welcome/Create wallet/Import wallet screen. This startup smoke is separate from the changed-flow evidence.
- iOS 26.5: **8/8 strict native assertions passed**. The actual production query handler and `BridgeWebView` navigated to a valid loopback HTTP dApp document without cancellation; its marker, origin and ready state matched. That document called the injected `getBlockCount` provider through the real native bridge/RpcServer/page/RpcClient and received `424242` from one controlled read-only upstream response. No signing or broadcast occurred. Preliminary HTML/about-blank attempts were insufficient and are not used as passing navigation evidence.
- After this strict iOS run, the external fixture and temporary loopback HTTP allowance were removed. A full product rebuild passed with zero warnings/errors; the installed product displayed Home and four tabs.

## Tested revision and limits

The full reviewed patch hash is `b8aeb16a65a670c16e2ce1b341c9c61b170ef7622117f7d3dc3bbbcc515f5696`, based independently on `master@623603d634f07eaead14745da87920a356159be0`. Earlier native evidence used full patch `7ed56e2a9332106b4e754ee88c758b33cfb241e30ae85f9f640ac6acc653de75`; the only intervening change removed an obsolete test-README integration paragraph. The `OneGateApp` production diff is unchanged, SHA-256 `84918d6cb655bd24d7c5aafe0b3a8e91222212d1be2ec7f2c590939716c46459`.

The installed Android provider supports the feature. This validates both controlled capability branches and the real supported provider; it does not prove behavior on a real obsolete WebView, every app store, or every OEM device. Fixtures and screenshots remain outside the repository. No asset upload, hosted CI pass, signing or broadcast is claimed.
