### PR TITLE
Preserve dAPI error categories across dispatch

### DIFF
--- a/OneGateApp.slnx
+++ b/OneGateApp.slnx
@@ -6,4 +6,5 @@
   <Project Path="OneGate.DebugProtocol/OneGate.DebugProtocol.csproj" />
   <Project Path="OneGate.DebugProtocol.Tests/OneGate.DebugProtocol.Tests.csproj" />
   <Project Path="OneGate.Tools/OneGate.Tools.csproj" />
+  <Project Path="tests/p2-15/P2-15.csproj" />
 </Solution>

--- a/OneGateApp/Services/RPC/RpcServer.cs
+++ b/OneGateApp/Services/RPC/RpcServer.cs
@@ -41,32 +41,60 @@ class RpcServer(object host)
         {
             response["result"] = await HandleRequestAsync(method, args);
         }
-        catch (OperationCanceledException)
+        catch (Exception ex)
         {
-            response["error"] = new JsonObject
-            {
-                ["code"] = 10006,
-                ["message"] = "Operation cancelled"
-            };
+            response["error"] = CreateError(ex);
         }
-        catch (DapiException ex)
+        return response;
+    }
+
+    static JsonObject CreateError(Exception exception)
+    {
+        // Synchronous handlers are wrapped by reflection; awaited handlers are not.
+        while (exception is TargetInvocationException { InnerException: not null } invocation)
+            exception = invocation.InnerException!;
+
+        return exception switch
         {
-            response["error"] = new JsonObject
+            DapiException ex => new JsonObject
             {
                 ["code"] = ex.Code,
                 ["message"] = ex.Message,
                 ["data"] = JsonSerializer.SerializeToNode(ex.Data, SharedOptions.JsonSerializerOptions)
-            };
-        }
-        catch (Exception ex)
-        {
-            response["error"] = new JsonObject
+            },
+            RpcException ex => new JsonObject
+            {
+                ["code"] = 10008,
+                ["message"] = ex.Message,
+                ["data"] = new JsonObject
+                {
+                    ["code"] = ex.Code,
+                    ["message"] = ex.Message,
+                    ["data"] = JsonSerializer.SerializeToNode(ex.Data, SharedOptions.JsonSerializerOptions)
+                }
+            },
+            // HttpClient identifies its own timeout with this inner exception.
+            TimeoutException or OperationCanceledException { InnerException: TimeoutException } => new JsonObject
+            {
+                ["code"] = 10005,
+                ["message"] = "Operation timed out"
+            },
+            OperationCanceledException => new JsonObject
+            {
+                ["code"] = 10006,
+                ["message"] = "Operation cancelled"
+            },
+            HttpRequestException ex => new JsonObject
+            {
+                ["code"] = 10008,
+                ["message"] = ex.Message
+            },
+            _ => new JsonObject
             {
                 ["code"] = 10000,
-                ["message"] = ex.Message
-            };
-        }
-        return response;
+                ["message"] = exception.Message
+            }
+        };
     }
 
     private async Task<JsonNode?> HandleRequestAsync(string method, JsonArray? args)
@@ -84,11 +112,27 @@ class RpcServer(object host)
                 else
                 {
                     JsonNode? node = args[parameter.Position];
-                    object? argument = node?.Deserialize(parameter.ParameterType, SharedOptions.JsonSerializerOptions);
+                    object? argument;
+                    try
+                    {
+                        argument = node?.Deserialize(parameter.ParameterType, SharedOptions.JsonSerializerOptions);
+                    }
+                    catch (Exception ex) when (ex is JsonException or FormatException or ArgumentException or OverflowException)
+                    {
+                        throw new DapiException(10002, $"Invalid parameter: {parameter.Name}");
+                    }
                     arguments.Add(argument);
                 }
             }
