### PR TITLE
Avoid mDNS advertisement response loops

### DIFF
--- a/OneGate.Codex/onegate/skills/onegate-dapp-debug/scripts/runtime/remote-debugger-advertiser.mjs
+++ b/OneGate.Codex/onegate/skills/onegate-dapp-debug/scripts/runtime/remote-debugger-advertiser.mjs
@@ -48,6 +48,53 @@ function txtData(values) {
   }));
 }
 
+function readQuestionName(packet, offset) {
+  const labels = [];
+  let cursor = offset;
+  let end;
+  const visited = new Set();
+  while (cursor < packet.length && visited.size < 128) {
+    if (visited.has(cursor)) throw new Error('DNS compression loop');
+    visited.add(cursor);
+    const length = packet[cursor++];
+    if (length === 0) return { name: labels.join('.').toLowerCase(), end: end ?? cursor };
+    if ((length & 0xc0) === 0xc0) {
+      if (cursor >= packet.length) throw new Error('Truncated DNS pointer');
+      end ??= cursor + 1;
+      cursor = ((length & 0x3f) << 8) | packet[cursor];
+    } else {
+      if (length > 63 || cursor + length > packet.length) throw new Error('Invalid DNS label');
+      labels.push(packet.toString('utf8', cursor, cursor + length));
+      cursor += length;
+    }
+  }
+  throw new Error('Invalid DNS question');
+}
+
+function isDiscoveryQuery(packet, instanceName, hostName) {
+  if (packet.length < 12 || (packet.readUInt16BE(2) & 0xf800) !== 0) return false;
+  const count = packet.readUInt16BE(4);
+  let offset = 12;
+  let relevant = false;
+  try {
+    for (let index = 0; index < count; index++) {
+      const question = readQuestionName(packet, offset);
+      offset = question.end;
+      if (offset + 4 > packet.length) return false;
+      const type = packet.readUInt16BE(offset);
+      const dnsClass = packet.readUInt16BE(offset + 2) & 0x7fff;
+      offset += 4;
+      if (dnsClass !== 1) continue;
+      relevant ||= question.name === SERVICE_NAME && (type === 12 || type === 255)
+        || question.name === instanceName.toLowerCase() && [33, 16, 255].includes(type)
+        || question.name === hostName.toLowerCase() && (type === 1 || type === 255);
+    }
+    return relevant;
+  } catch {
+    return false;
+  }
+}
+
 export class RemoteDebuggerAdvertiser {
   constructor({ debuggerId, debuggerName, port, addresses }) {
     this.debuggerId = debuggerId;
@@ -64,7 +111,7 @@ export class RemoteDebuggerAdvertiser {
     this.socket = socket;
     socket.on("error", () => undefined);
     socket.on("message", (message) => {
-      if (message.includes(Buffer.from("_onegate-debug", "utf8"))) this.announce();
+      if (isDiscoveryQuery(message, this.instanceName, this.hostName)) this.announce();
     });
     await new Promise((resolve, reject) => {
       socket.once("error", reject);

--- a/OneGateApp.slnx
+++ b/OneGateApp.slnx
@@ -1,6 +1,7 @@
 <Solution>
   <Folder Name="/Solution Items/">
     <File Path=".editorconfig" />
+    <File Path="tests/p2-17/mdns.test.mjs" />
   </Folder>
   <Project Path="OneGateApp/OneGateApp.csproj" />
   <Project Path="OneGate.DebugProtocol/OneGate.DebugProtocol.csproj" />

--- a/tests/p2-17/mdns.test.mjs
+++ b/tests/p2-17/mdns.test.mjs
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import dgram from 'node:dgram';
+import { EventEmitter } from 'node:events';
+import { RemoteDebuggerAdvertiser } from '../../OneGate.Codex/onegate/skills/onegate-dapp-debug/scripts/runtime/remote-debugger-advertiser.mjs';
+
+test('announcements do not answer themselves; only service queries trigger an answer', async () => {
+  const original = dgram.createSocket;
+  const socket = new EventEmitter();
+  const sent = [];
+  socket.bind = (_, __, callback) => callback();
+  socket.addMembership = socket.setMulticastTTL = () => {};
+  socket.send = (packet, _, __, callback) => { sent.push(packet); callback(); };
+  socket.close = callback => callback();
+  dgram.createSocket = () => socket;
+  const advertiser = new RemoteDebuggerAdvertiser({ debuggerId: 'test', debuggerName: 'Test', port: 12345, addresses: ['192.168.1.2'] });
+  try {
+    await advertiser.start();
+    socket.emit('message', sent[0]);
+    assert.equal(sent.length, 1, 'a response packet must not trigger another response');
+    socket.emit('message', Buffer.from('_onegate-debug garbage'));
+    assert.equal(sent.length, 1);
+    const query = Buffer.concat([Buffer.from([0,0,0,0,0,1,0,0,0,0,0,0]), ...['_onegate-debug','_tcp','local'].map(label => Buffer.concat([Buffer.from([label.length]), Buffer.from(label)])), Buffer.from([0,0,12,0,1])]);
+    socket.emit('message', query);
+    assert.equal(sent.length, 2);
+    socket.emit('message', query.subarray(0, query.length - 1));
+    assert.equal(sent.length, 2, 'truncated query must not be answered');
+  } finally {
+    await advertiser.stop();
+    dgram.createSocket = original;
+  }
+});


### PR DESCRIPTION
## Summary

Fix the existing remote-debugger mDNS advertiser replying to its own announcements and other response packets.

- Parse the DNS question section and answer only relevant service/instance/host queries with the expected class and record type.
- Ignore responses, unrelated traffic, truncated questions and invalid/compression-loop names.
- Preserve the existing announcement contents, service name, periodic schedule and debugger protocol. No new app API, permission flow or window-navigation behavior is added.

## Validation

- `node --test tests/p2-17/mdns.test.mjs`: 1 test passed, covering self-response rejection, malformed traffic, a real-shaped PTR query and truncation.
- Android API 36 arm64 emulator: the actual production `MdnsRemoteDebuggerDiscovery` received the real production host advertiser and reported debugger `audit-p2-17`, port `32145`. The native event was not injected. A local packet capture showed the guest service query followed by the actual host PTR/SRV/TXT announcement; a 45-second observation recorded two announcements with no response storm.
- Android required a separate emulator-network instance with host-mDNS forwarding. This was test infrastructure only, not a product source change. The fixture-free product was fully rebuilt with zero warnings/errors, installed and launched to Welcome. The temporary emulator/network instance was stopped; the other running Android emulator was not changed.
- iPhone 17 / iOS 26.5 simulator: the actual production discovery event received `audit-p2-17` at `198.18.0.1:32145` after the native listener started and the unchanged production advertiser was launched. The 45-second real UDP observation recorded two announcements, no storm, and normal advertiser exit. The fixture was removed; a full product rebuild passed with zero warnings/errors and the installed product displayed Home/four tabs. The temporary product source matched the source branch after restoration.
- Tested source diff SHA-256: `c276f4d8dfec85e4983b79f15f0f54e58c457ba7b4158162cca4bf1507a65797`, independently based on `master@623603d634f07eaead14745da87920a356159be0`.

## Limits

This verifies service discovery, not debugger authentication, a wallet operation or a blockchain transaction. Earlier emulator startup and listener-timing failures were retained and were not counted as passing runs. Android's system Bluetooth process reported an unrelated HCI failure; no OneGate crash was observed.

Screenshots, temporary QA fixtures and packet captures remain outside the repository. Raw packet captures contain unrelated local-network discovery traffic and are not for public upload. No screenshot upload, hosted CI pass or maintainer approval is claimed.