-        object result = handler.Invoke(host, arguments.ToArray())!;
+        object result;
+        try
+        {
+            result = handler.Invoke(host, arguments.ToArray())!;
+        }
+        catch (TargetParameterCountException)
+        {
+            throw new DapiException(10002, "Invalid parameter count");
+        }
         if (result is Task task)
         {
             await task;

--- a/tests/p2-15/P2-15.csproj
+++ b/tests/p2-15/P2-15.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="../../OneGateApp/Services/RPC/RpcServer.cs" Link="Production/RpcServer.cs" />
+    <Compile Include="../../OneGateApp/Services/RPC/RpcException.cs" Link="Production/RpcException.cs" />
+    <Compile Include="../../OneGateApp/Services/RPC/RpcMethodAttribute.cs" Link="Production/RpcMethodAttribute.cs" />
+    <Compile Include="../../OneGateApp/Models/DapiException.cs" Link="Production/DapiException.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../OneGateApp/OneGateApp.csproj"
+                      ReferenceOutputAssembly="false" BuildReference="false"
+                      SkipGetTargetFrameworkProperties="true" />
+  </ItemGroup>
+</Project>

--- a/tests/p2-15/Program.cs
+++ b/tests/p2-15/Program.cs
@@ -1,0 +1,153 @@
+using System.Net;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using NeoOrder.OneGate.Models;
+using NeoOrder.OneGate.Services;
+using NeoOrder.OneGate.Services.RPC;
+
+var failures = new List<string>();
+var tests = new List<(string Name, Func<Task> Run)>();
+
+void Error(string name, string method, JsonArray? parameters, int expectedCode, Exception? exception = null)
+{
+    tests.Add((name, async () =>
+    {
+        var host = new TestHost { Exception = exception };
+        var request = Request(method, parameters);
+        JsonObject response = await new RpcServer(host).HandleRequestAsync(request);
+        Equal(expectedCode, response["error"]?["code"]?.GetValue<int>(), response.ToJsonString());
+        Equal("request-7", response["id"]?.GetValue<string>(), "Request ID must survive errors.");
+        Check(!response.ContainsKey("result"), "Error responses must not contain a result.");
+    }));
+}
+
+Error("invalid JSON parameter type", "Number", ["not-an-int"], 10002);
+Error("converter format error", "Converted", ["not-a-number"], 10002);
+Error("converter numeric overflow", "Converted", ["999999999999999999999999"], 10002);
+Error("converter token mismatch", "Converted", [new JsonObject()], 10002);
+Error("missing parameter list", "Number", null, 10002);
+Error("unsupported method", "DoesNotExist", [], 10001);
+Error("synchronous business error", "ThrowSync", [], 10003, new DapiException(10003, "Account not found"));
+Error("asynchronous business error", "ThrowAsync", [], 10007, new DapiException(10007, "Insufficient funds"));
+Error("synchronous node error", "ThrowSync", [], 10008, new RpcException(-100, "Unknown transaction"));
+Error("asynchronous node error", "ThrowAsync", [], 10008, new RpcException(-32602, "Invalid node params"));
+Error("HTTP transport failure", "ThrowAsync", [], 10008, new HttpRequestException("Service unavailable", null, HttpStatusCode.ServiceUnavailable));
+Error("direct timeout", "ThrowSync", [], 10005, new TimeoutException("Timed out"));
+Error("asynchronous timeout", "ThrowAsync", [], 10005, new TimeoutException("Timed out"));
+Error("HTTP timeout cancellation", "ThrowAsync", [], 10005, new TaskCanceledException("Request canceled", new TimeoutException("Request timed out")));
+Error("synchronous user cancellation", "ThrowSync", [], 10006, new OperationCanceledException());
+Error("asynchronous user cancellation", "ThrowAsync", [], 10006, new OperationCanceledException());
+Error("task cancellation without timeout", "ThrowAsync", [], 10006, new TaskCanceledException());
+Error("nested reflection wrappers", "ThrowSync", [], 10008, new TargetInvocationException(new TargetInvocationException(new RpcException(-1, "Node rejected"))));
+Error("unknown handler error", "ThrowAsync", [], 10000, new InvalidOperationException("Internal handler failure"));
+Error("handler format error is not a binding error", "ThrowSync", [], 10000, new FormatException("Internal formatting failure"));
+
+tests.Add(("node details and JSON ownership survive mapping", async () =>
+{
+    JsonObject upstream = JsonNode.Parse("""{"error":{"data":{"hash":"0x123","trace":[1,2]}}}""")!.AsObject();
+    var exception = new RpcException(-100, "Unknown transaction", upstream["error"]!["data"]);
+    JsonObject response = await new RpcServer(new TestHost { Exception = exception }).HandleRequestAsync(Request("ThrowAsync", []));
+    JsonNode? data = response["error"]?["data"];
+    Equal(10008, response["error"]?["code"]?.GetValue<int>(), response.ToJsonString());
+    Equal(-100, data?["code"]?.GetValue<int>(), "Node error code must be preserved.");
+    Equal("Unknown transaction", data?["message"]?.GetValue<string>(), "Node error message must be preserved.");
+    Check(JsonNode.DeepEquals(upstream["error"]!["data"], data?["data"]), "Node error data must be preserved.");
+    data!["data"]!["hash"] = "changed";
+    Equal("0x123", upstream["error"]!["data"]!["hash"]?.GetValue<string>(), "Response must not mutate upstream JSON.");
+}));
+
+tests.Add(("business error retains invocation details", async () =>
+{
+    var exception = new DapiException(10004, "Contract execution failed", new InvocationResult("FAULT", "ABORT"));
+    JsonObject response = await new RpcServer(new TestHost { Exception = exception }).HandleRequestAsync(Request("ThrowSync", []));
+    Equal(10004, response["error"]?["code"]?.GetValue<int>(), response.ToJsonString());
+    Equal("FAULT", response["error"]?["data"]?["state"]?.GetValue<string>(), "Invocation data missing.");
+    Equal("ABORT", response["error"]?["data"]?["exception"]?.GetValue<string>(), "Invocation error missing.");
+}));
+
+tests.Add(("valid synchronous and asynchronous calls", async () =>
+{
+    var server = new RpcServer(new TestHost());
+    foreach (string method in new[] { "Number", "NumberAsync" })
+    {
+        JsonObject response = await server.HandleRequestAsync(Request(method, [7]));
+        Equal(7, response["result"]?.GetValue<int>(), response.ToJsonString());
+        Check(!response.ContainsKey("error"), "Successful calls must not contain an error.");
+    }
+    JsonObject noArgs = await server.HandleRequestAsync(Request("NoArguments", null));
+    Equal("ok", noArgs["result"]?.GetValue<string>(), noArgs.ToJsonString());
+    JsonObject nullable = await server.HandleRequestAsync(Request("NullableArgument", [null]));
+    Equal("default", nullable["result"]?.GetValue<string>(), nullable.ToJsonString());
+}));
+
+tests.Add(("malformed request envelope remains INVALID", async () =>
+{
+    foreach (string json in new[] { "{}", "{\"method\":7}", "{\"method\":\"Number\",\"params\":{}}", "{\"id\":{},\"method\":\"Number\"}" })
+    {
+        JsonObject response = await new RpcServer(new TestHost()).HandleRequestAsync(JsonNode.Parse(json)!.AsObject());
+        Equal(10002, response["error"]?["code"]?.GetValue<int>(), response.ToJsonString());
+        Check(response.ContainsKey("id"), "Malformed response must retain an ID field.");
+    }
+}));
+
+foreach ((string name, Func<Task> run) in tests)
+{
+    try
+    {
+        await run();
+        Console.WriteLine($"PASS {name}");
+    }
+    catch (Exception ex)
+    {
+        failures.Add(name);
+        Console.Error.WriteLine($"FAIL {name}: {ex.Message}");
+    }
+}
+Console.WriteLine($"{tests.Count - failures.Count}/{tests.Count} passed");
+return failures.Count == 0 ? 0 : 1;
+
+static JsonObject Request(string method, JsonArray? parameters) => new()
+{
+    ["jsonrpc"] = "2.0",
+    ["id"] = "request-7",
+    ["method"] = method,
+    ["params"] = parameters
+};
+
+static void Equal<T>(T expected, T actual, string message)
+{
+    if (!EqualityComparer<T>.Default.Equals(expected, actual))
+        throw new InvalidOperationException($"Expected {expected}, received {actual}. {message}");
+}
+
+static void Check(bool condition, string message)
+{
+    if (!condition) throw new InvalidOperationException(message);
+}
+
+public sealed class TestHost
+{
+    public Exception? Exception { get; init; }
+
+    [RpcMethod]
+    public int Number(int value) => value;
+
+    [RpcMethod]
+    public Task<int> NumberAsync(int value) => Task.FromResult(value);
+
+    [RpcMethod]
+    internal int Converted(StrictInteger value) => value.Value;
+
+    [RpcMethod]
+    public string NoArguments() => "ok";
+
+    [RpcMethod]
+    public string NullableArgument(string? value) => value ?? "default";
+
+    [RpcMethod]
+    public int ThrowSync() => throw Exception!;
+
+    [RpcMethod]
+    public Task<int> ThrowAsync() => Task.FromException<int>(Exception!);
+}

--- a/tests/p2-15/README.md
+++ b/tests/p2-15/README.md
@@ -1,0 +1,52 @@
+# NEP-21 RPC error mapping regression harness
+
+This independent .NET 10 console harness links the production `RpcServer`,
+`RpcException`, `RpcMethodAttribute` and `DapiException`. It requires no mobile
+workload, RPC server or wallet. Test-only serializer options and invocation data
+isolate the RPC boundary from MAUI and Neo VM dependencies.
+
+Run from the repository root:
+
+```sh
+dotnet run --project tests/p2-15/P2-15.csproj
+```
+
+The boundary keeps the JSON-RPC request ID and returns one result or one error.
+Parameter conversion errors become NEP-21 INVALID (10002). Node exceptions become
+RPC_ERROR (10008), with the original node code, message and data in `error.data`.
+Timeout exceptions, including the timeout nested by HttpClient inside cancellation,
+become TIMEOUT (10005); ordinary cancellation remains CANCELED (10006).
+Reflection wrappers do not hide business errors. Unexpected handler errors remain
+UNKNOWN (10000), including handler bugs that happen to throw a format exception.
+
+For example, a node error `{ "code": -100, "message": "Unknown transaction",
+"data": { "hash": "0x123" } }` becomes:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "request-7",
+  "error": {
+    "code": 10008,
+    "message": "Unknown transaction",
+    "data": {
+      "code": -100,
+      "message": "Unknown transaction",
+      "data": { "hash": "0x123" }
+    }
+  }
+}
+```
+
+The mapping does not retry requests, sign transactions, or introduce new network
+calls. Exception work is bounded by the wrapper depth; successful calls retain
+the existing dispatch path. Node error data is copied into the response, so it
+does not reparent/mutate JSON owned by the RPC client. No deployment or data
+migration is required. Clients can now branch on the documented NEP-21 codes
+instead of treating these known failures as UNKNOWN.
+
+Simulator QA should call `getTransaction` with a malformed hash (INVALID), a
+well-formed nonexistent hash (RPC_ERROR with nested node error), and cancel an
+address-selection dialog (CANCELED). Test a deliberately stalled test endpoint
+for TIMEOUT where the simulator environment supports endpoint fixtures. Use no
+real signing/broadcast requests for this validation.

--- a/tests/p2-15/TestDependencies.cs
+++ b/tests/p2-15/TestDependencies.cs
@@ -1,0 +1,32 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NeoOrder.OneGate.Services
+{
+    // Only serializer behavior needed by the RPC boundary; no MAUI filesystem.
+    static class SharedOptions
+    {
+        public static readonly JsonSerializerOptions JsonSerializerOptions = new(JsonSerializerDefaults.Web)
+        {
+            Converters = { new StrictIntegerConverter() }
+        };
+    }
+
+    sealed class StrictIntegerConverter : JsonConverter<StrictInteger>
+    {
+        public override StrictInteger Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            => new(int.Parse(reader.GetString()!, CultureInfo.InvariantCulture));
+
+        public override void Write(Utf8JsonWriter writer, StrictInteger value, JsonSerializerOptions options)
+            => writer.WriteNumberValue(value.Value);
+    }
+
+    sealed record StrictInteger(int Value);
+}
+
+namespace NeoOrder.OneGate.Models
+{
+    // Test data carrier for DapiException.Data; VM models are outside this harness.
+    public sealed record InvocationResult(string State, string? Exception);
+}


### PR DESCRIPTION
## Summary

Fix audit P2-15: retain actionable error categories at the existing dAPI RPC boundary instead of reporting every known parameter, node or transport failure as UNKNOWN.

- Unwrap reflection exceptions so synchronous business errors retain their codes.
- Map parameter conversion/count failures to INVALID (10002).
- Map node/HTTP failures to RPC_ERROR (10008), preserving upstream code/message/data in `error.data` without mutating the upstream JSON.
- Distinguish TIMEOUT (10005) from ordinary cancellation (10006); leave unexpected handler failures as UNKNOWN (10000).

No new dAPI method, permission flow, retry policy, network call or user-facing technical panel is introduced. Existing request-ID/envelope handling and successful dispatch remain in place.

## Validation

- Publication rerun: 24/24 production-linked console-harness cases passed, `dotnet run --project tests/p2-15/P2-15.csproj --no-restore`. The project is in `OneGateApp.slnx` with a non-build/non-output app project reference.
- iPhone 17 / iOS 26.5 simulator: 19/19 native assertions passed with the production `RpcServer`, reflection, serializers, UInt160 converter and invocation-result model. Cases covered parameter errors, sync/async business codes, node/HTTP failures, timeout/cancellation, nested wrappers, deep-cloned upstream details, successful responses and malformed envelopes.
- The iOS fixture was removed before a full zero-error product rebuild, install and Home/four-tab launch smoke.
- Android API 36 arm64 emulator: the same 19/19 production-dispatch assertions passed. The fixture was removed, the product fully rebuilt with zero warnings/errors, and the installed product displayed Home. No OneGate crash was observed; the device-wide crash buffer retained an unrelated earlier system Bluetooth crash.
- Reviewed complete patch SHA-256: `f574531f32d87e9b8b1d884edba0185f02f148c31b53ccdadef971d9e68bd359`, independently based on `master@623603d634f07eaead14745da87920a356159be0`. Both platform evidence sets match this hash.

## Scope and limits

Native assertions used controlled exception-producing hosts; they exercised production dispatch/error serialization, not a live RPC endpoint, actual user cancellation prompt, or JavaScript-to-native provider round trip. There was no wallet signing or transaction broadcast. Screenshots, fixture code and result JSON are not committed, and no screenshot upload or hosted CI result is claimed.

Before publication, recheck current master, current feedback, duplicate PRs and the complete diff. Tests for this error boundary remain independent of unrelated origin, navigation or query-mapping work.
